### PR TITLE
Formkrav opprydding

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
@@ -67,7 +67,7 @@ class BehandlingService(
             )
         ).id
 
-        return formService.opprettInitielleFormkrav(behandlingId, fagsak.id).behandlingId
+        return formService.opprettInitielleFormkrav(behandlingId).behandlingId
     }
 
     private fun hentKlageresultatDto(behandlingId: UUID): List<KlageresultatDto> {

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormController.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.klage.formkrav
 
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
-import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.klage.formkrav.dto.FormDto
 import no.nav.familie.klage.formkrav.dto.tilDto
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
@@ -32,9 +31,9 @@ class FormController(
     }
 
     @PostMapping
-    fun opprettEllerOppdaterFormkravVilkår(@RequestBody form: Form): Ressurs<FormDto> {
+    fun oppdaterFormkravVilkår(@RequestBody form: FormDto): Ressurs<FormDto> {
         tilgangService.validerTilgangTilBehandling(form.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
-        return Ressurs.success(formService.opprettEllerOppdaterForm(form))
+        return Ressurs.success(formService.oppdaterForm(form))
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormRepository.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormRepository.kt
@@ -7,7 +7,4 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface FormRepository : RepositoryInterface<Form, UUID>, InsertUpdateRepository<Form> {
-
-    fun findByBehandlingId(behandlingId: UUID): Form
-}
+interface FormRepository : RepositoryInterface<Form, UUID>, InsertUpdateRepository<Form>

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormService.kt
@@ -4,7 +4,6 @@ import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.formkrav.FormUtil.formkravErFerdigUtfyllt
 import no.nav.familie.klage.formkrav.FormUtil.formkravErOppfylt
-import no.nav.familie.klage.formkrav.FormUtil.initiellForm
 import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.klage.formkrav.dto.FormDto
 import no.nav.familie.klage.formkrav.dto.tilDto
@@ -23,7 +22,7 @@ class FormService(
 
     @Transactional
     fun opprettInitielleFormkrav(behandlingId: UUID): Form {
-        return formRepository.insert(initiellForm(behandlingId = behandlingId))
+        return formRepository.insert(Form(behandlingId = behandlingId))
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormService.kt
@@ -2,12 +2,13 @@ package no.nav.familie.klage.formkrav
 
 import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.formkrav.FormUtil.formkravErFerdigUtfyllt
+import no.nav.familie.klage.formkrav.FormUtil.formkravErOppfylt
+import no.nav.familie.klage.formkrav.FormUtil.initiellForm
 import no.nav.familie.klage.formkrav.domain.Form
-import no.nav.familie.klage.formkrav.domain.FormVilkår
 import no.nav.familie.klage.formkrav.dto.FormDto
 import no.nav.familie.klage.formkrav.dto.tilDto
 import no.nav.familie.klage.repository.findByIdOrThrow
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -21,82 +22,35 @@ class FormService(
     fun hentForm(behandlingId: UUID): Form = formRepository.findByIdOrThrow(behandlingId)
 
     @Transactional
-    fun opprettInitielleFormkrav(behandlingId: UUID, fagsakId: UUID): Form {
-        return formRepository.insert(
-            Form(
-                behandlingId = behandlingId,
-                fagsakId = fagsakId,
-                klagePart = FormVilkår.IKKE_SATT,
-                klagefristOverholdt = FormVilkår.IKKE_SATT,
-                klageKonkret = FormVilkår.IKKE_SATT,
-                klageSignert = FormVilkår.IKKE_SATT,
-                saksbehandlerBegrunnelse = "",
-            )
+    fun opprettInitielleFormkrav(behandlingId: UUID): Form {
+        return formRepository.insert(initiellForm(behandlingId = behandlingId))
+    }
+
+    @Transactional
+    fun oppdaterForm(form: FormDto): FormDto {
+        val behandlingId = form.behandlingId
+        val oppdatertForm = formRepository.findByIdOrThrow(behandlingId).copy(
+            klagePart = form.klagePart,
+            klagefristOverholdt = form.klagefristOverholdt,
+            klageKonkret = form.klageKonkret,
+            klageSignert = form.klageSignert,
+            saksbehandlerBegrunnelse = form.saksbehandlerBegrunnelse
         )
-    }
-
-    @Transactional
-    fun opprettEllerOppdaterForm(form: Form): FormDto {
-        if (formkravErFerdigUtfyllt(form)) {
-            if (formkravErOppfylt(form)) stegService.oppdaterSteg(form.behandlingId, StegType.VURDERING)
-            else stegService.oppdaterSteg(form.behandlingId, StegType.BREV)
+        if (formkravErFerdigUtfyllt(oppdatertForm)) {
+            if (formkravErOppfylt(oppdatertForm)) {
+                stegService.oppdaterSteg(behandlingId, StegType.VURDERING)
+            } else {
+                stegService.oppdaterSteg(behandlingId, StegType.BREV)
+            }
         } else {
-            stegService.oppdaterSteg(form.behandlingId, StegType.FORMKRAV)
+            stegService.oppdaterSteg(behandlingId, StegType.FORMKRAV)
         }
-        if (sjekkOmFormEksisterer(form.behandlingId)) {
-            return oppdaterForm(form)
-        }
-        return formRepository.insert(
-            Form(
-                behandlingId = form.behandlingId,
-                fagsakId = form.fagsakId,
-                klagePart = form.klagePart,
-                klageKonkret = form.klageKonkret,
-                klagefristOverholdt = form.klagefristOverholdt,
-                klageSignert = form.klageSignert,
-                saksbehandlerBegrunnelse = form.saksbehandlerBegrunnelse
-            )
-        ).tilDto()
-    }
 
-    private fun formkravErFerdigUtfyllt(form: Form) = !arrayOf(
-        form.klageKonkret,
-        form.klagePart,
-        form.klageSignert,
-        form.klagefristOverholdt
-    ).contains(FormVilkår.IKKE_SATT) &&
-        form.saksbehandlerBegrunnelse.isNotEmpty()
-
-    @Transactional
-    fun oppdaterForm(form: Form): FormDto {
-        val formFraDb = formRepository.findByBehandlingId(form.behandlingId)
-        return formRepository.update(
-            formFraDb.copy(
-                klagePart = form.klagePart,
-                klagefristOverholdt = form.klagefristOverholdt,
-                klageKonkret = form.klageKonkret,
-                klageSignert = form.klageSignert,
-                saksbehandlerBegrunnelse = form.saksbehandlerBegrunnelse
-            )
-        ).tilDto()
-    }
-
-    fun sjekkOmFormEksisterer(id: UUID): Boolean {
-        return formRepository.findById(id).isPresent
-    }
-
-    fun formkravErOppfylt(form: Form): Boolean {
-        return (
-            form.klageKonkret == FormVilkår.OPPFYLT &&
-                form.klagePart == FormVilkår.OPPFYLT &&
-                form.klageSignert == FormVilkår.OPPFYLT &&
-                form.klagefristOverholdt == FormVilkår.OPPFYLT &&
-                form.saksbehandlerBegrunnelse != ""
-            )
+        return formRepository.update(oppdatertForm).tilDto()
     }
 
     fun formkravErOppfyltForBehandling(behandlingId: UUID): Boolean {
-        val form = formRepository.findByIdOrNull(behandlingId) ?: error("Fant ikke formkrav for behandling=$behandlingId")
+        val form = formRepository.findByIdOrThrow(behandlingId)
         return formkravErOppfylt(form)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormUtil.kt
@@ -4,22 +4,37 @@ import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.klage.formkrav.domain.FormVilkår
 import java.util.UUID
 
-fun form(
-    behandlingId: UUID,
-    fagsakId: UUID = UUID.randomUUID(),
-    klagePart: FormVilkår = FormVilkår.IKKE_SATT,
-    klageKonkret: FormVilkår = FormVilkår.IKKE_SATT,
-    klagefristOverholdt: FormVilkår = FormVilkår.IKKE_SATT,
-    klageSignert: FormVilkår = FormVilkår.IKKE_SATT,
-    saksbehandlerBegrunnelse: String = "begrunnelsen kommer her",
+object FormUtil {
 
-): Form =
-    Form(
-        behandlingId,
-        fagsakId,
-        klagePart,
+    fun initiellForm(
+        behandlingId: UUID,
+        klagePart: FormVilkår = FormVilkår.IKKE_SATT,
+        klageKonkret: FormVilkår = FormVilkår.IKKE_SATT,
+        klagefristOverholdt: FormVilkår = FormVilkår.IKKE_SATT,
+        klageSignert: FormVilkår = FormVilkår.IKKE_SATT,
+        saksbehandlerBegrunnelse: String = ""
+    ): Form =
+        Form(
+            behandlingId,
+            klagePart,
+            klageKonkret,
+            klagefristOverholdt,
+            klageSignert,
+            saksbehandlerBegrunnelse
+        )
+
+    fun formkravErFerdigUtfyllt(form: Form) =
+        form.alleSvar().none { it == FormVilkår.IKKE_SATT } &&
+            form.saksbehandlerBegrunnelse.isNotBlank()
+
+    fun formkravErOppfylt(form: Form): Boolean {
+        return form.alleSvar().all { it == FormVilkår.OPPFYLT }
+    }
+
+    private fun Form.alleSvar() = setOf(
         klageKonkret,
-        klagefristOverholdt,
+        klagePart,
         klageSignert,
-        saksbehandlerBegrunnelse
+        klagefristOverholdt
     )
+}

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormUtil.kt
@@ -6,23 +6,6 @@ import java.util.UUID
 
 object FormUtil {
 
-    fun initiellForm(
-        behandlingId: UUID,
-        klagePart: FormVilkår = FormVilkår.IKKE_SATT,
-        klageKonkret: FormVilkår = FormVilkår.IKKE_SATT,
-        klagefristOverholdt: FormVilkår = FormVilkår.IKKE_SATT,
-        klageSignert: FormVilkår = FormVilkår.IKKE_SATT,
-        saksbehandlerBegrunnelse: String = ""
-    ): Form =
-        Form(
-            behandlingId,
-            klagePart,
-            klageKonkret,
-            klagefristOverholdt,
-            klageSignert,
-            saksbehandlerBegrunnelse
-        )
-
     fun formkravErFerdigUtfyllt(form: Form) =
         form.alleSvar().none { it == FormVilkår.IKKE_SATT } &&
             form.saksbehandlerBegrunnelse.isNotBlank()

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/domain/Form.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/domain/Form.kt
@@ -8,10 +8,10 @@ import java.util.UUID
 data class Form(
     @Id
     val behandlingId: UUID,
-    val klagePart: FormVilkår,
-    val klagefristOverholdt: FormVilkår,
-    val klageKonkret: FormVilkår,
-    val klageSignert: FormVilkår,
+    val klagePart: FormVilkår = FormVilkår.IKKE_SATT,
+    val klagefristOverholdt: FormVilkår = FormVilkår.IKKE_SATT,
+    val klageKonkret: FormVilkår = FormVilkår.IKKE_SATT,
+    val klageSignert: FormVilkår = FormVilkår.IKKE_SATT,
     val saksbehandlerBegrunnelse: String = "",
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar()

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/domain/Form.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/domain/Form.kt
@@ -8,12 +8,11 @@ import java.util.UUID
 data class Form(
     @Id
     val behandlingId: UUID,
-    val fagsakId: UUID = UUID.randomUUID(),
     val klagePart: FormVilkår,
     val klagefristOverholdt: FormVilkår,
     val klageKonkret: FormVilkår,
     val klageSignert: FormVilkår,
-    val saksbehandlerBegrunnelse: String = "begrunnelsen kommer her",
+    val saksbehandlerBegrunnelse: String = "",
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar()
 )

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/dto/FormDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/dto/FormDto.kt
@@ -7,7 +7,6 @@ import java.util.UUID
 
 data class FormDto(
     val behandlingId: UUID,
-    val fagsakId: UUID,
     val klagePart: FormVilkår,
     val klageKonkret: FormVilkår,
     val klagefristOverholdt: FormVilkår,
@@ -19,7 +18,6 @@ data class FormDto(
 fun Form.tilDto(): FormDto =
     FormDto(
         behandlingId = this.behandlingId,
-        fagsakId = this.fagsakId,
         klagePart = this.klagePart,
         klageKonkret = this.klageKonkret,
         klagefristOverholdt = this.klagefristOverholdt,

--- a/src/main/resources/db/migration/V19__formresultat.sql
+++ b/src/main/resources/db/migration/V19__formresultat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE form DROP COLUMN fagsak_id;

--- a/src/test/kotlin/no/nav/familie/klage/FlytTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/FlytTest.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.klage
+
+import no.nav.familie.klage.formkrav.FormController
+import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
+import no.nav.familie.klage.testutil.DomainUtil.behandling
+import no.nav.familie.klage.testutil.DomainUtil.fagsak
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class FlytTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    private lateinit var formController: FormController
+
+    private val fagsak = fagsak()
+    private val behandling = behandling(fagsak)
+
+    @BeforeEach
+    internal fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+        testoppsettService.lagreBehandling(behandling)
+    }
+
+    @Test
+    internal fun `skal sende melding til kabal ved`() {
+        // formController.hentVilkår()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingControllerTest.kt
@@ -3,13 +3,14 @@ package no.nav.familie.klage.behandling
 import no.nav.familie.klage.brev.BrevService
 import no.nav.familie.klage.distribusjon.DistribusjonResultatService
 import no.nav.familie.klage.formkrav.FormService
+import no.nav.familie.klage.formkrav.dto.tilDto
 import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
 import no.nav.familie.klage.infrastruktur.config.RolleConfig
 import no.nav.familie.klage.testutil.BrukerContextUtil
 import no.nav.familie.klage.testutil.DomainUtil.behandling
 import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
-import no.nav.familie.klage.testutil.DomainUtil.form
 import no.nav.familie.klage.testutil.DomainUtil.fritekstbrev
+import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
 import no.nav.familie.klage.testutil.DomainUtil.tilFagsak
 import no.nav.familie.klage.testutil.DomainUtil.vurdering
 import no.nav.familie.klage.vurdering.VurderingService
@@ -43,7 +44,6 @@ internal class FerdigstillBehandlingControllerTest : OppslagSpringRunnerTest() {
 
     val fagsak = fagsakDomain().tilFagsak()
     val behandling = behandling(fagsak = fagsak)
-    val form = form(fagsakId = fagsak.id, behandlingId = behandling.id)
     val vurdering = vurdering(behandlingId = behandling.id)
     val fritekstbrev = fritekstbrev(behandlingId = behandling.id)
 
@@ -55,7 +55,8 @@ internal class FerdigstillBehandlingControllerTest : OppslagSpringRunnerTest() {
         testoppsettService.lagreFagsak(fagsak)
         testoppsettService.lagreBehandling(behandling)
 
-        formService.opprettEllerOppdaterForm(form)
+        formService.opprettInitielleFormkrav(behandling.id)
+        formService.oppdaterForm(oppfyltForm(behandling.id).tilDto())
         vurderingService.opprettEllerOppdaterVurdering(vurdering)
 
         brevService.lagEllerOppdaterBrev(fritekstbrev)

--- a/src/test/kotlin/no/nav/familie/klage/formkrav/FormServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/formkrav/FormServiceTest.kt
@@ -1,0 +1,67 @@
+package no.nav.familie.klage.formkrav
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.klage.behandling.StegService
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.formkrav.FormUtil.initiellForm
+import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.formkrav.dto.tilDto
+import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import java.util.UUID
+
+internal class FormServiceTest {
+
+    private val formRepository = mockk<FormRepository>()
+    private val stegService = mockk<StegService>()
+    private val service = FormService(formRepository, stegService)
+
+    private val behandlingId = UUID.randomUUID()
+
+    @BeforeEach
+    internal fun setUp() {
+        justRun { stegService.oppdaterSteg(any(), any()) }
+        every { formRepository.findByIdOrNull(any()) } returns initiellForm(behandlingId)
+        every { formRepository.update(any()) } answers { firstArg() }
+    }
+
+    @Nested
+    inner class oppdaterForm {
+
+        @Test
+        internal fun `ikke ferdigutfylt skal gå til steget formKrav`() {
+            service.oppdaterForm(ikkeFerdigutfylt())
+
+            verify { stegService.oppdaterSteg(behandlingId, StegType.FORMKRAV) }
+            verify { formRepository.update(any()) }
+        }
+
+        @Test
+        internal fun `ferdigutfylt og oppfylt skal gå videre til vurdering`() {
+            service.oppdaterForm(oppfyltFormDto())
+
+            verify { stegService.oppdaterSteg(behandlingId, StegType.VURDERING) }
+            verify { formRepository.update(any()) }
+        }
+
+        @Test
+        internal fun `ferdigutfylt men ikke oppfylt skal gå videre til brev`() {
+            service.oppdaterForm(ikkeOppfyltFormDto())
+
+            verify { stegService.oppdaterSteg(behandlingId, StegType.BREV) }
+            verify { formRepository.update(any()) }
+        }
+    }
+
+    private fun oppfyltFormDto() = oppfyltForm(behandlingId).tilDto()
+
+    private fun ikkeOppfyltFormDto() = oppfyltForm(behandlingId).tilDto().copy(klagePart = FormVilkår.IKKE_OPPFYLT)
+
+    private fun ikkeFerdigutfylt() = oppfyltForm(behandlingId).tilDto().copy(klagePart = FormVilkår.IKKE_SATT)
+}

--- a/src/test/kotlin/no/nav/familie/klage/formkrav/FormServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/formkrav/FormServiceTest.kt
@@ -6,7 +6,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
-import no.nav.familie.klage.formkrav.FormUtil.initiellForm
+import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.klage.formkrav.domain.FormVilkår
 import no.nav.familie.klage.formkrav.dto.tilDto
 import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
@@ -27,7 +27,7 @@ internal class FormServiceTest {
     @BeforeEach
     internal fun setUp() {
         justRun { stegService.oppdaterSteg(any(), any()) }
-        every { formRepository.findByIdOrNull(any()) } returns initiellForm(behandlingId)
+        every { formRepository.findByIdOrNull(any()) } returns Form(behandlingId)
         every { formRepository.update(any()) } answers { firstArg() }
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/formkrav/FormUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/formkrav/FormUtilTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.klage.formkrav
 
 import no.nav.familie.klage.formkrav.FormUtil.formkravErFerdigUtfyllt
 import no.nav.familie.klage.formkrav.FormUtil.formkravErOppfylt
-import no.nav.familie.klage.formkrav.FormUtil.initiellForm
+import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.klage.formkrav.domain.FormVilkår
 import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
 import org.assertj.core.api.Assertions.assertThat
@@ -27,7 +27,7 @@ internal class FormUtilTest {
         internal fun `et eller flere er ikke utfylt`() {
             val oppfyltForm = oppfyltForm(UUID.randomUUID())
             assertThat(formkravErFerdigUtfyllt(oppfyltForm.copy(klagePart = FormVilkår.IKKE_SATT))).isFalse
-            assertThat(formkravErFerdigUtfyllt(initiellForm(UUID.randomUUID()))).isFalse
+            assertThat(formkravErFerdigUtfyllt(Form(UUID.randomUUID()))).isFalse
         }
     }
 
@@ -41,7 +41,7 @@ internal class FormUtilTest {
 
         @Test
         internal fun `et eller flere vilkår er ikke oppfylt`() {
-            val form = FormUtil.initiellForm(UUID.randomUUID())
+            val form = Form(UUID.randomUUID())
             assertThat(formkravErOppfylt(form)).isFalse
             assertThat(formkravErOppfylt(form.copy(klagePart = FormVilkår.OPPFYLT))).isFalse
 

--- a/src/test/kotlin/no/nav/familie/klage/formkrav/FormUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/formkrav/FormUtilTest.kt
@@ -1,0 +1,53 @@
+package no.nav.familie.klage.formkrav
+
+import no.nav.familie.klage.formkrav.FormUtil.formkravErFerdigUtfyllt
+import no.nav.familie.klage.formkrav.FormUtil.formkravErOppfylt
+import no.nav.familie.klage.formkrav.FormUtil.initiellForm
+import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class FormUtilTest {
+
+    @Nested
+    inner class formkravErFerdigUtfyllt {
+
+        @Test
+        internal fun `alle er ferdigutfylte`() {
+            val oppfyltForm = oppfyltForm(UUID.randomUUID())
+            assertThat(formkravErFerdigUtfyllt(oppfyltForm)).isTrue
+            assertThat(formkravErFerdigUtfyllt(oppfyltForm.copy(klagePart = FormVilkår.SKAL_IKKE_VURDERES))).isTrue
+            assertThat(formkravErFerdigUtfyllt(oppfyltForm.copy(klagePart = FormVilkår.IKKE_OPPFYLT))).isTrue
+        }
+
+        @Test
+        internal fun `et eller flere er ikke utfylt`() {
+            val oppfyltForm = oppfyltForm(UUID.randomUUID())
+            assertThat(formkravErFerdigUtfyllt(oppfyltForm.copy(klagePart = FormVilkår.IKKE_SATT))).isFalse
+            assertThat(formkravErFerdigUtfyllt(initiellForm(UUID.randomUUID()))).isFalse
+        }
+    }
+
+    @Nested
+    inner class formkravErOppfylt {
+
+        @Test
+        internal fun `alle er oppfylt`() {
+            assertThat(formkravErOppfylt(oppfyltForm(UUID.randomUUID()))).isTrue
+        }
+
+        @Test
+        internal fun `et eller flere vilkår er ikke oppfylt`() {
+            val form = FormUtil.initiellForm(UUID.randomUUID())
+            assertThat(formkravErOppfylt(form)).isFalse
+            assertThat(formkravErOppfylt(form.copy(klagePart = FormVilkår.OPPFYLT))).isFalse
+
+            assertThat(formkravErOppfylt(oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.IKKE_OPPFYLT))).isFalse
+            assertThat(formkravErOppfylt(oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.IKKE_SATT))).isFalse
+            assertThat(formkravErOppfylt(oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.SKAL_IKKE_VURDERES))).isFalse
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -77,10 +77,9 @@ object DomainUtil {
             beskrivelse = "En begrunnelse"
         )
 
-    fun form(fagsakId: UUID, behandlingId: UUID) =
+    fun oppfyltForm(behandlingId: UUID) =
         Form(
             behandlingId = behandlingId,
-            fagsakId = fagsakId,
             klagePart = FormVilkår.OPPFYLT,
             klagefristOverholdt = FormVilkår.OPPFYLT,
             klageKonkret = FormVilkår.OPPFYLT,


### PR DESCRIPTION
* Fjerner avhengighet til fagsakId i form
* Endrer controller til å motta FormDto og ikke domeneobjekt
* Flytter ut valideringsmetoder til utils, og lager noen enkle tester for disse
* Endrer opprettEllerOppdaterFormkravVilkår til å kun oppdatere, då vi initierer de i en egen metode når man oppretter behandlingen

* Flytter default values inn i domeneobjektet, og bruker det for initiell initiering, er det greit? [a2da966](https://github.com/navikt/familie-klage/pull/51/commits/a2da9667867465dc9a85b7f5d06e6bbfa0866488)