### PR TITLE
Skal kunne håndtere ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET-event fra kabal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
 		<prosessering.version>2.20230505152326_9265101-SPRING_BOOT_3</prosessering.version>
 		<start-class>no.nav.familie.klage.ApplicationKt</start-class>
-		<kontrakter.version>3.0_20230621135853_92036e1</kontrakter.version>
+		<kontrakter.version>3.0_20230704084854_83dd7ef</kontrakter.version>
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -67,7 +67,8 @@ data class BehandlingEvent(
             BehandlingEventType.ANKEBEHANDLING_OPPRETTET ->
                 detaljer.ankebehandlingOpprettet?.mottattKlageinstans ?: throw Feil(feilmelding)
             BehandlingEventType.ANKEBEHANDLING_AVSLUTTET -> detaljer.ankebehandlingAvsluttet?.avsluttet ?: throw Feil(feilmelding)
-            BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET -> throw Feil("Håndterer ikke typen $type")
+            BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET ->
+                detaljer.ankeITrygderettenbehandlingOpprettetDetaljer?.sendtTilTrygderetten ?: throw Feil(feilmelding)
             BehandlingEventType.BEHANDLING_FEILREGISTRERT -> detaljer.behandlingFeilregistrert?.feilregistrert ?: throw Feil("Fant ikke tidspunkt for feilregistrering")
         }
     }
@@ -95,6 +96,7 @@ data class BehandlingDetaljer(
     val ankebehandlingOpprettet: AnkebehandlingOpprettetDetaljer? = null,
     val ankebehandlingAvsluttet: AnkebehandlingAvsluttetDetaljer? = null,
     val behandlingFeilregistrert: BehandlingFeilregistrertDetaljer? = null,
+    val ankeITrygderettenbehandlingOpprettetDetaljer: AnkeITrygderettenbehandlingOpprettetDetaljer? = null,
 ) {
 
     fun journalpostReferanser(): List<String> {
@@ -145,3 +147,5 @@ data class AnkebehandlingAvsluttetDetaljer(
 }
 
 data class BehandlingFeilregistrertDetaljer(val reason: String, val type: Type, val feilregistrert: LocalDateTime)
+
+data class AnkeITrygderettenbehandlingOpprettetDetaljer(val sendtTilTrygderetten: LocalDateTime, val utfall: KlageinstansUtfall?)

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -185,8 +185,8 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
                         listOf(
-                            Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV),
-                            Dokumentvariant(variantformat = Dokumentvariantformat.ORIGINAL),
+                            Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true),
+                            Dokumentvariant(variantformat = Dokumentvariantformat.ORIGINAL, saksbehandlerHarTilgang = true),
                         ),
                     ),
                     DokumentInfo(
@@ -194,21 +194,21 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                         tittel = "Søknad om barnetilsyn - dokument 1",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                     ),
                     DokumentInfo(
                         dokumentInfoId = "12345",
                         tittel = "Samboeravtale",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                     ),
                     DokumentInfo(
                         dokumentInfoId = "12345",
                         tittel = "Manuelt skannet dokument",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                         logiskeVedlegg = listOf(
                             LogiskVedlegg(
                                 logiskVedleggId = "1",
@@ -225,21 +225,21 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                         tittel = "EtFrykteligLangtDokumentNavnSomTroligIkkeBrekkerOgØdeleggerGUI",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                     ),
                     DokumentInfo(
                         dokumentInfoId = "12345",
                         tittel = "Søknad om overgangsstønad - dokument 2",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                     ),
                     DokumentInfo(
                         dokumentInfoId = "12345",
                         tittel = "Søknad om overgangsstønad - dokument 3",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                     ),
                 ),
             )
@@ -262,7 +262,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                         tittel = "Søknad om overgangsstønad - dokument 1",
                         brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                         dokumentvarianter =
-                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                        listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
                     ),
                 ),
             )

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -223,7 +223,7 @@ object DomainUtil {
 
     fun journalpostDokument(
         status: Dokumentstatus = Dokumentstatus.FERDIGSTILT,
-        dokumentvarianter: List<Dokumentvariant>? = listOf(Dokumentvariant(Dokumentvariantformat.ARKIV)),
+        dokumentvarianter: List<Dokumentvariant>? = listOf(Dokumentvariant(Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
     ) = DokumentInfo(
         dokumentInfoId = UUID.randomUUID().toString(),
         tittel = "Tittel",


### PR DESCRIPTION
## Hvorfor er denne endringen nødvendig? ✨
Vi har fått en ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET-event fra kabal på en av sakene våre: https://familie-klage.intern.nav.no/behandling/7af02491-4aeb-4cfe-924f-b2fcfa4e237d/resultat Vi må kunne lagre og håndtere dette resultatet. Etter diskusjon med Lars oppretter vi ingen oppfølgingsoppgaver for eventet. Vi kommer bare til å vise det midlertidige resultatet i klage-frontend.

**Relaterte PRer**
https://github.com/navikt/familie-ef-sak-frontend/pull/2416
https://github.com/navikt/familie-kontrakter/pull/810
