### PR TITLE
Skal sette behandlingstema = ab0007 på klager som gjelder tilbakekreving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
 		<prosessering.version>2.20230214102837_4b63c2e-SPRING_BOOT_3</prosessering.version>
 		<start-class>no.nav.familie.klage.ApplicationKt</start-class>
-		<kontrakter.version>3.0_20230306094848_3425b04-JAKARTA</kontrakter.version>
+		<kontrakter.version>3.0_20230404163639_edb8619-JAKARTA</kontrakter.version>
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/OpprettBehandlingService.kt
@@ -64,7 +64,7 @@ class OpprettBehandlingService(
 
         formService.opprettInitielleFormkrav(behandlingId)
 
-        oppgaveTaskService.opprettBehandleSakOppgave(behandlingId)
+        oppgaveTaskService.opprettBehandleSakOppgave(behandlingId, opprettKlagebehandlingRequest.klageGjelderTilbakekreving)
         taskService.save(
             BehandlingsstatistikkTask.opprettMottattTask(behandlingId = behandlingId),
         )

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -32,7 +32,7 @@ class EksternBehandlingController(
     private val tilgangService: TilgangService,
     private val behandlingService: BehandlingService,
     private val opprettBehandlingService: OpprettBehandlingService,
-    private val oppgaveService: OppgaveService
+    private val oppgaveService: OppgaveService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -40,7 +40,7 @@ class EksternBehandlingController(
     @GetMapping("{fagsystem}")
     fun finnKlagebehandlingsresultat(
         @PathVariable fagsystem: Fagsystem,
-        @RequestParam("eksternFagsakId") eksternFagsakIder: Set<String>
+        @RequestParam("eksternFagsakId") eksternFagsakIder: Set<String>,
     ): Ressurs<Map<String, List<KlagebehandlingDto>>> {
         feilHvis(eksternFagsakIder.isEmpty()) {
             "Mangler eksternFagsakId i query param"

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -15,6 +15,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -67,7 +68,7 @@ class EksternBehandlingController(
         opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 
-    @PostMapping("{behandlingId}/gjelder-tilbakekreving")
+    @PatchMapping("{behandlingId}/gjelder-tilbakekreving")
     fun oppdaterOppgaveTilÅGjeldeTilbakekreving(@PathVariable behandlingId: UUID) {
         oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
     }

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -68,7 +68,7 @@ class EksternBehandlingController(
         opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 
-    @PatchMapping("/{behandlingId}/gjelder-tilbakekreving")
+    @PatchMapping("{behandlingId}/gjelder-tilbakekreving")
     fun oppdaterOppgaveTilÅGjeldeTilbakekreving(@PathVariable behandlingId: UUID) {
         oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
     }

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -15,7 +15,6 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -68,7 +67,7 @@ class EksternBehandlingController(
         opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 
-    @PatchMapping("{behandlingId}/gjelder-tilbakekreving")
+    @PostMapping("{behandlingId}/gjelder-tilbakekreving")
     fun oppdaterOppgaveTilÅGjeldeTilbakekreving(@PathVariable behandlingId: UUID) {
         oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
     }

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -15,6 +15,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -67,8 +68,8 @@ class EksternBehandlingController(
         opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 
-    @PostMapping("/behandling/{behandlingId}/gjelder-tilbakekreving")
-    fun oppdaterOppgaveForBehandling(@PathVariable behandlingId: UUID) {
+    @PatchMapping("/behandling/{behandlingId}/gjelder-tilbakekreving")
+    fun oppdaterOppgaveTilÅGjeldeTilbakekreving(@PathVariable behandlingId: UUID) {
         oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -68,7 +68,7 @@ class EksternBehandlingController(
         opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 
-    @PatchMapping("/behandling/{behandlingId}/gjelder-tilbakekreving")
+    @PatchMapping("/{behandlingId}/gjelder-tilbakekreving")
     fun oppdaterOppgaveTilÅGjeldeTilbakekreving(@PathVariable behandlingId: UUID) {
         oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
     }

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.klage.behandling.domain.tilEksternKlagebehandlingDto
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.klage.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.KlagebehandlingDto
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/ekstern/behandling"])
@@ -29,6 +31,7 @@ class EksternBehandlingController(
     private val tilgangService: TilgangService,
     private val behandlingService: BehandlingService,
     private val opprettBehandlingService: OpprettBehandlingService,
+    private val oppgaveService: OppgaveService
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -36,7 +39,7 @@ class EksternBehandlingController(
     @GetMapping("{fagsystem}")
     fun finnKlagebehandlingsresultat(
         @PathVariable fagsystem: Fagsystem,
-        @RequestParam("eksternFagsakId") eksternFagsakIder: Set<String>,
+        @RequestParam("eksternFagsakId") eksternFagsakIder: Set<String>
     ): Ressurs<Map<String, List<KlagebehandlingDto>>> {
         feilHvis(eksternFagsakIder.isEmpty()) {
             "Mangler eksternFagsakId i query param"
@@ -62,5 +65,10 @@ class EksternBehandlingController(
     @PostMapping("/opprett")
     fun opprettBehandling(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest) {
         opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
+    }
+
+    @PostMapping("/behandling/{behandlingId}/gjelder-tilbakekreving")
+    fun oppdaterOppgaveForBehandling(@PathVariable behandlingId: UUID) {
+        oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/felles/util/TaskMetadata.kt
+++ b/src/main/kotlin/no/nav/familie/klage/felles/util/TaskMetadata.kt
@@ -2,4 +2,5 @@ package no.nav.familie.klage.felles.util
 
 object TaskMetadata {
     const val saksbehandlerMetadataKey = "saksbehandler"
+    const val klageGjelderTilbakekrevingMetadataKey = "gjelderTilbakekreving"
 }

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -25,7 +25,7 @@ class BehandlingEventService(
     private val fagsakRepository: FagsakRepository,
     private val taskService: TaskService,
     private val klageresultatRepository: KlageresultatRepository,
-    private val stegService: StegService
+    private val stegService: StegService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -57,7 +57,7 @@ class BehandlingEventService(
             mottattEllerAvsluttetTidspunkt = behandlingEvent.mottattEllerAvsluttetTidspunkt(),
             kildereferanse = UUID.fromString(behandlingEvent.kildeReferanse),
             journalpostReferanser = StringListWrapper(behandlingEvent.journalpostReferanser()),
-            behandlingId = behandling.id
+            behandlingId = behandling.id,
         )
 
         klageresultatRepository.insert(klageinstansResultat)

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -13,12 +13,11 @@ import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import java.net.URI
-import java.util.*
 
 @Component
 class OppgaveClient(
     @Qualifier("azure") restOperations: RestOperations,
-    private val integrasjonerConfig: IntegrasjonerConfig
+    private val integrasjonerConfig: IntegrasjonerConfig,
 ) : AbstractPingableRestClient(restOperations, "oppgave") {
 
     override val pingUri: URI = integrasjonerConfig.pingUri
@@ -42,7 +41,7 @@ class OppgaveClient(
         val respons = patchForEntity<Ressurs<OppgaveResponse>>(
             uri,
             oppgave,
-            HttpHeaders().medContentTypeJsonUTF8()
+            HttpHeaders().medContentTypeJsonUTF8(),
         )
         return pakkUtRespons(respons, uri, "ferdigstillOppgave").oppgaveId
     }
@@ -50,7 +49,7 @@ class OppgaveClient(
     private fun <T> pakkUtRespons(
         respons: Ressurs<T>,
         uri: URI?,
-        metode: String
+        metode: String,
     ): T {
         val data = respons.data
         if (respons.status == Ressurs.Status.SUKSESS && data != null) {
@@ -62,7 +61,7 @@ class OppgaveClient(
                 "Respons fra $metode feilet med status=${respons.status} melding=${respons.melding}",
                 null,
                 uri,
-                data
+                data,
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -43,7 +43,7 @@ class OppgaveClient(
             oppgave,
             HttpHeaders().medContentTypeJsonUTF8(),
         )
-        return pakkUtRespons(respons, uri, "ferdigstillOppgave").oppgaveId
+        return pakkUtRespons(respons, uri, "oppdaterOppgave").oppgaveId
     }
 
     private fun <T> pakkUtRespons(

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -5,6 +5,7 @@ import no.nav.familie.klage.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.klage.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.klage.infrastruktur.exception.IntegrasjonException
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.springframework.beans.factory.annotation.Qualifier
@@ -12,11 +13,12 @@ import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import java.net.URI
+import java.util.*
 
 @Component
 class OppgaveClient(
     @Qualifier("azure") restOperations: RestOperations,
-    private val integrasjonerConfig: IntegrasjonerConfig,
+    private val integrasjonerConfig: IntegrasjonerConfig
 ) : AbstractPingableRestClient(restOperations, "oppgave") {
 
     override val pingUri: URI = integrasjonerConfig.pingUri
@@ -35,10 +37,20 @@ class OppgaveClient(
         pakkUtRespons(respons, uri, "ferdigstillOppgave")
     }
 
+    fun oppdaterOppgave(oppgave: Oppgave): Long {
+        val uri = URI.create("$oppgaveUri/${oppgave.id!!}/oppdater")
+        val respons = patchForEntity<Ressurs<OppgaveResponse>>(
+            uri,
+            oppgave,
+            HttpHeaders().medContentTypeJsonUTF8()
+        )
+        return pakkUtRespons(respons, uri, "ferdigstillOppgave").oppgaveId
+    }
+
     private fun <T> pakkUtRespons(
         respons: Ressurs<T>,
         uri: URI?,
-        metode: String,
+        metode: String
     ): T {
         val data = respons.data
         if (respons.status == Ressurs.Status.SUKSESS && data != null) {
@@ -50,7 +62,7 @@ class OppgaveClient(
                 "Respons fra $metode feilet med status=${respons.status} melding=${respons.melding}",
                 null,
                 uri,
-                data,
+                data
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
@@ -1,0 +1,17 @@
+package no.nav.familie.klage.oppgave
+
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class OppgaveService(private val behandleSakOppgaveRepository: BehandleSakOppgaveRepository, private val oppgaveClient: OppgaveClient) {
+
+    fun oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId: UUID): Long {
+        val eksisterendeOppgave = behandleSakOppgaveRepository.findByBehandlingId(behandlingId)
+        val oppdatertOppgave = Oppgave(id = eksisterendeOppgave.oppgaveId, behandlingstema = Behandlingstema.Tilbakebetaling.value)
+
+        return oppgaveClient.oppdaterOppgave(oppdatertOppgave)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
@@ -3,7 +3,7 @@ package no.nav.familie.klage.oppgave
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
 class OppgaveService(private val behandleSakOppgaveRepository: BehandleSakOppgaveRepository, private val oppgaveClient: OppgaveClient) {

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.klage.oppgave
 
+import no.nav.familie.klage.felles.util.TaskMetadata.klageGjelderTilbakekrevingMetadataKey
 import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.prosessering.domene.Task
@@ -10,12 +11,13 @@ import java.util.UUID
 
 @Service
 class OppgaveTaskService(private val taskService: TaskService) {
-    fun opprettBehandleSakOppgave(behandlingId: UUID) {
+    fun opprettBehandleSakOppgave(behandlingId: UUID, klageGjelderTilbakekreving: Boolean) {
         val behandleSakOppgaveTask = Task(
             type = OpprettBehandleSakOppgaveTask.TYPE,
             payload = behandlingId.toString(),
             properties = Properties().apply {
                 this[saksbehandlerMetadataKey] = SikkerhetContext.hentSaksbehandler(strict = true)
+                this[klageGjelderTilbakekrevingMetadataKey] = klageGjelderTilbakekreving.toString()
             },
         )
         taskService.save(behandleSakOppgaveTask)

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
@@ -46,7 +46,7 @@ class OpprettBehandleSakOppgaveTask(
             behandlingstype = Behandlingstema.Klage.value,
             behandlesAvApplikasjon = "familie-klage",
             tilordnetRessurs = task.metadata[saksbehandlerMetadataKey].toString(),
-            behandlingstema = if (klageGjelderTilbakekreving) "ab0007" else null,
+            behandlingstema = if (klageGjelderTilbakekreving) Behandlingstema.Tilbakebetaling.value else null,
         )
 
         val oppgaveId = oppgaveClient.opprettOppgave(opprettOppgaveRequest = oppgaveRequest)

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
@@ -33,7 +33,7 @@ class OpprettBehandleSakOppgaveTask(
         val behandlingId = UUID.fromString(task.payload)
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
-        val klageGjelderTilbakekreving: Boolean = task.metadata[klageGjelderTilbakekrevingMetadataKey].toString().toBoolean()
+        val klageGjelderTilbakekreving: Boolean = task.metadata.getProperty(klageGjelderTilbakekrevingMetadataKey).toBoolean()
 
         val oppgaveRequest = OpprettOppgaveRequest(
             ident = OppgaveIdentV2(ident = fagsak.hentAktivIdent(), gruppe = IdentGruppe.FOLKEREGISTERIDENT),
@@ -45,7 +45,7 @@ class OpprettBehandleSakOppgaveTask(
             enhetsnummer = behandling.behandlendeEnhet,
             behandlingstype = Behandlingstema.Klage.value,
             behandlesAvApplikasjon = "familie-klage",
-            tilordnetRessurs = task.metadata[saksbehandlerMetadataKey].toString(),
+            tilordnetRessurs = task.metadata.getProperty(saksbehandlerMetadataKey),
             behandlingstema = if (klageGjelderTilbakekreving) Behandlingstema.Tilbakebetaling.value else null,
         )
 

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
@@ -2,6 +2,7 @@ package no.nav.familie.klage.oppgave
 
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.felles.util.TaskMetadata.klageGjelderTilbakekrevingMetadataKey
 import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey
 import no.nav.familie.klage.oppgave.OppgaveUtil.lagFristForOppgave
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -32,6 +33,7 @@ class OpprettBehandleSakOppgaveTask(
         val behandlingId = UUID.fromString(task.payload)
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
+        val klageGjelderTilbakekreving: Boolean = task.metadata[klageGjelderTilbakekrevingMetadataKey].toString().toBoolean()
 
         val oppgaveRequest = OpprettOppgaveRequest(
             ident = OppgaveIdentV2(ident = fagsak.hentAktivIdent(), gruppe = IdentGruppe.FOLKEREGISTERIDENT),
@@ -44,7 +46,7 @@ class OpprettBehandleSakOppgaveTask(
             behandlingstype = Behandlingstema.Klage.value,
             behandlesAvApplikasjon = "familie-klage",
             tilordnetRessurs = task.metadata[saksbehandlerMetadataKey].toString(),
-            behandlingstema = null,
+            behandlingstema = if (klageGjelderTilbakekreving) "ab0007" else null,
         )
 
         val oppgaveId = oppgaveClient.opprettOppgave(opprettOppgaveRequest = oppgaveRequest)

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettKabalEventOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettKabalEventOppgaveTask.kt
@@ -27,13 +27,13 @@ import java.util.UUID
 @Service
 @TaskStepBeskrivelse(
     taskStepType = OpprettKabalEventOppgaveTask.TYPE,
-    beskrivelse = "Opprett oppgave for relevant hendelse fra kabal"
+    beskrivelse = "Opprett oppgave for relevant hendelse fra kabal",
 )
 class OpprettKabalEventOppgaveTask(
     private val fagsakRepository: FagsakRepository,
     private val behandlingRepository: BehandlingRepository,
     private val personRepository: FagsakPersonRepository,
-    private val oppgaveClient: OppgaveClient
+    private val oppgaveClient: OppgaveClient,
 ) : AsyncTaskStep {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -58,7 +58,7 @@ class OpprettKabalEventOppgaveTask(
                 beskrivelse = opprettOppgavePayload.oppgaveTekst,
                 enhetsnummer = behandling.behandlendeEnhet,
                 behandlingstema = finnBehandlingstema(fagsakDomain.stønadstype).value,
-                prioritet = prioritet
+                prioritet = prioritet,
             )
 
         val oppgaveId = oppgaveClient.opprettOppgave(opprettOppgaveRequest)
@@ -72,7 +72,7 @@ class OpprettKabalEventOppgaveTask(
         fun opprettTask(opprettOppgavePayload: OpprettOppgavePayload): Task {
             return Task(
                 TYPE,
-                objectMapper.writeValueAsString(opprettOppgavePayload)
+                objectMapper.writeValueAsString(opprettOppgavePayload),
             )
         }
     }
@@ -101,5 +101,5 @@ data class OpprettOppgavePayload(
     val klagebehandlingEksternId: UUID,
     val oppgaveTekst: String,
     val fagsystem: Fagsystem,
-    val klageinstansUtfall: KlageinstansUtfall?
+    val klageinstansUtfall: KlageinstansUtfall?,
 )

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/OpprettOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/OpprettOppgaveTaskTest.kt
@@ -54,9 +54,9 @@ class OpprettOppgaveTaskTest : OppslagSpringRunnerTest() {
         fagsak = testoppsettService.lagreFagsak(
             fagsakDomain().tilFagsakMedPerson(
                 setOf(
-                    PersonIdent(personIdent)
-                )
-            )
+                    PersonIdent(personIdent),
+                ),
+            ),
         )
         behandling = behandling(fagsak)
 

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveServiceTest.kt
@@ -23,7 +23,7 @@ internal class OppgaveServiceTest {
         val oppgaveSlot = slot<Oppgave>()
         val eksisterendeOppgave = BehandleSakOppgave(
             behandlingId = behandlingId,
-            oppgaveId = oppgaveId
+            oppgaveId = oppgaveId,
         )
 
         every { behandleSakOppgaveRepository.findByBehandlingId(behandlingId) } returns eksisterendeOppgave

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveServiceTest.kt
@@ -1,0 +1,66 @@
+package no.nav.familie.klage.oppgave
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class OppgaveServiceTest {
+
+    val behandleSakOppgaveRepository = mockk<BehandleSakOppgaveRepository>()
+    val oppgaveClient = mockk<OppgaveClient>()
+    val oppgaveService = OppgaveService(behandleSakOppgaveRepository, oppgaveClient)
+
+    val behandlingId = UUID.randomUUID()
+    val oppgaveId = 1L
+
+    @Test
+    internal fun `skal oppdatere oppgave med behandlingstemaet for klage-tilbakekreving`() {
+        val oppgaveSlot = slot<Oppgave>()
+        val eksisterendeOppgave = BehandleSakOppgave(
+            behandlingId = behandlingId,
+            oppgaveId = oppgaveId
+        )
+
+        every { behandleSakOppgaveRepository.findByBehandlingId(behandlingId) } returns eksisterendeOppgave
+
+        every { oppgaveClient.oppdaterOppgave(capture(oppgaveSlot)) } returns oppgaveId
+        oppgaveService.oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
+
+        assertThat(oppgaveSlot.captured.id).isEqualTo(oppgaveId)
+        assertThat(oppgaveSlot.captured.behandlingstema).isEqualTo(Behandlingstema.Tilbakebetaling.value)
+
+        // Sjekker at ingen andre felter blir satt
+        assertThat(oppgaveSlot.captured.aktivDato).isNull()
+        assertThat(oppgaveSlot.captured.behandlesAvApplikasjon).isNull()
+        assertThat(oppgaveSlot.captured.behandlingstype).isNull()
+        assertThat(oppgaveSlot.captured.beskrivelse).isNull()
+        assertThat(oppgaveSlot.captured.bnr).isNull()
+        assertThat(oppgaveSlot.captured.endretAv).isNull()
+        assertThat(oppgaveSlot.captured.endretAvEnhetsnr).isNull()
+        assertThat(oppgaveSlot.captured.endretTidspunkt).isNull()
+        assertThat(oppgaveSlot.captured.ferdigstiltTidspunkt).isNull()
+        assertThat(oppgaveSlot.captured.identer).isNull()
+        assertThat(oppgaveSlot.captured.journalpostId).isNull()
+        assertThat(oppgaveSlot.captured.journalpostkilde).isNull()
+        assertThat(oppgaveSlot.captured.mappeId).isNull()
+        assertThat(oppgaveSlot.captured.oppgavetype).isNull()
+        assertThat(oppgaveSlot.captured.opprettetAv).isNull()
+        assertThat(oppgaveSlot.captured.opprettetAvEnhetsnr).isNull()
+        assertThat(oppgaveSlot.captured.opprettetTidspunkt).isNull()
+        assertThat(oppgaveSlot.captured.orgnr).isNull()
+        assertThat(oppgaveSlot.captured.prioritet).isNull()
+        assertThat(oppgaveSlot.captured.saksreferanse).isNull()
+        assertThat(oppgaveSlot.captured.samhandlernr).isNull()
+        assertThat(oppgaveSlot.captured.status).isNull()
+        assertThat(oppgaveSlot.captured.tema).isNull()
+        assertThat(oppgaveSlot.captured.temagruppe).isNull()
+        assertThat(oppgaveSlot.captured.tildeltEnhetsnr).isNull()
+        assertThat(oppgaveSlot.captured.tilordnetRessurs).isNull()
+        assertThat(oppgaveSlot.captured.versjon).isNull()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskServiceTest.kt
@@ -91,7 +91,7 @@ internal class OppgaveTaskServiceTest {
                 payload = behandling.id.toString(),
                 properties = Properties().apply {
                     this[klageGjelderTilbakekrevingMetadataKey] = true
-                }
+                },
             )
 
             opprettBehandleSakOppgaveTask.doTask(behandleSakOppgaveTask)

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskServiceTest.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.klage.oppgave
 
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.felles.util.TaskMetadata.klageGjelderTilbakekrevingMetadataKey
 import no.nav.familie.klage.testutil.BrukerContextUtil
 import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.kontrakter.felles.Tema
@@ -14,8 +16,10 @@ import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.Properties
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 
@@ -48,29 +52,52 @@ internal class OppgaveTaskServiceTest {
         BrukerContextUtil.clearBrukerContext()
     }
 
-    @Test
-    internal fun `skal opprette behandleSak oppgave med riktige verdier for ny klagebehandling`() {
-        val oppgaveSlot = slot<OpprettOppgaveRequest>()
+    @Nested
+    inner class OpprettBehandleSakOppgave {
+        lateinit var oppgaveSlot: CapturingSlot<OpprettOppgaveRequest>
         val oppgaveId = 1L
-        every { oppgaveClient.opprettOppgave(capture(oppgaveSlot)) } returns oppgaveId
-        every { behandleSakOppgaveRepository.insert(any()) } answers { firstArg() }
 
-        val behandleSakOppgaveTask = Task(
-            type = OpprettBehandleSakOppgaveTask.TYPE,
-            payload = behandling.id.toString(),
-        )
+        @BeforeEach
+        fun setUp() {
+            oppgaveSlot = slot()
+            every { oppgaveClient.opprettOppgave(capture(oppgaveSlot)) } returns oppgaveId
+            every { behandleSakOppgaveRepository.insert(any()) } answers { firstArg() }
+        }
 
-        opprettBehandleSakOppgaveTask.doTask(behandleSakOppgaveTask)
+        @Test
+        internal fun `skal opprette behandleSak oppgave med riktige verdier for ny klagebehandling`() {
+            val behandleSakOppgaveTask = Task(
+                type = OpprettBehandleSakOppgaveTask.TYPE,
+                payload = behandling.id.toString(),
+            )
 
-        assertThat(oppgaveSlot.captured.behandlingstema).isNull()
-        assertThat(oppgaveSlot.captured.behandlingstype).isEqualTo("ae0058")
-        assertThat(oppgaveSlot.captured.behandlesAvApplikasjon).isEqualTo("familie-klage")
-        assertThat(oppgaveSlot.captured.oppgavetype).isEqualTo(Oppgavetype.BehandleSak)
-        assertThat(oppgaveSlot.captured.enhetsnummer).isEqualTo("4489")
-        assertThat(oppgaveSlot.captured.fristFerdigstillelse).isAfter(LocalDate.now())
-        assertThat(oppgaveSlot.captured.saksId).isEqualTo(fagsak.eksternId)
-        assertThat(oppgaveSlot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(oppgaveSlot.captured.tilordnetRessurs).isNotNull
+            opprettBehandleSakOppgaveTask.doTask(behandleSakOppgaveTask)
+
+            assertThat(oppgaveSlot.captured.behandlingstema).isNull()
+            assertThat(oppgaveSlot.captured.behandlingstype).isEqualTo("ae0058")
+            assertThat(oppgaveSlot.captured.behandlesAvApplikasjon).isEqualTo("familie-klage")
+            assertThat(oppgaveSlot.captured.oppgavetype).isEqualTo(Oppgavetype.BehandleSak)
+            assertThat(oppgaveSlot.captured.enhetsnummer).isEqualTo("4489")
+            assertThat(oppgaveSlot.captured.fristFerdigstillelse).isAfter(LocalDate.now())
+            assertThat(oppgaveSlot.captured.saksId).isEqualTo(fagsak.eksternId)
+            assertThat(oppgaveSlot.captured.tema).isEqualTo(Tema.ENF)
+            assertThat(oppgaveSlot.captured.tilordnetRessurs).isNotNull
+        }
+
+        @Test
+        internal fun `skal opprette behandleSakOppgave med behandlingstema klage tilbakekreving`() {
+            val behandleSakOppgaveTask = Task(
+                type = OpprettBehandleSakOppgaveTask.TYPE,
+                payload = behandling.id.toString(),
+                properties = Properties().apply {
+                    this[klageGjelderTilbakekrevingMetadataKey] = true
+                }
+            )
+
+            opprettBehandleSakOppgaveTask.doTask(behandleSakOppgaveTask)
+
+            assertThat(oppgaveSlot.captured.behandlingstema).isEqualTo("ab0007")
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveTaskServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.slot
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.util.TaskMetadata.klageGjelderTilbakekrevingMetadataKey
+import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey
 import no.nav.familie.klage.testutil.BrukerContextUtil
 import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.kontrakter.felles.Tema
@@ -69,6 +70,9 @@ internal class OppgaveTaskServiceTest {
             val behandleSakOppgaveTask = Task(
                 type = OpprettBehandleSakOppgaveTask.TYPE,
                 payload = behandling.id.toString(),
+                properties = Properties().apply {
+                    this[saksbehandlerMetadataKey] = ""
+                }
             )
 
             opprettBehandleSakOppgaveTask.doTask(behandleSakOppgaveTask)
@@ -90,7 +94,7 @@ internal class OppgaveTaskServiceTest {
                 type = OpprettBehandleSakOppgaveTask.TYPE,
                 payload = behandling.id.toString(),
                 properties = Properties().apply {
-                    this[klageGjelderTilbakekrevingMetadataKey] = true
+                    this[klageGjelderTilbakekrevingMetadataKey] = true.toString()
                 },
             )
 


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Saksbehandlere skal ha muligheten til å huke av for at en klage gjelder tilbakekreving, som skal sette behandlingstemaet på behandle sak oppgaven til `ab0007` (tilbakekreving). 

For ef-sak skal dette skje både via journalføring og ved manuell opprettelse av en klage.

### Hva er gjort? 🤓

1. Setter behandlingstema til `ab0007` dersom `klageGjelderTilbakekreving` er true ved opprettelse av ny oppgave.
2. Lagt til et endepunkt som setter behandlingstema på en eksisterende oppgave til `ab0007`

### Henger sammen med 🤹‍♀️

- [PR i EF-sak](https://github.com/navikt/familie-ef-sak/pull/2160) (Sende med klageGjelderTilbakekreving og opprette task for kall på nytt endepunkt)
- [PR i ef-sak-frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/2254) (Legge til checkbokser for å huke av om klage gjelder tilbakekreving)
- [PR i Kontrakter](https://github.com/navikt/familie-kontrakter/pull/767) (Legge til `klageGjelderTIlbakekreving` som felt i request). 
