### PR TITLE
Fjern bruk av deprecated felt vedtaksdatoInfotrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
@@ -137,7 +137,7 @@ class BehandlingService(
             eksternFagsystemBehandlingId = null,
             behandlingstype = "",
             resultat = "",
-            vedtakstidspunkt = påklagetVedtakDto.utledManuellVedtaksdato()?.atStartOfDay() ?: error("Mangler vedtaksdato")
+            vedtakstidspunkt = påklagetVedtakDto.manuellVedtaksdato?.atStartOfDay() ?: error("Mangler vedtaksdato")
         )
 
     private fun utledFagsystemType(påklagetVedtakDto: PåklagetVedtakDto): FagsystemType {

--- a/src/main/kotlin/no/nav/familie/klage/behandling/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/dto/BehandlingDto.kt
@@ -5,7 +5,6 @@ import no.nav.familie.klage.behandling.domain.FagsystemRevurdering
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype.IKKE_VALGT
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype.INFOTRYGD_TILBAKEKREVING
-import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype.UTEN_VEDTAK
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype.UTESTENGELSE
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype.VEDTAK
 import no.nav.familie.klage.behandling.domain.StegType
@@ -45,8 +44,6 @@ data class PåklagetVedtakDto(
     val eksternFagsystemBehandlingId: String?,
     val påklagetVedtakstype: PåklagetVedtakstype,
     val fagsystemVedtak: FagsystemVedtak? = null,
-    @Deprecated("Bruk manuell vedtaksdato")
-    val vedtaksdatoInfotrygd: LocalDate? = null,
     val manuellVedtaksdato: LocalDate? = null
 ) {
     fun erGyldig(): Boolean = when (eksternFagsystemBehandlingId) {
@@ -58,19 +55,9 @@ data class PåklagetVedtakDto(
 
     fun manglerVedtaksDato(): Boolean {
         if (påklagetVedtakstype == INFOTRYGD_TILBAKEKREVING || påklagetVedtakstype == UTESTENGELSE) {
-            return utledManuellVedtaksdato() == null
+            return manuellVedtaksdato == null
         }
         return false
-    }
-
-    fun utledManuellVedtaksdato(): LocalDate? {
-        return if (manuellVedtaksdato != null) {
-            manuellVedtaksdato
-        } else if (vedtaksdatoInfotrygd != null) {
-            vedtaksdatoInfotrygd
-        } else {
-            null
-        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/klage/behandling/dto/PåklagetVedtakDetaljerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/dto/PåklagetVedtakDetaljerMapper.kt
@@ -26,6 +26,5 @@ fun PåklagetVedtak.tilDto(): PåklagetVedtakDto =
         eksternFagsystemBehandlingId = this.påklagetVedtakDetaljer?.eksternFagsystemBehandlingId,
         påklagetVedtakstype = this.påklagetVedtakstype,
         fagsystemVedtak = this.påklagetVedtakDetaljer?.tilFagsystemVedtak(),
-        vedtaksdatoInfotrygd = if (påklagetVedtakstype == PåklagetVedtakstype.INFOTRYGD_TILBAKEKREVING) this.påklagetVedtakDetaljer?.vedtakstidspunkt?.toLocalDate() else null,
         manuellVedtaksdato = if (påklagetVedtakstype == PåklagetVedtakstype.INFOTRYGD_TILBAKEKREVING || påklagetVedtakstype == PåklagetVedtakstype.UTESTENGELSE) this.påklagetVedtakDetaljer?.vedtakstidspunkt?.toLocalDate() else null
     )


### PR DESCRIPTION
Opprydding etter [påklaget vedtak utestengelse](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10666).

`vedtaksdatoInfotrygd` er erstattet av `manuellVedtaksdato`, og brukes ikke lengre i frontend.

Venter litt med å merge så saksbehandlere får ny versjon av frontend.