### PR TITLE
Send saksbehandler enhet til kabal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
 		<prosessering.version>2.20230713120621_747ed8f</prosessering.version>
 		<start-class>no.nav.familie.klage.ApplicationKt</start-class>
-		<kontrakter.version>3.0_20230731084015_3570802</kontrakter.version>
+		<kontrakter.version>3.0_20230817140529_df3e9ab</kontrakter.version>
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTask.kt
@@ -2,6 +2,7 @@ package no.nav.familie.klage.distribusjon
 
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.felles.util.TaskMetadata
 import no.nav.familie.klage.kabal.KabalService
 import no.nav.familie.klage.vurdering.VurderingService
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -24,11 +25,12 @@ class SendTilKabalTask(
 
     override fun doTask(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
+        val saksbehandlerIdent = task.metadata[TaskMetadata.saksbehandlerMetadataKey].toString()
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         val vurdering =
             vurderingService.hentVurdering(behandlingId) ?: error("Mangler vurdering på klagen - kan ikke oversendes til kabal")
-        kabalService.sendTilKabal(fagsak, behandling, vurdering)
+        kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerIdent)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/IntegrasjonerConfig.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/IntegrasjonerConfig.kt
@@ -31,6 +31,7 @@ class IntegrasjonerConfig(@Value("\${FAMILIE_INTEGRASJONER_URL}") private val in
     val dokarkivUri: URI = UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_DOKARKIV).build().toUri()
 
     val navKontorUri: URI = UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_NAV_KONTOR).build().toUri()
+    val saksbehandlerUri: URI = UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_SAKSBEHANDLER).build().toUri()
 
     val distribuerDokumentUri: URI =
         UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_DOKDIST).build().toUri()
@@ -52,6 +53,7 @@ class IntegrasjonerConfig(@Value("\${FAMILIE_INTEGRASJONER_URL}") private val in
         private const val PATH_JOURNALPOST = "api/journalpost"
         private const val PATH_DOKARKIV = "api/arkiv"
         private const val PATH_NAV_KONTOR = "api/arbeidsfordeling/nav-kontor/ENF"
+        private const val PATH_SAKSBEHANDLER = "api/saksbehandler"
         private const val PATH_DOKDIST = "api/dist/v1"
         private const val PATH_KABAL = "api/oversendelse/v3/sak"
     }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieIntegrasjonerClient.kt
