### PR TITLE
Fjerner test.environment toggle

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 @Unprotected
 class FeatureToggleController(private val featureToggleService: FeatureToggleService) {
 
-    private val funksjonsbrytere: Set<Toggle> = setOf(Toggle.HENLEGG_FEILREGISTRERT_BEHANDLING, Toggle.TEST_ENVIRONMENT)
+    private val funksjonsbrytere: Set<Toggle> = setOf()
 
     @GetMapping
     fun sjekkAlle(): Map<String, Boolean> {

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -16,7 +16,6 @@ class FeatureToggleService(val defaultUnleashService: DefaultUnleashService) {
 }
 
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
-    PLACEHOLDER("Ktlint liker ikke tomme enums"),
     HENLEGG_FEILREGISTRERT_BEHANDLING("familie.klage.henlegg-feilregistrert-behandling"),
     ;
 

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -18,7 +18,6 @@ class FeatureToggleService(val defaultUnleashService: DefaultUnleashService) {
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     PLACEHOLDER("Ktlint liker ikke tomme enums"),
     HENLEGG_FEILREGISTRERT_BEHANDLING("familie.klage.henlegg-feilregistrert-behandling"),
-    TEST_ENVIRONMENT("test.environment"),
     ;
 
     companion object {


### PR DESCRIPTION
Fjerner toggle brukt til testing. Lar også settet av funksjonsbrytere i FeatureToggleController være tomt som det var i utgangspunktet. ~Fjerne controllerklassen ?~