### PR TITLE
Formkravtekst inn i brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.klage.brev
 
 import no.nav.familie.klage.brev.FormBrevUtil.utledIkkeOppfylteFormkrav
-import no.nav.familie.klage.brev.FormBrevUtil.utledInnholdstekst
+import no.nav.familie.klage.brev.FormBrevUtil.utledÅrsakTilAvvisningstekst
 import no.nav.familie.klage.brev.FormBrevUtil.utledLovtekst
 import no.nav.familie.klage.brev.dto.AvsnittDto
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
@@ -16,8 +16,6 @@ object BrevInnhold {
         navn: String,
         stønadstype: Stønadstype
     ): FritekstBrevRequestDto {
-        val stønadstypeVisningsnavn = stønadstype.tilVisningsnavn()
-        val lesMerUrl = stønadstype.lesMerUrl()
 
         return FritekstBrevRequestDto(
             overskrift = "Vi har sendt klagen din til NAV Klageinstans",
@@ -28,7 +26,7 @@ object BrevInnhold {
                 AvsnittDto(
                     deloverskrift = "",
                     innhold =
-                    "Vi har fått klagen din på vedtaket om $stønadstypeVisningsnavn, og kommet frem til at det ikke endres. NAV Klageinstans skal derfor vurdere saken din på nytt.."
+                    "Vi har fått klagen din på vedtaket om ${stønadstype.tilVisningsnavn()}, og kommet frem til at det ikke endres. NAV Klageinstans skal derfor vurdere saken din på nytt.."
                 ),
                 AvsnittDto(
                     deloverskrift = "",
@@ -45,7 +43,7 @@ object BrevInnhold {
                 ),
                 AvsnittDto(
                     deloverskrift = "Har du spørsmål?",
-                    innhold = "Du finner informasjon som kan være nyttig for deg på $lesMerUrl. Du kan også kontakte oss på nav.no/kontakt."
+                    innhold = "Du finner informasjon som kan være nyttig for deg på ${stønadstype.lesMerUrl()}. Du kan også kontakte oss på nav.no/kontakt."
                 )
             )
         )
@@ -57,19 +55,18 @@ object BrevInnhold {
             formkrav: Form,
             stønadstype: Stønadstype
     ): FritekstBrevRequestDto {
-        val lesMerUrl = stønadstype.lesMerUrl()
         val ikkeOppfylteFormkrav = utledIkkeOppfylteFormkrav(formkrav)
-        val innholdstekst = utledInnholdstekst(ikkeOppfylteFormkrav)
         val brevtekstFraSaksbehandler = formkrav.brevtekst ?: error("Må ha brevtekst fra saksbehandler for å generere brev ved formkrav ikke oppfylt")
+
         return FritekstBrevRequestDto(
             overskrift = "Vi har avvist klagen din på vedtaket om ${stønadstype.tilVisningsnavn()}",
             personIdent = ident,
             navn = navn,
-            avsnitt = listOf(
-
+            avsnitt =
+            listOf(
                 AvsnittDto(
                     deloverskrift = "Årsak til avvisning",
-                    innhold = innholdstekst
+                    innhold = utledÅrsakTilAvvisningstekst(ikkeOppfylteFormkrav)
                 ),
                 AvsnittDto(
                         deloverskrift = "",
@@ -92,7 +89,7 @@ object BrevInnhold {
                 AvsnittDto(
                         deloverskrift = "Har du spørsmål?",
                         innhold =
-                        "Du finner informasjon som kan være nyttig for deg på $lesMerUrl. Du kan også kontakte oss på nav.no/kontakt."
+                        "Du finner informasjon som kan være nyttig for deg på ${stønadstype.lesMerUrl()}. Du kan også kontakte oss på nav.no/kontakt."
                 )
             )
         )
@@ -106,9 +103,5 @@ object BrevInnhold {
         Stønadstype.SKOLEPENGER -> "nav.no/familie/alene-med-barn"
         Stønadstype.BARNETRYGD -> "nav.no/barnetrygd"
         Stønadstype.KONTANTSTØTTE -> "nav.no/kontantstotte"
-    }
-
-    private fun utledÅrsakTilAvvisning(formkrav: Form) = {
-
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
@@ -1,7 +1,11 @@
 package no.nav.familie.klage.brev
 
+import no.nav.familie.klage.brev.FormBrevUtil.utledIkkeOppfylteFormkrav
+import no.nav.familie.klage.brev.FormBrevUtil.utledInnholdstekst
+import no.nav.familie.klage.brev.FormBrevUtil.utledLovtekstInnhold
 import no.nav.familie.klage.brev.dto.AvsnittDto
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
+import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
 
 object BrevInnhold {
@@ -48,33 +52,47 @@ object BrevInnhold {
     }
 
     fun lagFormkravAvvistBrev(
-        ident: String,
-        navn: String,
-        begrunnelse: String,
-        stønadstype: Stønadstype
+            ident: String,
+            navn: String,
+            formkrav: Form,
+            stønadstype: Stønadstype
     ): FritekstBrevRequestDto {
         val lesMerUrl = stønadstype.lesMerUrl()
-
+        val ikkeOppfylteFormkrav = utledIkkeOppfylteFormkrav(formkrav)
+        val innholdstekst = utledInnholdstekst(ikkeOppfylteFormkrav)
+        val brevtekstFraSaksbehandler = formkrav.brevtekst ?: error("Må ha brevtekst fra saksbehandler for å generere brev ved formkrav ikke oppfylt")
         return FritekstBrevRequestDto(
-            overskrift = "",
+            overskrift = "Vi har avvist klagen din på vedtaket om ${stønadstype.tilVisningsnavn()}",
             personIdent = ident,
             navn = navn,
             avsnitt = listOf(
 
                 AvsnittDto(
-                    deloverskrift = "",
-                    innhold =
-                    begrunnelse
+                    deloverskrift = "Årsak til avvisning",
+                    innhold = innholdstekst
                 ),
                 AvsnittDto(
-                    deloverskrift = "",
-                    innhold =
-                    "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via nav.no/klage."
+                        deloverskrift = "",
+                        innhold = brevtekstFraSaksbehandler
                 ),
                 AvsnittDto(
-                    deloverskrift = "",
+                        deloverskrift = "",
+                        innhold = utledLovtekstInnhold(ikkeOppfylteFormkrav)
+                ),
+                AvsnittDto(
+                    deloverskrift = "Du har rett til å klage",
                     innhold =
-                    "Har du spørsmål?\nDu finner informasjon som kan være nyttig for deg på $lesMerUrl. Du kan også kontakte oss på nav.no/kontakt."
+                    "Hvis du vil klage, må du gjøre dette innen 3 uker fra den datoen du fikk dette brevet. Du finner skjema og informasjon på nav.no/klage."
+                ),
+                AvsnittDto(
+                    deloverskrift = "Du har rett til innsyn",
+                    innhold =
+                    "På nav.no/dittnav kan du se dokumentene i saken din."
+                ),
+                AvsnittDto(
+                        deloverskrift = "Har du spørsmål?",
+                        innhold =
+                        "Du finner informasjon som kan være nyttig for deg på $lesMerUrl. Du kan også kontakte oss på nav.no/kontakt."
                 )
             )
         )
@@ -88,5 +106,9 @@ object BrevInnhold {
         Stønadstype.SKOLEPENGER -> "nav.no/familie/alene-med-barn"
         Stønadstype.BARNETRYGD -> "nav.no/barnetrygd"
         Stønadstype.KONTANTSTØTTE -> "nav.no/kontantstotte"
+    }
+
+    private fun utledÅrsakTilAvvisning(formkrav: Form) = {
+
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
@@ -2,7 +2,7 @@ package no.nav.familie.klage.brev
 
 import no.nav.familie.klage.brev.FormBrevUtil.utledIkkeOppfylteFormkrav
 import no.nav.familie.klage.brev.FormBrevUtil.utledInnholdstekst
-import no.nav.familie.klage.brev.FormBrevUtil.utledLovtekstInnhold
+import no.nav.familie.klage.brev.FormBrevUtil.utledLovtekst
 import no.nav.familie.klage.brev.dto.AvsnittDto
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
 import no.nav.familie.klage.formkrav.domain.Form
@@ -77,7 +77,7 @@ object BrevInnhold {
                 ),
                 AvsnittDto(
                         deloverskrift = "",
-                        innhold = utledLovtekstInnhold(ikkeOppfylteFormkrav)
+                        innhold = utledLovtekst(ikkeOppfylteFormkrav)
                 ),
                 AvsnittDto(
                     deloverskrift = "Du har rett til å klage",

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -110,8 +110,8 @@ class BrevService(
                 BrevInnhold.lagOpprettholdelseBrev(fagsak.hentAktivIdent(), instillingKlageinstans, navn, fagsak.stønadstype)
             }
             BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST -> {
-                val begrunnelse = "Begrunnelse for formkrav avvist" // TODO
-                BrevInnhold.lagFormkravAvvistBrev(fagsak.hentAktivIdent(), navn, begrunnelse, fagsak.stønadstype)
+                val formkrav = formService.hentForm(behandlingId)
+                BrevInnhold.lagFormkravAvvistBrev(fagsak.hentAktivIdent(), navn, formkrav, fagsak.stønadstype)
             }
             BehandlingResultat.MEDHOLD,
             BehandlingResultat.IKKE_SATT,

--- a/src/main/kotlin/no/nav/familie/klage/brev/FormBrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/FormBrevUtil.kt
@@ -1,31 +1,31 @@
 package no.nav.familie.klage.brev
 
 import no.nav.familie.klage.formkrav.domain.Form
-import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.formkrav.domain.FormVilkår.IKKE_OPPFYLT
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 
 
 object FormBrevUtil {
 
-    fun utledInnholdstekst(formkravVilkår: Set<FormkravVilkår>): String {
+    fun utledIkkeOppfylteFormkrav(formkrav: Form): Set<FormkravVilkår> {
+        return setOf(
+                if (formkrav.klagePart == IKKE_OPPFYLT) FormkravVilkår.KLAGE_PART else null,
+                if (formkrav.klageKonkret == IKKE_OPPFYLT) FormkravVilkår.KLAGE_KONKRET else null,
+                if (formkrav.klageSignert == IKKE_OPPFYLT) FormkravVilkår.KLAGE_SIGNERT else null,
+                if (formkrav.klagefristOverholdt == IKKE_OPPFYLT) FormkravVilkår.KLAGEFRIST_OVERHOLDT else null,
+        ).filterNotNull().toSet()
+    }
+
+    fun utledÅrsakTilAvvisningstekst(formkravVilkår: Set<FormkravVilkår>): String {
         feilHvis(formkravVilkår.isEmpty()) {
             "Skal ikke kunne utlede innholdstekst til formkrav avvist brev uten ikke oppfylte formkrav"
         }
         if (formkravVilkår.size > 1) {
             return "$innholdstekstPrefix: ${formkravVilkår.joinToString("") { "\n  •  ${it.tekst}" }}"
         } else {
-            return "$innholdstekstPrefix ${formkravVilkår.first().tekst}"
+            return "$innholdstekstPrefix ${formkravVilkår.single().tekst}"
         }
-    }
-
-    fun utledIkkeOppfylteFormkrav(formkrav: Form): Set<FormkravVilkår> {
-        return setOf(
-                if (formkrav.klagePart == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGE_PART else null,
-                if (formkrav.klageKonkret == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGE_KONKRET else null,
-                if (formkrav.klageSignert == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGE_SIGNERT else null,
-                if (formkrav.klagefristOverholdt == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGEFRIST_OVERHOLDT else null,
-        ).filterNotNull().toSet()
     }
 
     fun utledLovtekst(formkravVilkår: Set<FormkravVilkår>): String {

--- a/src/main/kotlin/no/nav/familie/klage/brev/FormBrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/FormBrevUtil.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.klage.brev
+
+import no.nav.familie.klage.formkrav.domain.Form
+import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.exception.feilHvis
+
+
+object FormBrevUtil {
+
+    fun utledInnholdstekst(formkravVilkår: Set<FormkravVilkår>): String {
+        feilHvis(formkravVilkår.isEmpty()) {
+            "Skal ikke kunne utlede innholdstekst til formkrav avvist brev uten ikke oppfylte formkrav"
+        }
+        if (formkravVilkår.size > 1) {
+            return "$tekstPrefix: ${formkravVilkår.joinToString("") { "\n  •  ${it.tekst}" }}"
+        } else {
+            return "$tekstPrefix ${formkravVilkår.first().tekst}"
+        }
+    }
+
+    fun utledIkkeOppfylteFormkrav(formkrav: Form): Set<FormkravVilkår> {
+        return setOf(
+                if (formkrav.klagePart == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGE_PART else null,
+                if (formkrav.klageKonkret == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGE_KONKRET else null,
+                if (formkrav.klageSignert == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGE_SIGNERT else null,
+                if (formkrav.klagefristOverholdt == FormVilkår.IKKE_OPPFYLT) FormkravVilkår.KLAGEFRIST_OVERHOLDT else null,
+        ).filterNotNull().toSet()
+    }
+
+    fun utledLovtekstInnhold(formkravVilkår: Set<FormkravVilkår>): String {
+        val folketrygdloven = formkravVilkår.flatMap { it.folketrygdLoven }.sorted().toSet()
+        val forvaltningsloven = formkravVilkår.flatMap { it.forvaltningsloven }.sorted().toSet()
+        val harFolketrygdlov = folketrygdloven.isNotEmpty()
+        val harForvaltningslov = forvaltningsloven.isNotEmpty()
+
+        return if (harFolketrygdlov && harForvaltningslov) {
+            "Vedtaket er gjort etter folketrygdloven ${utledParagrafer(folketrygdloven)} og forvaltningsloven ${
+                utledParagrafer(forvaltningsloven)
+            }"
+        } else if (harFolketrygdlov) {
+            "Vedtaket er gjort etter folketrygdloven ${utledParagrafer(folketrygdloven)}"
+        } else if (harForvaltningslov) {
+            "Vedtaket er gjort etter forvaltningsloven ${utledParagrafer(forvaltningsloven)}"
+        } else {
+            throw Feil("Har ingen paragrafer å utlede i vedtaksbrev ved formkrav avvist")
+        }
+
+    }
+
+    private fun utledParagrafer(paragrafer: Set<String>): String {
+        return if (paragrafer.size == 1) {
+            "§ ${paragrafer.first()}"
+        } else {
+            val alleUnntattSiste = paragrafer.toList().dropLast(1)
+            val siste = paragrafer.toList().last()
+            "§§ ${alleUnntattSiste.joinToString { it }} og $siste"
+        }
+    }
+
+    const val tekstPrefix = "Vi har avvist klagen din fordi"
+
+    enum class FormkravVilkår(val tekst: String, val folketrygdLoven: Set<String>, val forvaltningsloven: Set<String>) {
+        KLAGE_KONKRET("du har ikke sagt hva du klager på.", emptySet(), setOf("32", "33")),
+        KLAGE_PART("du har klaget på et vedtak som ikke gjelder deg.", emptySet(), setOf("28", "33")),
+        KLAGE_SIGNERT("du ikke har underskrevet den.", emptySet(), setOf("31", "33")),
+        KLAGEFRIST_OVERHOLDT("du har klaget for sent.", setOf("21-12"), setOf("31", "33"))
+    }
+
+
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/FormBrevUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/FormBrevUtil.kt
@@ -13,9 +13,9 @@ object FormBrevUtil {
             "Skal ikke kunne utlede innholdstekst til formkrav avvist brev uten ikke oppfylte formkrav"
         }
         if (formkravVilkår.size > 1) {
-            return "$tekstPrefix: ${formkravVilkår.joinToString("") { "\n  •  ${it.tekst}" }}"
+            return "$innholdstekstPrefix: ${formkravVilkår.joinToString("") { "\n  •  ${it.tekst}" }}"
         } else {
-            return "$tekstPrefix ${formkravVilkår.first().tekst}"
+            return "$innholdstekstPrefix ${formkravVilkår.first().tekst}"
         }
     }
 
@@ -28,7 +28,7 @@ object FormBrevUtil {
         ).filterNotNull().toSet()
     }
 
-    fun utledLovtekstInnhold(formkravVilkår: Set<FormkravVilkår>): String {
+    fun utledLovtekst(formkravVilkår: Set<FormkravVilkår>): String {
         val folketrygdloven = formkravVilkår.flatMap { it.folketrygdLoven }.sorted().toSet()
         val forvaltningsloven = formkravVilkår.flatMap { it.forvaltningsloven }.sorted().toSet()
         val harFolketrygdlov = folketrygdloven.isNotEmpty()
@@ -45,7 +45,6 @@ object FormBrevUtil {
         } else {
             throw Feil("Har ingen paragrafer å utlede i vedtaksbrev ved formkrav avvist")
         }
-
     }
 
     private fun utledParagrafer(paragrafer: Set<String>): String {
@@ -58,7 +57,7 @@ object FormBrevUtil {
         }
     }
 
-    const val tekstPrefix = "Vi har avvist klagen din fordi"
+    const val innholdstekstPrefix = "Vi har avvist klagen din fordi"
 
     enum class FormkravVilkår(val tekst: String, val folketrygdLoven: Set<String>, val forvaltningsloven: Set<String>) {
         KLAGE_KONKRET("du har ikke sagt hva du klager på.", emptySet(), setOf("32", "33")),
@@ -66,6 +65,4 @@ object FormBrevUtil {
         KLAGE_SIGNERT("du ikke har underskrevet den.", emptySet(), setOf("31", "33")),
         KLAGEFRIST_OVERHOLDT("du har klaget for sent.", setOf("21-12"), setOf("31", "33"))
     }
-
-
 }

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormUtil.kt
@@ -23,8 +23,6 @@ object FormUtil {
                                            && formkrav.saksbehandlerBegrunnelse.isNotBlank()
                                            && formkrav.brevtekst != null
                                            && formkrav.brevtekst.isNotBlank()
-
-
     private fun Form.alleSvar() = setOf(
         klageKonkret,
         klagePart,

--- a/src/test/kotlin/no/nav/familie/klage/brev/FormBrevUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/FormBrevUtilTest.kt
@@ -1,0 +1,139 @@
+package no.nav.familie.klage.brev
+
+import no.nav.familie.klage.brev.FormBrevUtil.utledIkkeOppfylteFormkrav
+import no.nav.familie.klage.brev.FormBrevUtil.utledInnholdstekst
+import no.nav.familie.klage.brev.FormBrevUtil.utledLovtekst
+import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+internal class FormBrevUtilTest {
+
+
+    @Test
+    internal fun `et formkrav ikke oppfylt`() {
+        val klagePart = oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.IKKE_OPPFYLT)
+        val klageKonkret = oppfyltForm(UUID.randomUUID()).copy(klageKonkret = FormVilkår.IKKE_OPPFYLT)
+        val klageSignert = oppfyltForm(UUID.randomUUID()).copy(klageSignert = FormVilkår.IKKE_OPPFYLT)
+        val klagefristOverholdt = oppfyltForm(UUID.randomUUID()).copy(klagefristOverholdt = FormVilkår.IKKE_OPPFYLT)
+
+        assertThat(utledIkkeOppfylteFormkrav(klagePart)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART))
+        assertThat(utledIkkeOppfylteFormkrav(klageKonkret)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_KONKRET))
+        assertThat(utledIkkeOppfylteFormkrav(klageSignert)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT))
+        assertThat(utledIkkeOppfylteFormkrav(klagefristOverholdt)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT))
+    }
+
+    @Test
+    internal fun `ingen formkrav oppfylt`() {
+        val formkravFireIkkeOppfylt = oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.IKKE_OPPFYLT,
+                                                                          klageSignert = FormVilkår.IKKE_OPPFYLT,
+                                                                          klageKonkret = FormVilkår.IKKE_OPPFYLT,
+                                                                          klagefristOverholdt = FormVilkår.IKKE_OPPFYLT)
+
+        assertThat(utledIkkeOppfylteFormkrav(formkravFireIkkeOppfylt)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART,
+                                                                                       FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT,
+                                                                                       FormBrevUtil.FormkravVilkår.KLAGE_KONKRET,
+                                                                                       FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT))
+    }
+
+    @Test
+    internal fun `skal ikke utlede innholdstekst dersom alle formkrav er oppfylt`() {
+        val feil = assertThrows<Feil> { utledInnholdstekst(tomIkkeOppfylteFormkrav) }
+        assertThat(feil.frontendFeilmelding).isEqualTo("Skal ikke kunne utlede innholdstekst til formkrav avvist brev uten ikke oppfylte formkrav")
+    }
+
+    @Test
+    internal fun `skal utlede riktig innholdstekst dersom kun et formkrav er ikke oppfylt`() {
+        assertThat(utledInnholdstekst(klagePart)).isEqualTo("$innholdstekstPrefix $klagePartTekst")
+        assertThat(utledInnholdstekst(klageKonkret)).isEqualTo("$innholdstekstPrefix $klageKonkretTekst")
+        assertThat(utledInnholdstekst(klageSignert)).isEqualTo("$innholdstekstPrefix $klageSignertTekst")
+        assertThat(utledInnholdstekst(klagefristOverholdt)).isEqualTo("$innholdstekstPrefix $klageFristOverholdtTekst")
+    }
+
+    @Test
+    internal fun `skal utlede riktig innholdstekst dersom flere formkrav ikke er oppfylt`() {
+        val innholdstekst = utledInnholdstekst(ikkeOppfylteFormkrav)
+
+        assertThat(innholdstekst).contains("$innholdstekstPrefix:")
+        assertThat(innholdstekst).contains("$klageKonkretTekst")
+        assertThat(innholdstekst).contains("$klageSignertTekst")
+        assertThat(innholdstekst).contains("$klageFristOverholdtTekst")
+    }
+
+    @Test
+    internal fun `skal ikke utlede lovtekst dersom alle formkrav er oppfylt`() {
+        val feil = assertThrows<Feil> { utledLovtekst(tomIkkeOppfylteFormkrav) }
+        assertThat(feil.message).isEqualTo("Har ingen paragrafer å utlede i vedtaksbrev ved formkrav avvist")
+    }
+
+    @Test
+    internal fun `skal utlede riktig lovtekst dersom kun et formkrav er ikke oppfylt`() {
+        val klagePartLovtekst = utledLovtekst(klagePart)
+        assertThat(klagePartLovtekst).contains(forvaltningslovPrefix)
+        assertThat(klagePartLovtekst).contains("28")
+        assertThat(klagePartLovtekst).contains("33")
+        assertThat(klagePartLovtekst).doesNotContain("31")
+        assertThat(klagePartLovtekst).doesNotContain("32")
+        assertThat(klagePartLovtekst).doesNotContain("21-12")
+
+        val klageKonkretLovtekst = utledLovtekst(klageKonkret)
+        assertThat(klageKonkretLovtekst).contains(forvaltningslovPrefix)
+        assertThat(klageKonkretLovtekst).contains("32")
+        assertThat(klageKonkretLovtekst).contains("33")
+        assertThat(klageKonkretLovtekst).doesNotContain("28")
+        assertThat(klageKonkretLovtekst).doesNotContain("31")
+        assertThat(klageKonkretLovtekst).doesNotContain("21-12")
+
+        val klageSignertLovtekst = utledLovtekst(klageSignert)
+        assertThat(klageSignertLovtekst).contains(forvaltningslovPrefix)
+        assertThat(klageSignertLovtekst).contains("31")
+        assertThat(klageSignertLovtekst).contains("33")
+        assertThat(klageSignertLovtekst).doesNotContain("28")
+        assertThat(klageSignertLovtekst).doesNotContain("32")
+        assertThat(klageSignertLovtekst).doesNotContain("21-12")
+
+        val klageFristLovtekst = utledLovtekst(klagefristOverholdt)
+        assertThat(klageFristLovtekst).contains(folketrygdLovPrefix)
+        assertThat(klageFristLovtekst).contains("og forvaltningsloven")
+        assertThat(klageFristLovtekst).contains("21-12")
+        assertThat(klageFristLovtekst).contains("31")
+        assertThat(klageFristLovtekst).contains("33")
+        assertThat(klageFristLovtekst).doesNotContain("28")
+        assertThat(klageFristLovtekst).doesNotContain("32")
+    }
+
+    @Test
+    internal fun `skal utlede riktig lovtekst dersom flere formkrav ikke er oppfylt`() {
+        val lovtekst = utledLovtekst(ikkeOppfylteFormkrav)
+
+        assertThat(lovtekst).contains("Vedtaket er gjort etter folketrygdloven")
+        assertThat(lovtekst).contains("og forvaltningsloven")
+        assertThat(lovtekst).contains("28")
+        assertThat(lovtekst).contains("31")
+        assertThat(lovtekst).contains("32")
+        assertThat(lovtekst).contains("33")
+        assertThat(lovtekst).contains("21-12")
+    }
+
+    val klagePartTekst = "du har klaget på et vedtak som ikke gjelder deg."
+    val klageKonkretTekst = "du har ikke sagt hva du klager på."
+    val klageSignertTekst = "du ikke har underskrevet den."
+    val klageFristOverholdtTekst = "du har klaget for sent."
+    val innholdstekstPrefix = "Vi har avvist klagen din fordi"
+    val folketrygdLovPrefix = "Vedtaket er gjort etter folketrygdloven"
+    val forvaltningslovPrefix = "Vedtaket er gjort etter forvaltningsloven"
+
+    val tomIkkeOppfylteFormkrav = emptySet<FormBrevUtil.FormkravVilkår>()
+    val klagePart = setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART)
+    val klageKonkret = setOf(FormBrevUtil.FormkravVilkår.KLAGE_KONKRET)
+    val klageSignert = setOf(FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT)
+    val klagefristOverholdt = setOf(FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT)
+    val ikkeOppfylteFormkrav = setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART,
+                                     FormBrevUtil.FormkravVilkår.KLAGE_KONKRET,
+                                     FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT,
+                                     FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT)
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/FormBrevUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/FormBrevUtilTest.kt
@@ -1,9 +1,14 @@
 package no.nav.familie.klage.brev
 
 import no.nav.familie.klage.brev.FormBrevUtil.utledIkkeOppfylteFormkrav
-import no.nav.familie.klage.brev.FormBrevUtil.utledInnholdstekst
+import no.nav.familie.klage.brev.FormBrevUtil.utledÅrsakTilAvvisningstekst
 import no.nav.familie.klage.brev.FormBrevUtil.utledLovtekst
-import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.brev.FormBrevUtil.FormkravVilkår
+import no.nav.familie.klage.brev.FormBrevUtil.FormkravVilkår.KLAGE_PART
+import no.nav.familie.klage.brev.FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT
+import no.nav.familie.klage.brev.FormBrevUtil.FormkravVilkår.KLAGE_KONKRET
+import no.nav.familie.klage.brev.FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT
+import no.nav.familie.klage.formkrav.domain.FormVilkår.IKKE_OPPFYLT
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.testutil.DomainUtil.oppfyltForm
 import org.assertj.core.api.Assertions.assertThat
@@ -16,52 +21,49 @@ internal class FormBrevUtilTest {
 
     @Test
     internal fun `et formkrav ikke oppfylt`() {
-        val klagePart = oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.IKKE_OPPFYLT)
-        val klageKonkret = oppfyltForm(UUID.randomUUID()).copy(klageKonkret = FormVilkår.IKKE_OPPFYLT)
-        val klageSignert = oppfyltForm(UUID.randomUUID()).copy(klageSignert = FormVilkår.IKKE_OPPFYLT)
-        val klagefristOverholdt = oppfyltForm(UUID.randomUUID()).copy(klagefristOverholdt = FormVilkår.IKKE_OPPFYLT)
+        val klagePart = oppfyltForm(UUID.randomUUID()).copy(klagePart = IKKE_OPPFYLT)
+        val klageKonkret = oppfyltForm(UUID.randomUUID()).copy(klageKonkret = IKKE_OPPFYLT)
+        val klageSignert = oppfyltForm(UUID.randomUUID()).copy(klageSignert = IKKE_OPPFYLT)
+        val klagefristOverholdt = oppfyltForm(UUID.randomUUID()).copy(klagefristOverholdt = IKKE_OPPFYLT)
 
-        assertThat(utledIkkeOppfylteFormkrav(klagePart)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART))
-        assertThat(utledIkkeOppfylteFormkrav(klageKonkret)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_KONKRET))
-        assertThat(utledIkkeOppfylteFormkrav(klageSignert)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT))
-        assertThat(utledIkkeOppfylteFormkrav(klagefristOverholdt)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT))
+        assertThat(utledIkkeOppfylteFormkrav(klagePart)).isEqualTo(setOf(KLAGE_PART))
+        assertThat(utledIkkeOppfylteFormkrav(klageKonkret)).isEqualTo(setOf(KLAGE_KONKRET))
+        assertThat(utledIkkeOppfylteFormkrav(klageSignert)).isEqualTo(setOf(KLAGE_SIGNERT))
+        assertThat(utledIkkeOppfylteFormkrav(klagefristOverholdt)).isEqualTo(setOf(KLAGEFRIST_OVERHOLDT))
     }
 
     @Test
     internal fun `ingen formkrav oppfylt`() {
-        val formkravFireIkkeOppfylt = oppfyltForm(UUID.randomUUID()).copy(klagePart = FormVilkår.IKKE_OPPFYLT,
-                                                                          klageSignert = FormVilkår.IKKE_OPPFYLT,
-                                                                          klageKonkret = FormVilkår.IKKE_OPPFYLT,
-                                                                          klagefristOverholdt = FormVilkår.IKKE_OPPFYLT)
+        val formkravFireIkkeOppfylt = oppfyltForm(UUID.randomUUID()).copy(klagePart = IKKE_OPPFYLT,
+                                                                          klageSignert = IKKE_OPPFYLT,
+                                                                          klageKonkret = IKKE_OPPFYLT,
+                                                                          klagefristOverholdt = IKKE_OPPFYLT)
 
-        assertThat(utledIkkeOppfylteFormkrav(formkravFireIkkeOppfylt)).isEqualTo(setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART,
-                                                                                       FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT,
-                                                                                       FormBrevUtil.FormkravVilkår.KLAGE_KONKRET,
-                                                                                       FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT))
+        assertThat(utledIkkeOppfylteFormkrav(formkravFireIkkeOppfylt)).isEqualTo(setOf(KLAGE_PART, KLAGE_SIGNERT, KLAGE_KONKRET, KLAGEFRIST_OVERHOLDT))
     }
 
     @Test
     internal fun `skal ikke utlede innholdstekst dersom alle formkrav er oppfylt`() {
-        val feil = assertThrows<Feil> { utledInnholdstekst(tomIkkeOppfylteFormkrav) }
+        val feil = assertThrows<Feil> { utledÅrsakTilAvvisningstekst(tomIkkeOppfylteFormkrav) }
         assertThat(feil.frontendFeilmelding).isEqualTo("Skal ikke kunne utlede innholdstekst til formkrav avvist brev uten ikke oppfylte formkrav")
     }
 
     @Test
     internal fun `skal utlede riktig innholdstekst dersom kun et formkrav er ikke oppfylt`() {
-        assertThat(utledInnholdstekst(klagePart)).isEqualTo("$innholdstekstPrefix $klagePartTekst")
-        assertThat(utledInnholdstekst(klageKonkret)).isEqualTo("$innholdstekstPrefix $klageKonkretTekst")
-        assertThat(utledInnholdstekst(klageSignert)).isEqualTo("$innholdstekstPrefix $klageSignertTekst")
-        assertThat(utledInnholdstekst(klagefristOverholdt)).isEqualTo("$innholdstekstPrefix $klageFristOverholdtTekst")
+        assertThat(utledÅrsakTilAvvisningstekst(klagePart)).isEqualTo("$innholdstekstPrefix $klagePartTekst")
+        assertThat(utledÅrsakTilAvvisningstekst(klageKonkret)).isEqualTo("$innholdstekstPrefix $klageKonkretTekst")
+        assertThat(utledÅrsakTilAvvisningstekst(klageSignert)).isEqualTo("$innholdstekstPrefix $klageSignertTekst")
+        assertThat(utledÅrsakTilAvvisningstekst(klagefristOverholdt)).isEqualTo("$innholdstekstPrefix $klageFristOverholdtTekst")
     }
 
     @Test
     internal fun `skal utlede riktig innholdstekst dersom flere formkrav ikke er oppfylt`() {
-        val innholdstekst = utledInnholdstekst(ikkeOppfylteFormkrav)
+        val innholdstekst = utledÅrsakTilAvvisningstekst(ikkeOppfylteFormkrav)
 
         assertThat(innholdstekst).contains("$innholdstekstPrefix:")
-        assertThat(innholdstekst).contains("$klageKonkretTekst")
-        assertThat(innholdstekst).contains("$klageSignertTekst")
-        assertThat(innholdstekst).contains("$klageFristOverholdtTekst")
+        assertThat(innholdstekst).contains(klageKonkretTekst)
+        assertThat(innholdstekst).contains(klageSignertTekst)
+        assertThat(innholdstekst).contains(klageFristOverholdtTekst)
     }
 
     @Test
@@ -127,13 +129,10 @@ internal class FormBrevUtilTest {
     val folketrygdLovPrefix = "Vedtaket er gjort etter folketrygdloven"
     val forvaltningslovPrefix = "Vedtaket er gjort etter forvaltningsloven"
 
-    val tomIkkeOppfylteFormkrav = emptySet<FormBrevUtil.FormkravVilkår>()
-    val klagePart = setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART)
-    val klageKonkret = setOf(FormBrevUtil.FormkravVilkår.KLAGE_KONKRET)
-    val klageSignert = setOf(FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT)
-    val klagefristOverholdt = setOf(FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT)
-    val ikkeOppfylteFormkrav = setOf(FormBrevUtil.FormkravVilkår.KLAGE_PART,
-                                     FormBrevUtil.FormkravVilkår.KLAGE_KONKRET,
-                                     FormBrevUtil.FormkravVilkår.KLAGE_SIGNERT,
-                                     FormBrevUtil.FormkravVilkår.KLAGEFRIST_OVERHOLDT)
+    val tomIkkeOppfylteFormkrav = emptySet<FormkravVilkår>()
+    val klagePart = setOf(KLAGE_PART)
+    val klageKonkret = setOf(KLAGE_KONKRET)
+    val klageSignert = setOf(KLAGE_SIGNERT)
+    val klagefristOverholdt = setOf(KLAGEFRIST_OVERHOLDT)
+    val ikkeOppfylteFormkrav = setOf(KLAGE_PART, KLAGE_KONKRET, KLAGE_SIGNERT, KLAGEFRIST_OVERHOLDT)
 }


### PR DESCRIPTION
Skal sende med brevtekst til frontend, bassert på fritekst i formkravfane. Forskjellig tekst skal vises basert på hvilke formkrav som ikke er oppfylte.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10172)
[Design](https://www.figma.com/file/JEmXg4WqG0DFItNGpoX696/Skisser-EF-sak?node-id=9854%3A148394)

Eksempel:
<img width="567" alt="Skjermbilde 2022-11-01 kl  21 12 26" src="https://user-images.githubusercontent.com/32769446/199331800-d6a4b0fa-82e3-4474-817d-e3b8b39d0cd4.png">

