### PR TITLE
Skal håndtere, men feile ved eventypen BEHANDLING_FEILREGISTRERT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
 		<prosessering.version>2.20230505152326_9265101-SPRING_BOOT_3</prosessering.version>
 		<start-class>no.nav.familie.klage.ApplicationKt</start-class>
-		<kontrakter.version>3.0_20230526102731_e1eff1d</kontrakter.version>
+		<kontrakter.version>3.0_20230607101621_61d0afb</kontrakter.version>
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -67,7 +67,7 @@ data class BehandlingEvent(
             BehandlingEventType.ANKEBEHANDLING_OPPRETTET ->
                 detaljer.ankebehandlingOpprettet?.mottattKlageinstans ?: throw Feil(feilmelding)
             BehandlingEventType.ANKEBEHANDLING_AVSLUTTET -> detaljer.ankebehandlingAvsluttet?.avsluttet ?: throw Feil(feilmelding)
-            BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET -> throw Feil("Håndterer ikke typen $type")
+            BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET, BehandlingEventType.BEHANDLING_FEILREGISTRERT -> throw Feil("Håndterer ikke typen $type")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.klage.behandling.domain.Behandling
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.fagsak.FagsakRepository
 import no.nav.familie.klage.infrastruktur.config.DatabaseConfiguration.StringListWrapper
+import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.kabal.BehandlingEvent
 import no.nav.familie.klage.kabal.KlageresultatRepository
 import no.nav.familie.klage.kabal.domain.KlageinstansResultat
@@ -44,7 +45,10 @@ class BehandlingEventService(
 
             when (behandlingEvent.type) {
                 BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET -> behandleKlageAvsluttet(behandling, behandlingEvent)
-                else -> behandleAnke(behandling, behandlingEvent)
+                BehandlingEventType.ANKEBEHANDLING_AVSLUTTET,
+                BehandlingEventType.ANKEBEHANDLING_OPPRETTET -> behandleAnke(behandling, behandlingEvent)
+                BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
+                BehandlingEventType.BEHANDLING_FEILREGISTRERT -> throw Feil("Håndterer ikke typen ${behandlingEvent.type}")
             }
         }
     }

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -113,7 +113,6 @@ internal class BehandlingEventServiceTest {
 
     @Test
     internal fun `Skal feile for behandlingsevent BEHANDLING_FEILREGISTRERT`() {
-
         val feil = assertThrows<Feil> {
             behandlingEventService.handleEvent(lagBehandlingEvent(BehandlingEventType.BEHANDLING_FEILREGISTRERT))
         }

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.klage.behandling.BehandlingRepository
 import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.fagsak.FagsakRepository
+import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.kabal.AnkebehandlingOpprettetDetaljer
 import no.nav.familie.klage.kabal.BehandlingDetaljer
 import no.nav.familie.klage.kabal.BehandlingEvent
@@ -17,8 +18,10 @@ import no.nav.familie.kontrakter.felles.klage.BehandlingEventType
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.klage.KlageinstansUtfall
 import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -106,6 +109,15 @@ internal class BehandlingEventServiceTest {
 
         verify(exactly = 1) { behandlingRepository.findByEksternBehandlingId(any()) }
         verify(exactly = 1) { klageresultatRepository.insert(any()) }
+    }
+
+    @Test
+    internal fun `Skal feile for behandlingsevent BEHANDLING_FEILREGISTRERT`() {
+
+        val feil = assertThrows<Feil> {
+            behandlingEventService.handleEvent(lagBehandlingEvent(BehandlingEventType.BEHANDLING_FEILREGISTRERT))
+        }
+        assertThat(feil.message).contains("Håndterer ikke typen BEHANDLING_FEILREGISTRERT")
     }
 
     private fun lagBehandlingEvent(


### PR DESCRIPTION
**Hvorfor?**
[Kabal har lagt til ny eventtype BEHANDLING_FEILREGISTERT](https://nav-it.slack.com/archives/C058Z17RTSR/p1684918865152359), og disse må kunne leses av klage. Foreløpig vil vi bare feile dersom vi får en melding av den typen men i fremtiden kan vi vurdere om vi skal opprette oppfølgingsoppgave eller åpne/tilbakestille behandlingen i klage.

Vi har en favrooppgave for videre oppfølging: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12862