### PR TITLE
Skal opprette task for å håndtere beahandling feilregistrert fra kabal

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnhold.kt
@@ -137,7 +137,7 @@ object BrevInnhold {
         deloverskrift = "Du har rett til å klage",
         innhold =
         "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
-                "Du finner skjema og informasjon på ${stønadstype.klageUrl()}.",
+            "Du finner skjema og informasjon på ${stønadstype.klageUrl()}.",
     )
 
     private fun harDuSpørsmålAvsnitt(stønadstype: Stønadstype) = AvsnittDto(

--- a/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.klage.kabal
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = BehandlingFeilregistrertTask.TYPE,
+    beskrivelse = "Håndter feilregistret klage fra kabal",
+)
+class BehandlingFeilregistrertTask : AsyncTaskStep {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        throw NotImplementedError("Håndtering av feilregistret behandling fra kabal er ikke implementert enda")
+    }
+
+    companion object {
+
+        const val TYPE = "BehandlingFeilregistrert"
+
+        fun opprettTask(behandlingId: UUID): Task =
+            Task(TYPE, behandlingId.toString())
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 @TaskStepBeskrivelse(
     taskStepType = BehandlingFeilregistrertTask.TYPE,
     beskrivelse = "Håndter feilregistret klage fra kabal",
+    maxAntallFeil = 1,
 )
 class BehandlingFeilregistrertTask : AsyncTaskStep {
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
@@ -12,6 +12,7 @@ import java.util.UUID
     taskStepType = BehandlingFeilregistrertTask.TYPE,
     beskrivelse = "Håndter feilregistret klage fra kabal",
     maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
 )
 class BehandlingFeilregistrertTask : AsyncTaskStep {
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -67,7 +67,8 @@ data class BehandlingEvent(
             BehandlingEventType.ANKEBEHANDLING_OPPRETTET ->
                 detaljer.ankebehandlingOpprettet?.mottattKlageinstans ?: throw Feil(feilmelding)
             BehandlingEventType.ANKEBEHANDLING_AVSLUTTET -> detaljer.ankebehandlingAvsluttet?.avsluttet ?: throw Feil(feilmelding)
-            BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET, BehandlingEventType.BEHANDLING_FEILREGISTRERT -> throw Feil("Håndterer ikke typen $type")
+            BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET -> throw Feil("Håndterer ikke typen $type")
+            BehandlingEventType.BEHANDLING_FEILREGISTRERT -> detaljer.behandlingFeilregistrert?.feilregistrert ?: throw Feil("Fant ikke tidspunkt for feilregistrering")
         }
     }
 
@@ -93,6 +94,7 @@ data class BehandlingDetaljer(
     val klagebehandlingAvsluttet: KlagebehandlingAvsluttetDetaljer? = null,
     val ankebehandlingOpprettet: AnkebehandlingOpprettetDetaljer? = null,
     val ankebehandlingAvsluttet: AnkebehandlingAvsluttetDetaljer? = null,
+    val behandlingFeilregistrert: BehandlingFeilregistrertDetaljer? = null,
 ) {
 
     fun journalpostReferanser(): List<String> {
@@ -141,3 +143,5 @@ data class AnkebehandlingAvsluttetDetaljer(
             "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
     }
 }
+
+data class BehandlingFeilregistrertDetaljer(val reason: String, val type: Type, val feilregistrert: LocalDateTime)

--- a/src/main/kotlin/no/nav/familie/klage/kabal/domain/KlageinstansResultat.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/domain/KlageinstansResultat.kt
@@ -5,6 +5,7 @@ import no.nav.familie.kontrakter.felles.klage.BehandlingEventType
 import no.nav.familie.kontrakter.felles.klage.KlageinstansResultatDto
 import no.nav.familie.kontrakter.felles.klage.KlageinstansUtfall
 import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 import java.util.UUID
@@ -19,6 +20,8 @@ class KlageinstansResultat(
     val kildereferanse: UUID,
     val journalpostReferanser: StringListWrapper,
     val behandlingId: UUID,
+    @Column("arsak_feilregistrert")
+    val årsakFeilregistrert: String? = null,
 )
 
 fun List<KlageinstansResultat>.tilDto(): List<KlageinstansResultatDto> {

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.klage.fagsak.FagsakRepository
 import no.nav.familie.klage.infrastruktur.config.DatabaseConfiguration.StringListWrapper
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.kabal.BehandlingEvent
+import no.nav.familie.klage.kabal.BehandlingFeilregistrertTask
 import no.nav.familie.klage.kabal.KlageresultatRepository
 import no.nav.familie.klage.kabal.domain.KlageinstansResultat
 import no.nav.familie.klage.oppgave.OpprettKabalEventOppgaveTask
@@ -46,11 +47,16 @@ class BehandlingEventService(
             when (behandlingEvent.type) {
                 BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET -> behandleKlageAvsluttet(behandling, behandlingEvent)
                 BehandlingEventType.ANKEBEHANDLING_AVSLUTTET,
-                BehandlingEventType.ANKEBEHANDLING_OPPRETTET -> behandleAnke(behandling, behandlingEvent)
-                BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
-                BehandlingEventType.BEHANDLING_FEILREGISTRERT -> throw Feil("Håndterer ikke typen ${behandlingEvent.type}")
+                BehandlingEventType.ANKEBEHANDLING_OPPRETTET,
+                -> behandleAnke(behandling, behandlingEvent)
+                BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET -> throw Feil("Håndterer ikke typen ${behandlingEvent.type}")
+                BehandlingEventType.BEHANDLING_FEILREGISTRERT -> opprettBehandlingFeilregistretTask(behandling.id)
             }
         }
+    }
+
+    private fun opprettBehandlingFeilregistretTask(behandlingId: UUID) {
+        taskService.save(BehandlingFeilregistrertTask.opprettTask(behandlingId))
     }
 
     private fun lagreKlageresultat(behandlingEvent: BehandlingEvent, behandling: Behandling) {
@@ -62,10 +68,19 @@ class BehandlingEventService(
             kildereferanse = UUID.fromString(behandlingEvent.kildeReferanse),
             journalpostReferanser = StringListWrapper(behandlingEvent.journalpostReferanser()),
             behandlingId = behandling.id,
+            årsakFeilregistrert = utledÅrsakRegiregistrert(behandlingEvent),
         )
 
         klageresultatRepository.insert(klageinstansResultat)
     }
+
+    private fun utledÅrsakRegiregistrert(behandlingEvent: BehandlingEvent) =
+        if (behandlingEvent.type == BehandlingEventType.BEHANDLING_FEILREGISTRERT) {
+            behandlingEvent.detaljer.behandlingFeilregistrert?.reason
+                ?: error("Finner ikke årsak til feilregistrering")
+        } else {
+            null
+        }
 
     private fun behandleAnke(behandling: Behandling, behandlingEvent: BehandlingEvent) {
         opprettOppgaveTask(behandlingEvent, behandling)

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -68,13 +68,13 @@ class BehandlingEventService(
             kildereferanse = UUID.fromString(behandlingEvent.kildeReferanse),
             journalpostReferanser = StringListWrapper(behandlingEvent.journalpostReferanser()),
             behandlingId = behandling.id,
-            årsakFeilregistrert = utledÅrsakRegiregistrert(behandlingEvent),
+            årsakFeilregistrert = utledÅrsakFeilregistrert(behandlingEvent),
         )
 
         klageresultatRepository.insert(klageinstansResultat)
     }
 
-    private fun utledÅrsakRegiregistrert(behandlingEvent: BehandlingEvent) =
+    private fun utledÅrsakFeilregistrert(behandlingEvent: BehandlingEvent) =
         if (behandlingEvent.type == BehandlingEventType.BEHANDLING_FEILREGISTRERT) {
             behandlingEvent.detaljer.behandlingFeilregistrert?.reason
                 ?: error("Finner ikke årsak til feilregistrering")

--- a/src/main/resources/db/migration/V19__årsak_feirlregistrert_klageresultat.sql
+++ b/src/main/resources/db/migration/V19__årsak_feirlregistrert_klageresultat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Klageresultat ADD COLUMN arsak_feilregistrert VARCHAR;

--- a/src/test/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTaskTest.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.klage.kabal
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class BehandlingFeilregistrertTaskTest {
+
+    val behandlingFeilregistrertTask = BehandlingFeilregistrertTask()
+
+    @Test
+    internal fun `Behanlding feilregistrert task skal feile fordi den ikke er implementert enda`() {
+        val task = BehandlingFeilregistrertTask.opprettTask(UUID.randomUUID())
+
+        val feil = assertThrows<NotImplementedError> { behandlingFeilregistrertTask.doTask(task) }
+
+        assertThat(feil.message).contains("Håndtering av feilregistret behandling fra kabal er ikke implementert enda")
+    }
+}


### PR DESCRIPTION
**Hvorfor?**
Vi får ikke lest meldinger på kafka-køen fra kabal fordi vi feiler på håndtering av en BEHANDLING_FEILREGISTRERT-event. I stedenfor å feile lager vi heller en task som skal implementeres og følges opp av oss.