### PR TITLE
Stkal ha stønadstypen sin klageurl på egen linje da denne brekker ove…

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
@@ -43,7 +43,7 @@ object BrevInnhold {
                 AvsnittDto(
                     deloverskrift = "",
                     innhold =
-                    "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via ${stønadstype.klageUrl()}."
+                    "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via \n${stønadstype.klageUrl()}."
                 ),
                 AvsnittDto(
                     deloverskrift = "Har du spørsmål?",


### PR DESCRIPTION

<img width="560" alt="Skjermbilde 2022-11-07 kl  15 47 47" src="https://user-images.githubusercontent.com/402915/200339206-71f1ec45-06b6-4f5a-bd10-ac198891b8d7.png">
…r to linjer slik den står nå (PS: Tom space først på linje2 er fjernet!)