### PR TITLE
Brevsignatur skal anonymisere saksbehandlers navn og enhet hvis stren…

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -69,7 +69,8 @@ class BrevService(
     }
 
     fun lagBrev(behandlingId: UUID): ByteArray {
-        val navn = personopplysningerService.hentPersonopplysninger(behandlingId).navn
+        val personopplysninger = personopplysningerService.hentPersonopplysninger(behandlingId)
+        val navn = personopplysninger.navn
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsak(behandling.fagsakId)
         val påklagetFagsystemVedtak: FagsystemVedtak? = utledPåklagetFagsystemVedtak(behandling)
@@ -77,7 +78,7 @@ class BrevService(
 
         val brevRequest = lagBrevRequest(behandlingId, fagsak, navn, påklagetFagsystemVedtak, behandling.klageMottatt)
 
-        val signaturMedEnhet = brevsignaturService.lagSignatur(behandling.id)
+        val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysninger)
 
         val html = brevClient.genererHtmlFritekstbrev(
             fritekstBrev = brevRequest,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevsignaturService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevsignaturService.kt
@@ -2,17 +2,24 @@ package no.nav.familie.klage.brev
 
 import no.nav.familie.klage.brev.dto.SignaturDto
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
-class BrevsignaturService() {
+class BrevsignaturService {
 
-    fun lagSignatur(behandlingId: UUID): SignaturDto {
-        return SignaturDto(SikkerhetContext.hentSaksbehandlerNavn(true), ENHET_NAY, false)
+    fun lagSignatur(personopplysningerDto: PersonopplysningerDto): SignaturDto {
+        val harStrengtFortroligAdresse: Boolean = personopplysningerDto.adressebeskyttelse?.erStrengtFortrolig() ?: false
+
+        return if (harStrengtFortroligAdresse) {
+            SignaturDto(NAV_ANONYM_NAVN, ENHET_VIKAFOSSEN)
+        } else {
+            SignaturDto(SikkerhetContext.hentSaksbehandlerNavn(true), ENHET_NAY)
+        }
     }
 
     companion object {
+
         val NAV_ANONYM_NAVN = "NAV anonym"
         val ENHET_VIKAFOSSEN = "NAV Vikafossen"
         val ENHET_NAY = "NAV Arbeid og ytelser"

--- a/src/main/kotlin/no/nav/familie/klage/brev/dto/SignaturDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/dto/SignaturDto.kt
@@ -1,3 +1,3 @@
 package no.nav.familie.klage.brev.dto
 
-data class SignaturDto(val navn: String, val enhet: String, val skjulBeslutter: Boolean)
+data class SignaturDto(val navn: String, val enhet: String)

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevsignaturServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevsignaturServiceTest.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.klage.brev
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.personopplysninger.dto.Adressebeskyttelse
+import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
+import no.nav.familie.klage.testutil.BrukerContextUtil.testWithBrukerContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class BrevsignaturServiceTest {
+
+    val brevsignaturService = BrevsignaturService()
+
+    @Test
+    fun `skal anonymisere signatur hvis strengt fortrolig`() {
+        val personopplysningerDto = mockk<PersonopplysningerDto>()
+        every { personopplysningerDto.adressebeskyttelse } returns Adressebeskyttelse.STRENGT_FORTROLIG
+
+        val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysningerDto)
+
+        assertThat(signaturMedEnhet.enhet).isEqualTo(BrevsignaturService.ENHET_VIKAFOSSEN)
+        assertThat(signaturMedEnhet.navn).isEqualTo(BrevsignaturService.NAV_ANONYM_NAVN)
+    }
+
+    @Test
+    internal fun `skal returnere saksehandlers navn og enhet hvis ikke strengt fortrolig`() {
+        val personopplysningerDto = mockk<PersonopplysningerDto>()
+        every { personopplysningerDto.adressebeskyttelse } returns null
+
+        val signaturMedEnhet = testWithBrukerContext(preferredUsername = "Julenissen") {
+            brevsignaturService.lagSignatur(personopplysningerDto)
+        }
+
+        assertThat(signaturMedEnhet.enhet).isEqualTo(BrevsignaturService.ENHET_NAY)
+        assertThat(signaturMedEnhet.navn).isEqualTo("Julenissen")
+    }
+
+}


### PR DESCRIPTION
…gt fortrolig

Liknende kode som i EF-sak https://github.com/navikt/familie-ef-sak/blob/master/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10282

Del fra brev:
<img width="147" alt="image" src="https://user-images.githubusercontent.com/937168/202901082-da82d17b-cdcd-4897-9f6b-bebe2fc57399.png">

https://familie-klage.dev.intern.nav.no/behandling/b1b6a03e-ddb4-4a8d-b153-c318eef9b4d5/brev