### PR TITLE
Fiks BA og KS urler for å opprette revurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -35,7 +35,7 @@ class FamilieBASakClient(
 
     fun opprettRevurdering(fagsystemEksternFagsakId: String): OpprettRevurderingResponse {
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieBaSakUri)
-            .pathSegment("api/klage/fagsaker/$fagsystemEksternFagsakId/behandling/opprett-revurdering-klage/")
+            .pathSegment("api/klage/fagsaker/$fagsystemEksternFagsakId/opprett-revurdering-klage/")
             .build().toUri()
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
     }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
@@ -35,7 +35,7 @@ class FamilieKSSakClient(
 
     fun opprettRevurdering(fagsystemEksternFagsakId: String): OpprettRevurderingResponse {
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieKsSakUri)
-            .pathSegment("api/ekstern/fagsaker/$fagsystemEksternFagsakId/behandling/opprett-revurdering-klage/")
+            .pathSegment("api/ekstern/fagsaker/$fagsystemEksternFagsakId/opprett-revurdering-klage/")
             .build().toUri()
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
     }


### PR DESCRIPTION
Det hadde sneket seg inn en ekstra `/behandling/` i URLene for å opprette revurdering. Fjerner det i denne PRen