### PR TITLE
Skal ikke oppdatere tema på oppgaver hvor behandlingen er alt er ferdigstilt

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
@@ -1,17 +1,24 @@
 package no.nav.familie.klage.oppgave
 
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.erUnderArbeidAvSaksbehandler
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class OppgaveService(private val behandleSakOppgaveRepository: BehandleSakOppgaveRepository, private val oppgaveClient: OppgaveClient) {
+class OppgaveService(private val behandleSakOppgaveRepository: BehandleSakOppgaveRepository, private val oppgaveClient: OppgaveClient, private val behandlingService: BehandlingService) {
 
-    fun oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId: UUID): Long {
+    fun oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId: UUID) {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+
+        // Skal ikke oppdatere tema for oppgaver som alt er ferdigstilt
+        if (!behandling.status.erUnderArbeidAvSaksbehandler()) return
+
         val eksisterendeOppgave = behandleSakOppgaveRepository.findByBehandlingId(behandlingId)
         val oppdatertOppgave = Oppgave(id = eksisterendeOppgave.oppgaveId, behandlingstema = Behandlingstema.Tilbakebetaling.value)
 
-        return oppgaveClient.oppdaterOppgave(oppdatertOppgave)
+        oppgaveClient.oppdaterOppgave(oppdatertOppgave)
     }
 }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? 🤔
**Bakgrunn:** Task `oppdaterOppgaveTilÅGjeldeTilbakekreving` feiler med melding "kan ikke oppdatere ferdigstilte oppgaver" fra oppgavesystemet. 

Dette kommer av at det er mulig å journalføre på eksisterende ferdigstilte behandlinger, og dersom journalføringen både er klage og journalføring skal oppgaven markeres med eget behandlingstema. 

### Løsning
Droppe oppdatering av oppgave dersom behandling alt er ferdigstilt fordi målet med markeringen av "Klage - TIlbakekreving" er å unngå at feil SB plukker slike oppgaver, som ikke er et problem når behandlingen alt er ferdigstilt. 

