### PR TITLE
Fjerner Unleash og legger til Unleash Next fra felles

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -72,7 +72,7 @@ spec:
           namespace: klage
       external:
         - host: api-gw-q1.oera.no
-        - host: unleash.nais.io
+        - host: teamfamilie-unleash-api.nav.cloud.nais.io
         - host: familie-oppdrag.dev-fss-pub.nais.io
         - host: familie-integrasjoner.dev-fss-pub.nais.io
         - host: familie-ef-infotrygd.dev-fss-pub.nais.io

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -72,7 +72,7 @@ spec:
 
       external:
         - host: api-gw.oera.no
-        - host: unleash.nais.io
+        - host: teamfamilie-unleash-api.nav.cloud.nais.io
         - host: familie-oppdrag.prod-fss-pub.nais.io
         - host: familie-integrasjoner.prod-fss-pub.nais.io
         - host: familie-ef-infotrygd.prod-fss-pub.nais.io

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
 		<saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
 		<nav.security.version>3.0.8</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
 		<okhttp3.version>4.9.1</okhttp3.version> <!-- overskrever spring sin versjon, blir brukt av mock-oauth2-server -->
-		<unleash.version>8.3.1</unleash.version>
 	</properties>
 
 	<dependencies>
@@ -106,9 +105,9 @@
 			<version>${springdoc.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.getunleash</groupId>
-			<artifactId>unleash-client-java</artifactId>
-			<version>${unleash.version}</version>
+			<groupId>no.nav.familie.felles</groupId>
+			<artifactId>unleash</artifactId>
+			<version>${felles.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/ApplicationConfig.kt
@@ -30,7 +30,7 @@ import java.time.temporal.ChronoUnit
 
 @SpringBootConfiguration
 @ConfigurationPropertiesScan
-@ComponentScan("no.nav.familie.prosessering", "no.nav.familie.klage", "no.nav.familie.sikkerhet")
+@ComponentScan("no.nav.familie.prosessering", "no.nav.familie.klage", "no.nav.familie.sikkerhet", "no.nav.familie.unleash")
 @EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 @Import(RestTemplateAzure::class)
 @EnableOAuth2Client(cacheEnabled = true)

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/FeatureToggleConfig.kt
@@ -1,90 +1,27 @@
 package no.nav.familie.klage.infrastruktur.config
 
-import io.getunleash.DefaultUnleash
-import io.getunleash.UnleashContext
-import io.getunleash.UnleashContextProvider
-import io.getunleash.util.UnleashConfig
+import io.getunleash.strategy.Strategy
 import no.nav.familie.klage.infrastruktur.featuretoggle.ByEnvironmentStrategy
 import no.nav.familie.klage.infrastruktur.featuretoggle.ByUserIdStrategy
-import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.boot.context.properties.ConfigurationProperties
+import no.nav.familie.unleash.DefaultUnleashService
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
-import java.net.URI
+import org.springframework.context.annotation.Configuration
 
-@ConfigurationProperties("funksjonsbrytere")
+@Configuration
 class FeatureToggleConfig(
-    private val enabled: Boolean,
-    private val unleash: Unleash,
+    @Value("\${UNLEASH_SERVER_API_URL}") private val apiUrl: String,
+    @Value("\${UNLEASH_SERVER_API_TOKEN}") private val apiToken: String,
+    @Value("\${NAIS_APP_NAME}") private val appName: String,
 ) {
 
-    data class Unleash(
-        val uri: URI,
-        val environment: String,
-        val applicationName: String,
-    )
-
-    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    @Bean
+    fun strategies(): List<Strategy> {
+        return listOf(ByUserIdStrategy(), ByEnvironmentStrategy())
+    }
 
     @Bean
-    fun featureToggle(): FeatureToggleService =
-        if (enabled) {
-            lagUnleashFeatureToggleService()
-        } else {
-            log.warn(
-                "Funksjonsbryter-funksjonalitet er skrudd AV. " +
-                    "Gir standardoppførsel for alle funksjonsbrytere, dvs 'false'",
-            )
-            lagDummyFeatureToggleService()
-        }
-
-    private fun lagUnleashFeatureToggleService(): FeatureToggleService {
-        val unleash = DefaultUnleash(
-            UnleashConfig.builder()
-                .appName(unleash.applicationName)
-                .unleashAPI(unleash.uri)
-                .unleashContextProvider(lagUnleashContextProvider())
-                .build(),
-            ByEnvironmentStrategy(),
-            ByUserIdStrategy(),
-        )
-
-        return object : FeatureToggleService {
-            override fun isEnabled(toggle: Toggle, defaultValue: Boolean): Boolean {
-                return unleash.isEnabled(toggle.toggleId, defaultValue)
-            }
-
-            // Spring trigger denne ved shutdown. Gjøres for å unngå at unleash fortsetter å gjøre kall ut
-            override fun destroy() {
-                unleash.shutdown()
-            }
-        }
-    }
-
-    private fun lagUnleashContextProvider(): UnleashContextProvider {
-        return UnleashContextProvider {
-            UnleashContext.builder()
-                // .userId("a user") // Må legges til en gang i fremtiden
-                .environment(unleash.environment)
-                .appName(unleash.applicationName)
-                .build()
-        }
-    }
-
-    private fun lagDummyFeatureToggleService(): FeatureToggleService {
-        return object : FeatureToggleService {
-            override fun isEnabled(toggle: Toggle, defaultValue: Boolean): Boolean {
-                if (unleash.environment == "local") {
-                    return true
-                }
-                return defaultValue
-            }
-
-            override fun destroy() {
-                // Dummy featureToggleService trenger ikke destroy, då den ikke har en unleash å lukke
-            }
-        }
+    fun defaultUnleashService(strategies: List<Strategy>): DefaultUnleashService {
+        return DefaultUnleashService(apiUrl, apiToken, appName, strategies)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 @Unprotected
 class FeatureToggleController(private val featureToggleService: FeatureToggleService) {
 
-    private val funksjonsbrytere: Set<Toggle> = setOf()
+    private val funksjonsbrytere: Set<Toggle> = setOf(Toggle.HENLEGG_FEILREGISTRERT_BEHANDLING, Toggle.TEST_ENVIRONMENT)
 
     @GetMapping
     fun sjekkAlle(): Map<String, Boolean> {

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -1,19 +1,24 @@
 package no.nav.familie.klage.infrastruktur.featuretoggle
 
-import org.springframework.beans.factory.DisposableBean
+import no.nav.familie.unleash.DefaultUnleashService
+import org.springframework.stereotype.Service
 
-interface FeatureToggleService : DisposableBean {
+@Service
+class FeatureToggleService(val defaultUnleashService: DefaultUnleashService) {
 
     fun isEnabled(toggle: Toggle): Boolean {
-        return isEnabled(toggle, false)
+        return defaultUnleashService.isEnabled(toggle.toggleId, false)
     }
 
-    fun isEnabled(toggle: Toggle, defaultValue: Boolean): Boolean
+    fun isEnabled(toggle: Toggle, defaultVerdi: Boolean): Boolean {
+        return defaultUnleashService.isEnabled(toggle.toggleId, defaultVerdi)
+    }
 }
 
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     PLACEHOLDER("Ktlint liker ikke tomme enums"),
     HENLEGG_FEILREGISTRERT_BEHANDLING("familie.klage.henlegg-feilregistrert-behandling"),
+    TEST_ENVIRONMENT("test.environment"),
     ;
 
     companion object {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -226,12 +226,8 @@ rolle:
     veileder: "54cd86b8-2e23-48b2-8852-b05b5827bb0f"
 
 
-funksjonsbrytere:
+unleash:
   enabled: true
-  unleash:
-    uri: https://unleash.nais.io/api/
-    environment: ${NAIS_CLUSTER_NAME}
-    applicationName: ${NAIS_APP_NAME}
 
 prosessering:
   continuousRunning.enabled: true

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -19,12 +19,8 @@ spring:
       security:
         protocol: PLAINTEXT
 
-funksjonsbrytere:
-  enabled: false
-  unleash:
-    uri: http://localhost:4242/api
-    environment: local
-    applicationName: familie-klage
+unleash:
+  enabled: true
 
 FAMILIE_INTEGRASJONER_URL: http://localhost:8386
 FAMILIE_BREV_API_URL: http://localhost:8002
@@ -33,3 +29,7 @@ AZURE_APP_TENANT_ID: navq.onmicrosoft.com
 
 CREDENTIAL_USERNAME: not-a-real-srvuser
 CREDENTIAL_PASSWORD: not-a-real-pw
+
+NAIS_APP_NAME: familie-klage
+UNLEASH_SERVER_API_URL: http://localhost:4242/api
+UNLEASH_SERVER_API_TOKEN: token

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -53,11 +53,9 @@ rolle:
     saksbehandler: "c7e0b108-7ae6-432c-9ab4-946174c240c0"
 
 
-funksjonsbrytere:
-  enabled: false
-  unleash:
-    uri: http://localhost:4242/api
-    environment: local
-    applicationName: familie-klage
+unleash:
+  enabled: true
 
 NAIS_APP_NAME: familie-klage
+UNLEASH_SERVER_API_URL: http://localhost:4242/api
+UNLEASH_SERVER_API_TOKEN: token


### PR DESCRIPTION
Hvorfor er denne endringen nødvendig? ✨

Oppsett for Unleash Next og fjerning av Unleash. Det fantes én toggle for familie-klage per i dag (familie.klage.henlegg-feilregistrert-behandling), som er opprettet her : https://teamfamilie-unleash-web.nav.cloud.nais.io/. Denne PRen fjerner koblingen til unleash.nais.io. 

Testet ok i dev. 

Favro : https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14466