### PR TITLE
klagebehandlinger skal få satt vedtaksdato til nåværende tidspunkt nå…

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.klage.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.klage.behandlingsstatistikk.BehandlingsstatistikkTask
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.fagsak.domain.Fagsak
+import no.nav.familie.klage.felles.domain.SporbarUtils
 import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvisIkke
@@ -164,6 +165,7 @@ class BehandlingService(
             resultat = BehandlingResultat.HENLAGT,
             steg = BEHANDLING_FERDIGSTILT,
             status = FERDIGSTILT,
+            vedtakDato = SporbarUtils.now()
         )
 
         behandlinghistorikkService.opprettBehandlingshistorikk(behandlingId, BEHANDLING_FERDIGSTILT)

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingServiceTest.kt
@@ -90,6 +90,7 @@ internal class BehandlingServiceTest {
             assertThat(behandlingSlot.captured.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
             assertThat(behandlingSlot.captured.resultat).isEqualTo(BehandlingResultat.HENLAGT)
             assertThat(behandlingSlot.captured.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+            assertThat(behandlingSlot.captured.vedtakDato).isNotNull
         }
 
         private fun henleggOgForventApiFeilmelding(behandling: Behandling, henlagtÅrsak: HenlagtÅrsak) {


### PR DESCRIPTION
…r de blir henlagt

##Hensikten med denne PRen 
Det er ønskelig at vedtaksdato blir vist også for henlagte klagebehandlinger i fagsystemet. Da kan behandlingene opptre i riktig rekkefølge på behandlingsoversikten vår.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12118)