### PR TITLE
Skal sende med behandlingsnummer header ved call til PDL. Datatyper f…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
 		<prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
 		<start-class>no.nav.familie.klage.ApplicationKt</start-class>
-		<kontrakter.version>3.0_20230404163639_edb8619-JAKARTA</kontrakter.version>
+		<kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/fagsak/FagsakService.kt
@@ -21,7 +21,7 @@ class FagsakService(
 
     @Transactional
     fun hentEllerOpprettFagsak(ident: String, eksternId: String, fagsystem: Fagsystem, stønadstype: Stønadstype): Fagsak {
-        val personIdenter = pdlClient.hentPersonidenter(ident, true)
+        val personIdenter = pdlClient.hentPersonidenter(ident, stønadstype, true)
         val gjeldendePersonIdent = personIdenter.gjeldende()
         val person = fagsakPersonService.hentEllerOpprettPerson(personIdenter.identer(), gjeldendePersonIdent.ident)
         val oppdatertPerson = fagsakPersonService.oppdaterIdent(person, gjeldendePersonIdent.ident)

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.klage.personopplysninger.pdl.PdlSøker
 import no.nav.familie.klage.personopplysninger.pdl.gjeldende
 import no.nav.familie.klage.personopplysninger.pdl.gjelende
 import no.nav.familie.klage.personopplysninger.pdl.visningsnavn
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -31,8 +32,8 @@ class PersonopplysningerService(
 
         val egenAnsatt = integrasjonerClient.egenAnsatt(fagsak.hentAktivIdent())
 
-        val pdlSøker = pdlClient.hentPerson(fagsak.hentAktivIdent())
-        val andreParterNavn = hentNavnAndreParter(pdlSøker)
+        val pdlSøker = pdlClient.hentPerson(fagsak.hentAktivIdent(), fagsak.stønadstype)
+        val andreParterNavn = hentNavnAndreParter(pdlSøker, fagsak.stønadstype)
         return PersonopplysningerDto(
             personIdent = fagsak.hentAktivIdent(),
             navn = pdlSøker.navn.gjeldende().visningsnavn(),
@@ -50,15 +51,15 @@ class PersonopplysningerService(
     /**
      * Returnerer map med ident og visningsnavn
      */
-    private fun hentNavnAndreParter(pdlSøker: PdlSøker): Map<String, String> {
+    private fun hentNavnAndreParter(pdlSøker: PdlSøker, stønadstype: Stønadstype): Map<String, String> {
         return pdlSøker.fullmakt.map { it.motpartsPersonident }.distinct()
             .takeIf { it.isNotEmpty() }
-            ?.let { hentNavn(it) }
+            ?.let { hentNavn(it, stønadstype) }
             ?: emptyMap()
     }
 
-    private fun hentNavn(it: List<String>): Map<String, String> =
-        pdlClient.hentNavnBolk(it).map { it.key to it.value.navn.gjeldende().visningsnavn() }.toMap()
+    private fun hentNavn(it: List<String>, stønadstype: Stønadstype): Map<String, String> =
+        pdlClient.hentNavnBolk(it, stønadstype).map { it.key to it.value.navn.gjeldende().visningsnavn() }.toMap()
 
     private fun mapFullmakt(pdlSøker: PdlSøker, andreParterNavn: Map<String, String>) = pdlSøker.fullmakt.map {
         FullmaktDto(

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlClient.kt
@@ -91,7 +91,6 @@ class PdlClient(
             Stønadstype.BARNETILSYN -> Tema.ENF
             Stønadstype.BARNETRYGD -> Tema.BAR
             Stønadstype.KONTANTSTØTTE -> Tema.KON
-            else -> error("Kunne ikke finne tema for stønadstype=$stønadstype")
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
@@ -7,30 +7,39 @@ import java.time.LocalDateTime
 data class PdlResponse<T>(
     val data: T,
     val errors: List<PdlError>?,
+    val extensions: PdlExtensions?,
 ) {
 
     fun harFeil(): Boolean {
         return errors != null && errors.isNotEmpty()
     }
-
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
+    }
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
     }
 }
 
-data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?) {
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)
+
+data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?, val extensions: PdlExtensions?) {
 
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
+    }
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 }
 
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?,
+    val extensions: PdlErrorExtensions?,
 )
 
-data class PdlExtensions(val code: String?) {
+data class PdlErrorExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
 }

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlUtil.kt
@@ -20,6 +20,10 @@ inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
         secureLogger.error("Feil ved henting av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
     }
+    if (pdlResponse.harAdvarsel()) {
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+    }
 
     val data = dataMapper.invoke(pdlResponse.data)
     if (data == null) {
@@ -38,7 +42,10 @@ inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkRespons
         secureLogger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Data er null fra PDL -  ${T::class}. Se secure logg for detaljer.")
     }
-
+    if (pdlResponse.harAdvarsel()) {
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
+        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+    }
     val feil = pdlResponse.data.personBolk.filter { it.code != "ok" }.associate { it.ident to it.code }
     if (feil.isNotEmpty()) {
         secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")

--- a/src/main/kotlin/no/nav/familie/klage/søk/SøkController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/søk/SøkController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.klage.søk
 
+import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.exception.ApiFeil
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
@@ -29,6 +30,7 @@ class SøkController(
     private val tilgangService: TilgangService,
     private val pdlClient: PdlClient,
     private val eregService: EregService,
+    private val fagsakService: FagsakService,
 ) {
 
     @PostMapping("person")
@@ -36,8 +38,10 @@ class SøkController(
         @RequestBody personIdentDto: PersonIdentDto,
     ): Ressurs<PersonTreffDto> {
         val personIdent = personIdentDto.personIdent
+        val behandlingId = personIdentDto.behandlingId
+        val fagsak = fagsakService.hentFagsak(behandlingId)
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.UPDATE)
-        val person = pdlClient.hentPerson(personIdent)
+        val person = pdlClient.hentPerson(personIdent, fagsak.stønadstype)
         val result = PersonTreffDto(personIdent, person.navn.gjeldende().visningsnavn())
         return Ressurs.success(result)
     }

--- a/src/main/kotlin/no/nav/familie/klage/søk/dto/SøkDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/søk/dto/SøkDto.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.klage.søk.dto
 
-data class PersonIdentDto(val personIdent: String)
+import java.util.UUID
+
+data class PersonIdentDto(val personIdent: String, val behandlingId: UUID)
 
 data class PersonTreffDto(val personIdent: String, val navn: String)

--- a/src/main/kotlin/no/nav/familie/klage/vedlegg/VedleggController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vedlegg/VedleggController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.klage.journalpost.JournalpostService
 import no.nav.familie.klage.personopplysninger.pdl.PdlClient
 import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
@@ -45,7 +46,7 @@ class VedleggController(
         val personIdent = journalpost.bruker?.let {
             when (it.type) {
                 BrukerIdType.FNR -> it.id
-                BrukerIdType.AKTOERID -> pdlClient.hentPersonidenter(it.id).identer.first().ident
+                BrukerIdType.AKTOERID -> pdlClient.hentPersonidenter(it.id, Tema.valueOf(journalpost.tema ?: error("Tema er null for journalpostId=$journalpostId"))).identer.first().ident
                 BrukerIdType.ORGNR -> error("Kan ikke hente journalpost=$journalpostId for orgnr")
             }
         } ?: error("Kan ikke hente journalpost=$journalpostId uten bruker")

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
@@ -19,6 +19,7 @@ import no.nav.familie.klage.testutil.PdlTestdataHelper.lagNavn
 import no.nav.familie.klage.testutil.PdlTestdataHelper.metadataGjeldende
 import no.nav.familie.klage.testutil.PdlTestdataHelper.pdlNavn
 import no.nav.familie.klage.testutil.PdlTestdataHelper.pdlSøker
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -36,11 +37,11 @@ class PdlClientMock {
 
         every { pdlClient.ping() } just runs
 
-        every { pdlClient.hentNavnBolk(any()) } answers { firstArg<List<String>>().associateWith { pdlNavn(listOf(lagNavn())) } }
+        every { pdlClient.hentNavnBolk(any(), any()) } answers { firstArg<List<String>>().associateWith { pdlNavn(listOf(lagNavn())) } }
 
-        every { pdlClient.hentPerson(any()) } returns opprettPdlSøker()
+        every { pdlClient.hentPerson(any(), any()) } returns opprettPdlSøker()
 
-        every { pdlClient.hentPersonidenter(any(), eq(true)) } answers
+        every { pdlClient.hentPersonidenter(any(), Stønadstype.OVERGANGSSTØNAD, eq(true)) } answers
             { PdlIdenter(listOf(PdlIdent(firstArg(), false), PdlIdent("98765432109", true))) }
 
         return pdlClient

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerServiceTest.kt
@@ -50,8 +50,8 @@ internal class PersonopplysningerServiceTest {
     internal fun setUp() {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
-        every { pdlClient.hentPerson(any()) } returns lagPdlSøker()
-        every { pdlClient.hentNavnBolk(any()) } returns navnBolkResponse()
+        every { pdlClient.hentPerson(any(), any()) } returns lagPdlSøker()
+        every { pdlClient.hentNavnBolk(any(), any()) } returns navnBolkResponse()
         every { integrasjonerClient.egenAnsatt(any()) } returns true
     }
 
@@ -69,7 +69,7 @@ internal class PersonopplysningerServiceTest {
         assertThat(personopplysninger.egenAnsatt).isTrue
         assertThat(personopplysninger.vergemål).hasSize(1)
 
-        verify(exactly = 1) { pdlClient.hentNavnBolk(eq(listOf("fullmaktIdent"))) }
+        verify(exactly = 1) { pdlClient.hentNavnBolk(eq(listOf("fullmaktIdent")), any()) }
     }
 
     @Test
@@ -78,7 +78,7 @@ internal class PersonopplysningerServiceTest {
 
         assertThat(personopplysninger.fullmakt.single().navn).isEqualTo("fullmakt etternavn")
 
-        verify(exactly = 1) { pdlClient.hentNavnBolk(eq(listOf("fullmaktIdent"))) }
+        verify(exactly = 1) { pdlClient.hentNavnBolk(eq(listOf("fullmaktIdent")), any()) }
     }
 
     private fun navnBolkResponse() = mapOf(


### PR DESCRIPTION
…or PdlExtensions og PdlWarning.

Hvorfor ?

PDL gjør endringer mot en mere fingranulert tilgangsstyring, og ønsker at konsumentene skal legge på en header med behandlingsnummer fra enhetskatalogen. Vi ønsker også å logge advarsler fra PDL, og ikke bare feil.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402

Andre PRer : 

https://github.com/navikt/familie-ba-sak/pull/3582


