### PR TITLE
Reduser CPU-forespørsel

### DIFF
--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -29,7 +29,7 @@ spec:
       memory: 2048Mi
     requests:
       memory: 512Mi
-      cpu: 500m
+      cpu: 200m
   secureLogs:
     enabled: true
   kafka:


### PR DESCRIPTION
Reduserer hvor mye CPU vi ber om med 60%

Her er hvor mye vi bruker. I følge [dokumenteringen til Nais](https://doc.nais.io/explanation/good-practices/?h=cp#set-reasonable-resource-requests-and-limits)
skal man sette cpu-requests til hva applikasjonen bruker ved normal
last. Ser det er på ca 1%, men at vi til tider kan gå en del over. 
![image](https://github.com/navikt/familie-klage/assets/17828446/4a324b09-b55c-4eb3-b2bf-4cf9fae102d3)
