### PR TITLE
skal ta i bruk ny url mot familie-brev for generering av blankett

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
@@ -20,7 +20,7 @@ class BrevClient(
 ) : AbstractPingableRestClient(restOperations, "familie.brev") {
 
     override val pingUri: URI = URI.create("$familieBrevUri/api/status")
-    private val pdfUri = URI.create("$familieBrevUri/api/blankett/klage/pdf")
+    private val pdfUri = URI.create("$familieBrevUri/blankett/klage/pdf")
 
     override fun ping() {
         operations.optionsForAllow(pingUri)


### PR DESCRIPTION
Skal ta i bruk ny url mot familie-brev for generering av blankett.
Henger sammen med PR i familie-brev:
* https://github.com/navikt/familie-brev/pull/586

Testet i preprod ✅ 