### PR TITLE
Taskhåndtering feilregistrert klage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
 		<prosessering.version>2.20230505152326_9265101-SPRING_BOOT_3</prosessering.version>
 		<start-class>no.nav.familie.klage.ApplicationKt</start-class>
-		<kontrakter.version>3.0_20230615142948_f6dc470</kontrakter.version>
+		<kontrakter.version>3.0_20230621135853_92036e1</kontrakter.version>
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -13,8 +13,7 @@ interface FeatureToggleService : DisposableBean {
 
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     PLACEHOLDER("Ktlint liker ikke tomme enums"),
-    HENLEGG_FEILREGISTRERT_BEHANDLING("familie.klage.henlegg-feilregistrert-behandling")
-    ,
+    HENLEGG_FEILREGISTRERT_BEHANDLING("familie.klage.henlegg-feilregistrert-behandling"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -13,6 +13,8 @@ interface FeatureToggleService : DisposableBean {
 
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     PLACEHOLDER("Ktlint liker ikke tomme enums"),
+    HENLEGG_FEILREGISTRERT_BEHANDLING("familie.klage.henlegg-feilregistrert-behandling")
+    ,
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
@@ -39,7 +39,6 @@ class BehandlingFeilregistrertTask(
         val behandlingId = UUID.fromString(task.payload)
 
         if (featuretoggleService.isEnabled(Toggle.HENLEGG_FEILREGISTRERT_BEHANDLING)) {
-
             taskService.save(lagOpprettOppgaveTask(behandlingId))
 
             stegService.oppdaterSteg(
@@ -47,7 +46,6 @@ class BehandlingFeilregistrertTask(
                 StegType.KABAL_VENTER_SVAR,
                 StegType.BEHANDLING_FERDIGSTILT,
             )
-
         } else {
             throw Feil("Toggle for henlegging av feilregistrerte behandlinger er ikke påskrudd")
         }
@@ -55,7 +53,7 @@ class BehandlingFeilregistrertTask(
 
     private fun lagOpprettOppgaveTask(behandlingId: UUID): Task {
         val behandling = behandlingService.hentBehandling(behandlingId)
-        val fagsak = fagsakService.hentFagsak(behandlingId)
+        val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         val årsakFeilregistrert = behandlingService.hentKlageresultatDto(behandlingId)
             .single().årsakFeilregistrert ?: error("Fant ikke årsak for feilregistrering")
 
@@ -65,12 +63,12 @@ class BehandlingFeilregistrertTask(
                 oppgaveTekst = lagOppgavebeskrivelse(årsakFeilregistrert),
                 fagsystem = fagsak.fagsystem,
                 klageinstansUtfall = null,
-            )
+            ),
         )
     }
 
     private fun lagOppgavebeskrivelse(årsakFeilregistrert: String) =
-        "Klagebehandlingen er sendt tilbake fra kabal med status feilregistrert.\nÅrsak fra kabal:\n\"$årsakFeilregistrert\""
+        "Klagebehandlingen er sendt tilbake fra kabal med status feilregistrert.\n\nÅrsak fra kabal: \"$årsakFeilregistrert\""
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTask.kt
@@ -68,7 +68,7 @@ class BehandlingFeilregistrertTask(
     }
 
     private fun lagOppgavebeskrivelse(årsakFeilregistrert: String) =
-        "Klagebehandlingen er sendt tilbake fra kabal med status feilregistrert.\n\nÅrsak fra kabal: \"$årsakFeilregistrert\""
+        "Klagebehandlingen er sendt tilbake fra KA med status feilregistrert.\n\nBegrunnelse fra KA: \"$årsakFeilregistrert\""
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/domain/KlageinstansResultat.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/domain/KlageinstansResultat.kt
@@ -31,6 +31,7 @@ fun List<KlageinstansResultat>.tilDto(): List<KlageinstansResultatDto> {
             utfall = it.utfall,
             mottattEllerAvsluttetTidspunkt = it.mottattEllerAvsluttetTidspunkt,
             journalpostReferanser = it.journalpostReferanser.verdier,
+            årsakFeilregistrert = it.årsakFeilregistrert,
         )
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/BehandlingFeilregistrertTaskTest.kt
@@ -105,7 +105,7 @@ class BehandlingFeilregistrertTaskTest : OppslagSpringRunnerTest() {
 
         val opprettOppgaveTask = taskService.findAll().single { it.type == OpprettKabalEventOppgaveTask.TYPE }
         val opprettOppgavePayload = objectMapper.readValue<OpprettOppgavePayload>(opprettOppgaveTask.payload)
-        assertThat(opprettOppgavePayload.oppgaveTekst).isEqualTo("Klagebehandlingen er sendt tilbake fra kabal med status feilregistrert.\n\nÅrsak fra kabal: \"fordi det var feil\"")
+        assertThat(opprettOppgavePayload.oppgaveTekst).isEqualTo("Klagebehandlingen er sendt tilbake fra KA med status feilregistrert.\n\nBegrunnelse fra KA: \"fordi det var feil\"")
 
         assertThat(opprettOppgavePayload.klagebehandlingEksternId).isEqualTo(behandling.eksternBehandlingId)
         assertThat(opprettOppgavePayload.fagsystem).isEqualTo(fagsak.fagsystem)


### PR DESCRIPTION
**Hvorfor?**
Vi har fått en feilregistrert klage i prod, og risikerer og få flere fremover. Disse må håndteres ved at vi oppretter en task, som videre ferdigstiller behandlingen og oppretter en oppfølgingsoppgave. Vi kommer til å ha featuretogglen for dette avskrudd, for å kunne følge opp de enkelte behandlingene.

Tråd på slack om aktuell sak i prod: https://nav-it.slack.com/archives/C01087QRJ2U/p1687333031507799