@@ -14,6 +14,7 @@ import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariantformat
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
+import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import no.nav.familie.log.NavHttpHeaders
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -40,6 +41,7 @@ class FamilieIntegrasjonerClient(
 
     private val dokuarkivUri: URI = UriComponentsBuilder.fromUri(integrasjonUri).pathSegment("api/arkiv").build().toUri()
     private val journalpostURI: URI = integrasjonerConfig.journalPostUri
+    private val saksbehandlerUri: URI = integrasjonerConfig.saksbehandlerUri
 
     // lagre brev
     fun arkiverDokument(arkiverDokumentRequest: ArkiverDokumentRequest, saksbehandler: String?): ArkiverDokumentResponse {
@@ -49,6 +51,14 @@ class FamilieIntegrasjonerClient(
             headerMedSaksbehandler(saksbehandler),
         ).data
             ?: error("Kunne ikke arkivere dokument med fagsakid ${arkiverDokumentRequest.fagsakId}")
+    }
+
+    fun hentSaksbehandlerInfo(navIdent: String): Saksbehandler {
+        return getForEntity<Ressurs<Saksbehandler>>(
+            URI.create("$saksbehandlerUri/$navIdent"),
+            HttpHeaders().medContentTypeJsonUTF8(),
+        ).data
+            ?: error("Kunne ikke hente saksbehandlerinfo for saksbehandler med ident=$navIdent")
     }
 
     // sende brev til bruker

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.klage.behandling.domain.PåklagetVedtak
 import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.fagsak.domain.tilYtelse
 import no.nav.familie.klage.infrastruktur.config.LenkeConfig
+import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.vurdering.domain.Vurdering
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
@@ -13,15 +14,17 @@ import org.springframework.stereotype.Service
 @Service
 class KabalService(
     private val kabalClient: KabalClient,
+    private val integrasjonerClient: FamilieIntegrasjonerClient,
     private val lenkeConfig: LenkeConfig,
 ) {
 
-    fun sendTilKabal(fagsak: Fagsak, behandling: Behandling, vurdering: Vurdering) {
-        val oversendtKlageAnkeV3 = lagKlageOversendelseV3(fagsak, behandling, vurdering)
+    fun sendTilKabal(fagsak: Fagsak, behandling: Behandling, vurdering: Vurdering, saksbehandlerIdent: String) {
+        val saksbehandler = integrasjonerClient.hentSaksbehandlerInfo(saksbehandlerIdent)
+        val oversendtKlageAnkeV3 = lagKlageOversendelseV3(fagsak, behandling, vurdering, saksbehandler.enhet)
         kabalClient.sendTilKabal(oversendtKlageAnkeV3)
     }
 
-    private fun lagKlageOversendelseV3(fagsak: Fagsak, behandling: Behandling, vurdering: Vurdering): OversendtKlageAnkeV3 {
+    private fun lagKlageOversendelseV3(fagsak: Fagsak, behandling: Behandling, vurdering: Vurdering, saksbehandlersEnhet: String): OversendtKlageAnkeV3 {
         return OversendtKlageAnkeV3(
             type = Type.KLAGE,
             klager = OversendtKlager(
@@ -34,8 +37,8 @@ class KabalService(
             kildeReferanse = behandling.eksternBehandlingId.toString(),
             innsynUrl = lagInnsynUrl(fagsak, behandling.påklagetVedtak),
             hjemler = vurdering.hjemmel?.let { listOf(it.kabalHjemmel) } ?: emptyList(),
-            forrigeBehandlendeEnhet = behandling.behandlendeEnhet,
-            tilknyttedeJournalposter = listOf(), // TODO: klagebrev kan puttes på automatisk, vedtaksbrev fra EF-sak må hentes fra iverksett, klage må velges ved ferdigstilling eller ved journalføring av klage
+            forrigeBehandlendeEnhet = saksbehandlersEnhet,
+            tilknyttedeJournalposter = listOf(),
             brukersHenvendelseMottattNavDato = behandling.klageMottatt,
             innsendtTilNav = behandling.klageMottatt,
             kilde = fagsak.fagsystem,

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -93,7 +93,7 @@ class BehandlingEventService(
 
     private fun behandleKlageAvsluttet(behandling: Behandling, behandlingEvent: BehandlingEvent) {
         when (behandling.status) {
-            BehandlingStatus.FERDIGSTILT -> logger.error("Mottatt event på ferdigstilt behandling $behandlingEvent - event kan være lest fra før") // TODO korrigeringer - kan vi få det?
+            BehandlingStatus.FERDIGSTILT -> logger.error("Mottatt event på ferdigstilt behandling $behandlingEvent - event kan være lest fra før")
             else -> {
                 opprettOppgaveTask(behandlingEvent, behandling)
                 ferdigstillKlagebehandling(behandling)

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingRepositoryTest.kt
@@ -174,6 +174,5 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
             assertThat(behandlinger).hasSize(2)
             assertThat(behandlinger.map { it.id }).containsExactlyInAnyOrder(behandling.id, behandling2.id)
         }
-
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingRepositoryTest.kt
@@ -175,6 +175,5 @@ class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
             assertThat(behandlinger.map { it.id }).containsExactlyInAnyOrder(behandling.id, behandling2.id)
         }
 
-        // TODO test som sjekker mapping av verdier
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingServiceTest.kt
@@ -89,7 +89,7 @@ internal class FerdigstillBehandlingServiceTest {
         every { distribusjonService.journalførBrev(any(), any(), any(), any(), any()) } returns journalpostId
         every { distribusjonService.distribuerBrev(any()) } returns brevDistribusjonId
         every { vurderingService.hentVurdering(any()) } returns vurdering
-        every { kabalService.sendTilKabal(any(), any(), any()) } just Runs
+        every { kabalService.sendTilKabal(any(), any(), any(), any()) } just Runs
         justRun { stegService.oppdaterSteg(any(), any(), capture(stegSlot), any()) }
         every { formService.formkravErOppfyltForBehandling(any()) } returns true
         justRun { behandlingService.oppdaterBehandlingMedResultat(any(), capture(behandlingsresultatSlot), null) }

--- a/src/test/kotlin/no/nav/familie/klage/kabal/KabalServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/KabalServiceTest.kt
@@ -110,6 +110,5 @@ internal class KabalServiceTest {
         assertThrows<IllegalStateException> {
             kabalService.sendTilKabal(fagsak, behandling, vurdering, "UKJENT1234")
         }
-
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/kabal/KabalServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/KabalServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.klage.behandling.domain.PåklagetVedtak
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.familie.klage.fagsak.domain.PersonIdent
 import no.nav.familie.klage.infrastruktur.config.LenkeConfig
+import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.testutil.DomainUtil.behandling
 import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
 import no.nav.familie.klage.testutil.DomainUtil.påklagetVedtakDetaljer
@@ -16,24 +17,37 @@ import no.nav.familie.klage.testutil.DomainUtil.vurdering
 import no.nav.familie.klage.vurdering.domain.Hjemmel
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
+import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
 
 internal class KabalServiceTest {
 
     val kabalClient = mockk<KabalClient>()
+    val integrasjonerClient = mockk<FamilieIntegrasjonerClient>()
     val lenkeConfig = LenkeConfig(efSakLenke = "BASEURL_EF", baSakLenke = "BASEURL_BA", ksSakLenke = "BASEURL_KS")
-    val kabalService = KabalService(kabalClient, lenkeConfig)
+    val kabalService = KabalService(kabalClient, integrasjonerClient, lenkeConfig)
     val fagsak = fagsakDomain().tilFagsakMedPerson(setOf(PersonIdent("1")))
 
     val hjemmel = Hjemmel.FT_FEMTEN_FIRE
 
     val oversendelseSlot = slot<OversendtKlageAnkeV3>()
+    val saksbehandlerA = Saksbehandler(UUID.randomUUID(), "A123456", "Alfa", "Surname", "4415")
+    val saksbehandlerB = Saksbehandler(UUID.randomUUID(), "B987654", "Beta", "Etternavn", "4408")
 
     @BeforeEach
     internal fun setUp() {
         every { kabalClient.sendTilKabal(capture(oversendelseSlot)) } just Runs
+        every { integrasjonerClient.hentSaksbehandlerInfo(any()) } answers {
+            when (firstArg<String>()) {
+                saksbehandlerA.navIdent -> saksbehandlerA
+                saksbehandlerB.navIdent -> saksbehandlerB
+                else -> error("Fant ikke info om saksbehanlder ${firstArg<String>()}")
+            }
+        }
     }
 
     @Test
@@ -42,7 +56,7 @@ internal class KabalServiceTest {
         val behandling = behandling(fagsak, påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.VEDTAK, påklagetVedtakDetaljer))
         val vurdering = vurdering(behandlingId = behandling.id, hjemmel = hjemmel)
 
-        kabalService.sendTilKabal(fagsak, behandling, vurdering)
+        kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerA.navIdent)
 
         val oversendelse = oversendelseSlot.captured
         assertThat(oversendelse.fagsak?.fagsakId).isEqualTo(fagsak.eksternId)
@@ -51,8 +65,7 @@ internal class KabalServiceTest {
         assertThat(oversendelse.kildeReferanse).isEqualTo(behandling.eksternBehandlingId.toString())
         assertThat(oversendelse.innsynUrl)
             .isEqualTo("${lenkeConfig.efSakLenke}/fagsak/${fagsak.eksternId}/${påklagetVedtakDetaljer.eksternFagsystemBehandlingId}")
-        assertThat(oversendelse.forrigeBehandlendeEnhet).isEqualTo(behandling.behandlendeEnhet)
-        assertThat(oversendelse.tilknyttedeJournalposter).isEmpty() // TODO: Sjekk for relevante
+        assertThat(oversendelse.tilknyttedeJournalposter).isEmpty()
         assertThat(oversendelse.brukersHenvendelseMottattNavDato).isEqualTo(behandling.klageMottatt)
         assertThat(oversendelse.innsendtTilNav).isEqualTo(behandling.klageMottatt)
         assertThat(oversendelse.klager.id.verdi).isEqualTo(fagsak.hentAktivIdent())
@@ -61,6 +74,7 @@ internal class KabalServiceTest {
         assertThat(oversendelse.ytelse).isEqualTo(Ytelse.ENF_ENF)
         assertThat(oversendelse.kommentar).isNull()
         assertThat(oversendelse.dvhReferanse).isNull()
+        assertThat(oversendelse.forrigeBehandlendeEnhet).isEqualTo(saksbehandlerA.enhet)
     }
 
     @Test
@@ -69,10 +83,11 @@ internal class KabalServiceTest {
         val behandling = behandling(fagsak, påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.VEDTAK, påklagetVedtakDetaljer))
         val vurdering = vurdering(behandlingId = behandling.id, hjemmel = hjemmel)
 
-        kabalService.sendTilKabal(fagsak, behandling, vurdering)
+        kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerB.navIdent)
 
         assertThat(oversendelseSlot.captured.innsynUrl)
             .isEqualTo("${lenkeConfig.efSakLenke}/fagsak/${fagsak.eksternId}/saksoversikt")
+        assertThat(oversendelseSlot.captured.forrigeBehandlendeEnhet).isEqualTo(saksbehandlerB.enhet)
     }
 
     @Test
@@ -80,9 +95,21 @@ internal class KabalServiceTest {
         val behandling = behandling(fagsak, påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.UTEN_VEDTAK))
         val vurdering = vurdering(behandlingId = behandling.id, hjemmel = hjemmel)
 
-        kabalService.sendTilKabal(fagsak, behandling, vurdering)
+        kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerB.navIdent)
 
         assertThat(oversendelseSlot.captured.innsynUrl)
             .isEqualTo("${lenkeConfig.efSakLenke}/fagsak/${fagsak.eksternId}/saksoversikt")
+        assertThat(oversendelseSlot.captured.forrigeBehandlendeEnhet).isEqualTo(saksbehandlerB.enhet)
+    }
+
+    @Test
+    internal fun `skal feile hvis saksbehandlerinfo ikke finnes`() {
+        val behandling = behandling(fagsak, påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.UTEN_VEDTAK))
+        val vurdering = vurdering(behandlingId = behandling.id, hjemmel = hjemmel)
+
+        assertThrows<IllegalStateException> {
+            kabalService.sendTilKabal(fagsak, behandling, vurdering, "UKJENT1234")
+        }
+
     }
 }


### PR DESCRIPTION
Skal sende med saksbehandlers fysiske enhet når vi oversender en klage til kabal for at statistikken i KAKA skal bli tilgjengelig for avdelingsledere. Dette er enten 4408, 4410 eller 4415 som henviser til Skien, Arendal og Kristiansund (usikkert hvem som er hvor)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13617)