### PR TITLE
Ønsker å ikke dele opp dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,15 +18,9 @@ updates:
     registries:
       - familie-felles
     groups:
-      kotlin:
+      all-dependencies:
         patterns:
-          - "org.jetbrains.kotlin:*"
-      familie-felles:
-        patterns:
-          - "no.nav.familie.felles:*"
-      familie-kontrakter:
-        patterns:
-          - "no.nav.familie.kontrakter:*"
+          - "*"
     ignore:
       - dependency-name: org.jetbrains.kotlinx:kotlinx-coroutines-core
         versions:


### PR DESCRIPTION
Sjeldent det er breaking changes ved oppdateringer, men synes som oftest det er ganske enkelt å se hvilken avhengighet som har skylda dersom et bygg brekker, og at det er like greit å fikse i samme branch sammen med alle andre oppdateringer.