### PR TITLE
Skal sette høy prioritet på oppgaver hvor klageinstansutfall er opphevet

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -25,7 +25,7 @@ class BehandlingEventService(
     private val fagsakRepository: FagsakRepository,
     private val taskService: TaskService,
     private val klageresultatRepository: KlageresultatRepository,
-    private val stegService: StegService,
+    private val stegService: StegService
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -57,7 +57,7 @@ class BehandlingEventService(
             mottattEllerAvsluttetTidspunkt = behandlingEvent.mottattEllerAvsluttetTidspunkt(),
             kildereferanse = UUID.fromString(behandlingEvent.kildeReferanse),
             journalpostReferanser = StringListWrapper(behandlingEvent.journalpostReferanser()),
-            behandlingId = behandling.id,
+            behandlingId = behandling.id
         )
 
         klageresultatRepository.insert(klageinstansResultat)
@@ -82,7 +82,7 @@ class BehandlingEventService(
             ?: error("Finner ikke fagsak for behandlingId: ${behandling.id}")
         val oppgaveTekst = "${behandlingEvent.detaljer.oppgaveTekst()} Gjelder: ${fagsakDomain.stønadstype}"
         val klageBehandlingEksternId = UUID.fromString(behandlingEvent.kildeReferanse)
-        val opprettOppgavePayload = OpprettOppgavePayload(klageBehandlingEksternId, oppgaveTekst, fagsakDomain.fagsystem)
+        val opprettOppgavePayload = OpprettOppgavePayload(klageBehandlingEksternId, oppgaveTekst, fagsakDomain.fagsystem, behandlingEvent.utfall())
         val opprettOppgaveTask = OpprettKabalEventOppgaveTask.opprettTask(opprettOppgavePayload)
         taskService.save(opprettOppgaveTask)
     }

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/OpprettOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/OpprettOppgaveTaskTest.kt
@@ -4,8 +4,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.klage.behandling.BehandlingRepository
+import no.nav.familie.klage.behandling.domain.Behandling
 import no.nav.familie.klage.fagsak.FagsakPersonRepository
 import no.nav.familie.klage.fagsak.FagsakRepository
+import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.fagsak.domain.PersonIdent
 import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
 import no.nav.familie.klage.oppgave.OppgaveClient
@@ -16,8 +18,10 @@ import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.KlageinstansUtfall
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
+import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -38,28 +42,32 @@ class OpprettOppgaveTaskTest : OppslagSpringRunnerTest() {
 
     private lateinit var opprettOppgaveTask: OpprettKabalEventOppgaveTask
 
+    val personIdent = "12345678901"
+    private lateinit var fagsak: Fagsak
+    private lateinit var behandling: Behandling
+
     @BeforeEach
     fun setup() {
         opprettOppgaveTask = OpprettKabalEventOppgaveTask(fagsakRepository, behandlingRepository, personRepository, oppgaveClient)
         every { oppgaveClient.opprettOppgave(capture(opprettOppgaveRequestSlot)) } answers { 9L }
+
+        fagsak = testoppsettService.lagreFagsak(
+            fagsakDomain().tilFagsakMedPerson(
+                setOf(
+                    PersonIdent(personIdent)
+                )
+            )
+        )
+        behandling = behandling(fagsak)
+
+        behandlingRepository.insert(behandling)
     }
 
     @Test
     fun `skal lage oppgave med riktige verdier i request`() {
-        val personIdent = "12345678901"
-        val fagsak = testoppsettService.lagreFagsak(
-            fagsakDomain().tilFagsakMedPerson(
-                setOf(
-                    PersonIdent(personIdent),
-                ),
-            ),
-        )
-        val behandling = behandling(fagsak = fagsak)
-        behandlingRepository.insert(behandling)
-
         val fagsakDomain = fagsakRepository.findByIdOrNull(fagsak.id) ?: error("Finner ikke fagsak med id")
 
-        val opprettOppgavePayload = OpprettOppgavePayload(behandling.eksternBehandlingId, "tekst", Fagsystem.EF)
+        val opprettOppgavePayload = OpprettOppgavePayload(behandling.eksternBehandlingId, "tekst", Fagsystem.EF, null)
         opprettOppgaveTask.doTask(OpprettKabalEventOppgaveTask.opprettTask(opprettOppgavePayload))
 
         assertThat(opprettOppgaveRequestSlot.captured.tema).isEqualTo(Tema.ENF)
@@ -68,5 +76,22 @@ class OpprettOppgaveTaskTest : OppslagSpringRunnerTest() {
         assertThat(opprettOppgaveRequestSlot.captured.saksId).isEqualTo(fagsakDomain.eksternId)
         assertThat(opprettOppgaveRequestSlot.captured.enhetsnummer).isEqualTo(behandling.behandlendeEnhet)
         assertThat(opprettOppgaveRequestSlot.captured.behandlingstema).isEqualTo(Behandlingstema.Overgangsstønad.value)
+        assertThat(opprettOppgaveRequestSlot.captured.prioritet).isEqualTo(OppgavePrioritet.NORM)
+    }
+
+    @Test
+    fun `skal gi høy prioritet til oppgaver med klageinnstansutfall lik opphevet`() {
+        val opprettOppgavePayload = OpprettOppgavePayload(behandling.eksternBehandlingId, "tekst", Fagsystem.EF, KlageinstansUtfall.OPPHEVET)
+        opprettOppgaveTask.doTask(OpprettKabalEventOppgaveTask.opprettTask(opprettOppgavePayload))
+
+        assertThat(opprettOppgaveRequestSlot.captured.prioritet).isEqualTo(OppgavePrioritet.HOY)
+    }
+
+    @Test
+    fun `skal gi norm prioritet til oppgaver med klageinnstansutfall ikke lik opphevet`() {
+        val opprettOppgavePayload = OpprettOppgavePayload(behandling.eksternBehandlingId, "tekst", Fagsystem.EF, KlageinstansUtfall.MEDHOLD)
+        opprettOppgaveTask.doTask(OpprettKabalEventOppgaveTask.opprettTask(opprettOppgavePayload))
+
+        assertThat(opprettOppgaveRequestSlot.captured.prioritet).isEqualTo(OppgavePrioritet.NORM)
     }
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
Setter prioritet høy for hjemsendte klager fra NAV-klageinnstand for å minke saksbehandlertid ([FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12269))

### Hva er gjort?
Setter prioritet høy dersom klageinstansutfall = opphevet. Resterende får prioritet normal. 

Utfallet sendes med i payloaden i stedet for å hente det fra `KlagreresultatRepository` fordi en behandling kan ha flere klageresultater knyttet til seg. En eventuell løsning ville vært å sette prioritet høy dersom en av klageresultatene har result = opphevet, men da risikerer man å sette høy prioritet på oppgaver som ikke nødvendigvis skulle hatt det. Kunne sammenlignet `mottattEllerAvsluttetTidspunkt` for å finne aktuelt klageresultat, men dette måtte da blitt sendt med i payload i stedet. 