### PR TITLE
Endrer til distroless docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
-
-ENV APP_NAME=familie-klage
+FROM gcr.io/distroless/java21-debian12:nonroot
+ENV TZ="Europe/Oslo"
+COPY target/familie-klage.jar /app/app.jar
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
-
-COPY ./target/familie-klage.jar "app.jar"
+CMD ["-jar", "/app/app.jar"]


### PR DESCRIPTION
Hvorfor trengs denne endringen ?

Det virker unødvendig å ha egen distro inkludert i docker image, da dette er overflødig og gir potensielt mange sikkerhetshull.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-16237