### PR TITLE
Kun samle avhengigheter som hører sammen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,15 @@ updates:
     registries:
       - familie-felles
     groups:
-      all-dependencies:
+      kotlin:
         patterns:
-          - "*"
+          - "org.jetbrains.kotlin:*"
+      familie-felles:
+        patterns:
+          - "no.nav.familie.felles:*"
+      familie-kontrakter:
+        patterns:
+          - "no.nav.familie.kontrakter:*"
     ignore:
       - dependency-name: org.jetbrains.kotlinx:kotlinx-coroutines-core
         versions:


### PR DESCRIPTION
Synes det blir litt mye å samle sammen alle avhengighetene i én dependabot-pr. 

Deler det opp slik at vi kun samler de som hører sammen: 

