### PR TITLE
når en klage eller anke blir ferdigbehandlet fra KA sin side skal vi …

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -99,14 +99,10 @@ data class BehandlingDetaljer(
     val ankeITrygderettenbehandlingOpprettet: AnkeITrygderettenbehandlingOpprettetDetaljer? = null,
 ) {
 
-    fun journalpostReferanser(): List<String> {
-        return klagebehandlingAvsluttet?.journalpostReferanser ?: ankebehandlingAvsluttet?.journalpostReferanser ?: listOf()
-    }
-
-    fun oppgaveTekst(): String {
-        return klagebehandlingAvsluttet?.oppgaveTekst()
-            ?: ankebehandlingOpprettet?.oppgaveTekst()
-            ?: ankebehandlingAvsluttet?.oppgaveTekst()
+    fun oppgaveTekst(saksbehandlersEnhet: String): String {
+        return klagebehandlingAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
+            ?: ankebehandlingOpprettet?.oppgaveTekst(saksbehandlersEnhet)
+            ?: ankebehandlingAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
             ?: "Ukjent"
     }
 }
@@ -117,9 +113,10 @@ data class KlagebehandlingAvsluttetDetaljer(
     val journalpostReferanser: List<String>,
 ) {
 
-    fun oppgaveTekst(): String {
+    fun oppgaveTekst(saksbehandlersEnhet: String): String {
         return "Hendelse fra klage av type klagebehandling avsluttet med utfall: $utfall mottatt. " +
             "Avsluttet tidspunkt: $avsluttet. " +
+            "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
             "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
     }
 }
@@ -128,8 +125,9 @@ data class AnkebehandlingOpprettetDetaljer(
     val mottattKlageinstans: LocalDateTime,
 ) {
 
-    fun oppgaveTekst(): String {
-        return "Hendelse fra klage av type ankebehandling opprettet mottatt. Mottatt klageinstans: $mottattKlageinstans."
+    fun oppgaveTekst(saksbehandlersEnhet: String): String {
+        return "Hendelse fra klage av type ankebehandling opprettet mottatt. Mottatt klageinstans: $mottattKlageinstans. " +
+            "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet."
     }
 }
 
@@ -139,9 +137,10 @@ data class AnkebehandlingAvsluttetDetaljer(
     val journalpostReferanser: List<String>,
 ) {
 
-    fun oppgaveTekst(): String {
+    fun oppgaveTekst(saksbehandlersEnhet: String): String {
         return "Hendelse fra klage av type ankebehandling avsluttet med utfall: $utfall mottatt. " +
             "Avsluttet tidspunkt: $avsluttet. " +
+            "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
             "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -36,10 +36,12 @@ import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
+import java.util.UUID
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 
@@ -50,6 +52,8 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
         listOf(
             get(urlEqualTo(integrasjonerConfig.pingUri.path))
                 .willReturn(aResponse().withStatus(200)),
+            get(urlPathMatching("${integrasjonerConfig.saksbehandlerUri.path}/([A-Za-z0-9]*)"))
+                .willReturn(okJson(objectMapper.writeValueAsString(saksbehandler))),
             post(urlEqualTo(integrasjonerConfig.egenAnsattUri.path))
                 .willReturn(okJson(objectMapper.writeValueAsString(egenAnsatt))),
             post(urlEqualTo(integrasjonerConfig.tilgangRelasjonerUri.path))
@@ -276,6 +280,15 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                 navn = "NAV Kristiansand",
                 enhetNr = "1001",
                 status = "Aktiv",
+            ),
+        )
+        private val saksbehandler = Ressurs.success(
+            Saksbehandler(
+                azureId = UUID.randomUUID(),
+                navIdent = "Z999999",
+                fornavn = "Darth",
+                etternavn = "Vader",
+                enhet = "4405",
             ),
         )
     }


### PR DESCRIPTION
…markere tilhørende oppgave med saksbehandler av den opprinnelige klagen sin enhet

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14581)
Når KA behadler en anke eller klage og vi får beskjed om dette, så skal vi markere tilhørende oppgave med hvilken enhet (saksbehandlers enhet) som behandlet den opprinnelige klagen som førte til KA-behandlingen.