### PR TITLE
skal sette vedtakstidspunkt på henlagte behandlinger til tidsunktet f…

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.klage.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.klage.behandlingsstatistikk.BehandlingsstatistikkTask
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.fagsak.domain.Fagsak
+import no.nav.familie.klage.felles.domain.SporbarUtils
 import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvisIkke
@@ -164,6 +165,7 @@ class BehandlingService(
             resultat = BehandlingResultat.HENLAGT,
             steg = BEHANDLING_FERDIGSTILT,
             status = FERDIGSTILT,
+            vedtakDato = SporbarUtils.now()
         )
 
         behandlinghistorikkService.opprettBehandlingshistorikk(behandlingId, BEHANDLING_FERDIGSTILT)

--- a/src/main/resources/db/migration/V18__vedtaksdato_henlagte_behandlinger.sql
+++ b/src/main/resources/db/migration/V18__vedtaksdato_henlagte_behandlinger.sql
@@ -1,0 +1,1 @@
+UPDATE Behandling SET vedtak_dato=endret_tid where resultat='HENLAGT' AND vedtak_dato is null

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingServiceTest.kt
@@ -90,6 +90,7 @@ internal class BehandlingServiceTest {
             assertThat(behandlingSlot.captured.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
             assertThat(behandlingSlot.captured.resultat).isEqualTo(BehandlingResultat.HENLAGT)
             assertThat(behandlingSlot.captured.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+            assertThat(behandlingSlot.captured.vedtakDato).isNotNull
         }
 
         private fun henleggOgForventApiFeilmelding(behandling: Behandling, henlagtÅrsak: HenlagtÅrsak) {


### PR DESCRIPTION
…or henleggelse

Skal testes lokalt og i preprod

**Hvorfor?**
Dette gjøres slik at at behandlingsoversikten i fagsystemet også viser henlagte klagebehandlinger sortert på vedtaksdato.

