### PR TITLE
Nytt endepunkt fullmakt

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -70,6 +70,9 @@ spec:
         - application: familie-dokument
         - application: kabal-api
           namespace: klage
+        - application: pdl-fullmakt
+          namespace: pdl
+          cluster: dev-fss
       external:
         - host: api-gw-q1.oera.no
         - host: teamfamilie-unleash-api.nav.cloud.nais.io

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -68,7 +68,9 @@ spec:
         - application: familie-dokument
         - application: kabal-api
           namespace: klage
-
+        - application: pdl-fullmakt
+          namespace: pdl
+          cluster: prod-fss
       external:
         - host: api-gw.oera.no
         - host: teamfamilie-unleash-api.nav.cloud.nais.io

--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.klage.behandling.dto.HenlagtDto
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.klage.integrasjoner.FagsystemVedtakService
-import no.nav.familie.klage.oppgave.OppgaveService
 import no.nav.familie.klage.oppgave.TilordnetRessursService
 import no.nav.familie.klage.oppgave.dto.SaksbehandlerDto
 import no.nav.familie.kontrakter.felles.Ressurs

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/dto/PersonopplysningerDto.kt
@@ -17,7 +17,7 @@ data class PersonopplysningerDto(
 
 data class FullmaktDto(
     val gyldigFraOgMed: LocalDate,
-    val gyldigTilOgMed: LocalDate,
+    val gyldigTilOgMed: LocalDate?,
     val motpartsPersonident: String,
     val navn: String?,
     val områder: List<String>,

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.klage.personopplysninger.fullmakt
 
 import no.nav.familie.http.client.AbstractRestClient
 import org.apache.hc.client5.http.utils.Base64
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -22,6 +23,7 @@ class FullmaktClient(
         val base64EncodedIdent = Base64.encodeBase64String(ident.toByteArray())
 
         val fullmaktResponse = postForEntity<List<FullmaktResponse>>(url, FullmaktRequest(base64EncodedIdent))
+        secureLogger.info("FullmaktResponse: $fullmaktResponse")
         return fullmaktResponse
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.klage.personopplysninger.fullmakt
+
+import no.nav.familie.http.client.AbstractRestClient
+import org.apache.hc.client5.http.utils.Base64
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import java.net.URI
+import java.time.LocalDate
+
+@Component
+class FullmaktClient(
+    @Value("\${PDL_FULLMAKT_URL}")
+    private val fullmaktUrl: String,
+    @Qualifier("azure")
+    private val restOperations: RestOperations,
+) : AbstractRestClient(restOperations, "fullmakt") {
+
+    fun hentFullmakt(ident: String): List<FullmaktResponse> {
+        val url = URI.create("$fullmaktUrl/api/internbruker/fullmaktsgiver")
+        val base64EncodedIdent = Base64.encodeBase64String(ident.toByteArray())
+
+        val fullmaktResponse = postForEntity<List<FullmaktResponse>>(url, FullmaktRequest(base64EncodedIdent))
+        return fullmaktResponse
+    }
+}
+
+data class FullmaktRequest(
+    val ident: String,
+)
+
+data class FullmaktResponse(
+    val gyldigFraOgMed: LocalDate,
+    val gyldigTilOgMed: LocalDate?,
+    val fullmektig: String,
+    val fullmektigsNavn: String?,
+    val omraade: List<Område>,
+)
+
+data class Område(
+    val tema: String,
+    val handling: List<Handling>,
+)
+
+enum class Handling { LES, KOMMUNISER, SKRIV }

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktService.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.klage.personopplysninger.fullmakt
+
+import no.nav.familie.klage.personopplysninger.pdl.Fullmakt
+import no.nav.familie.klage.personopplysninger.pdl.MotpartsRolle
+import org.springframework.stereotype.Service
+
+@Service
+class FullmaktService(
+    val fullmaktClient: FullmaktClient,
+) {
+
+    fun hentFullmakt(ident: String): List<Fullmakt> {
+        val fullmaktResponse = fullmaktClient.hentFullmakt(ident)
+        return fullmaktResponse.map {
+            Fullmakt(
+                gyldigFraOgMed = it.gyldigFraOgMed,
+                gyldigTilOgMed = it.gyldigTilOgMed,
+                motpartsPersonident = it.fullmektig,
+                fullmektigsNavn = it.fullmektigsNavn,
+                motpartsRolle = MotpartsRolle.FULLMEKTIG,
+                it.omraade.map { it.tema },
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
@@ -68,7 +68,6 @@ data class PdlSøker(
     @JsonProperty("doedsfall") val dødsfall: List<Dødsfall>,
     @JsonProperty("kjoenn") val kjønn: List<Kjønn>,
     val folkeregisterpersonstatus: List<Folkeregisterpersonstatus>,
-    val fullmakt: List<Fullmakt>,
     val navn: List<Navn>,
     val vergemaalEllerFremtidsfullmakt: List<VergemaalEllerFremtidsfullmakt>,
 )

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
@@ -103,8 +103,9 @@ data class Folkeregisterpersonstatus(
 
 data class Fullmakt(
     val gyldigFraOgMed: LocalDate,
-    val gyldigTilOgMed: LocalDate,
+    val gyldigTilOgMed: LocalDate?,
     val motpartsPersonident: String,
+    val fullmektigsNavn: String?,
     val motpartsRolle: MotpartsRolle,
     val omraader: List<String>,
 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,24 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl-fullmakt:
+        resource-url: ${PDL_FULLMAKT_URL}
+        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: ${PDL_FULLMAKT_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      pdl-fullmakt-clientcredentials:
+        resource-url: ${PDL_FULLMAKT_URL}
+        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
+        grant-type: client_credentials
+        scope: ${PDL_FULLMAKT_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       kabal:
         resource-url: ${KABAL_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -197,6 +197,7 @@ FAMILIE_DOKUMENT_URL: http://familie-dokument
 
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.${ON_PREM_URL_ENV}-fss-pub.nais.io
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
+PDL_FULLMAKT_URL: https://pdl-fullmakt.${ON_PREM_URL_ENV}-fss-pub.nais.io
 
 KABAL_URL: http://kabal-api.klage
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,7 @@ no.nav.security.jwt:
 
 
 PDL_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-api/.default
+PDL_FULLMAKT_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-fullmakt/.default
 KABAL_SCOPE: api://${DEPLOY_ENV}-gcp.klage.kabal-api/.default
 FAMILIE_EF_SAK_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-sak/.default
 FAMILIE_EF_PROXY_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-ef-proxy/.default

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -16,13 +16,6 @@ query($ident: ID!){
                 historisk
             }
         }
-        fullmakt(historikk: true) {
-            gyldigFraOgMed
-            gyldigTilOgMed
-            motpartsPersonident
-            motpartsRolle
-            omraader
-        }
         kjoenn {
             kjoenn
         }

--- a/src/test/kotlin/no/nav/familie/klage/ApplicationLocal.kt
+++ b/src/test/kotlin/no/nav/familie/klage/ApplicationLocal.kt
@@ -22,6 +22,7 @@ fun main(args: Array<String>) {
             "mock-dokument",
             "mock-kabal",
             "mock-ereg",
+            "mock-fullmakt",
         )
         .run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/klage/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/no/nav/familie/klage/ApplicationLocalPostgres.kt
@@ -29,6 +29,7 @@ fun main(args: Array<String>) {
             "mock-kabal",
             "mock-ereg",
             "mock-inntekt",
+            "mock-fullmakt",
         )
         .properties(properties)
         .run(*args)

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FullmaktClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FullmaktClientMock.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.klage.infrastruktur.config
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.personopplysninger.fullmakt.FullmaktClient
+import no.nav.familie.klage.personopplysninger.fullmakt.FullmaktResponse
+import no.nav.familie.klage.personopplysninger.fullmakt.Handling
+import no.nav.familie.klage.personopplysninger.fullmakt.Område
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import java.time.LocalDate
+
+@Configuration
+@Profile("mock-fullmakt")
+class FullmaktClientMock {
+    @Bean
+    @Primary
+    fun fullmaktClient(): FullmaktClient {
+        val fullmaktClient: FullmaktClient = mockk()
+        every { fullmaktClient.hentFullmakt(any()) } returns
+            listOf(
+                FullmaktResponse(
+                    LocalDate.now().minusYears(1),
+                    LocalDate.now().plusYears(1),
+                    "01010199999",
+                    "Navn",
+                    listOf(Område("ENF", listOf(Handling.LES))),
+                ),
+            )
+
+        return fullmaktClient
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/OppslagSpringRunnerTest.kt
@@ -50,6 +50,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
     "mock-ef-sak",
     "mock-ereg",
     "mock-inntekt",
+    "mock-fullmakt",
 )
 @EnableMockOAuth2Server
 abstract class OppslagSpringRunnerTest {

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
@@ -62,7 +62,6 @@ class PdlClientMock {
                     ),
                 ),
                 dødsfall = listOf(),
-                fullmakt = fullmakter(),
                 kjønn = lagKjønn(KjønnType.KVINNE),
                 navn = listOf(lagNavn()),
                 vergemaalEllerFremtidsfullmakt = vergemaalEllerFremtidsfullmakt(),

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
@@ -74,6 +74,7 @@ class PdlClientMock {
                     gyldigTilOgMed = startdato,
                     gyldigFraOgMed = sluttdato,
                     motpartsPersonident = "11111133333",
+                    fullmektigsNavn = "fullmektigsNavn",
                     motpartsRolle = MotpartsRolle.FULLMEKTIG,
                     omraader = listOf(),
                 ),

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerServiceTest.kt
@@ -95,7 +95,6 @@ internal class PersonopplysningerServiceTest {
         listOf(PdlAdressebeskyttelse(PdlAdressebeskyttelseGradering1.FORTROLIG, metadataGjeldende)),
         listOf(Dødsfall(LocalDate.now())),
         listOf(PdlFolkeregisterpersonstatus1("doed", "d", metadataGjeldende)),
-        listOf(Fullmakt(LocalDate.now(), LocalDate.now(), "fullmaktIdent", "fullmektigsNavn", MotpartsRolle.FULLMEKTIG, listOf("o"))),
         PdlKjønn(KjønnType.KVINNE),
         listOf(lagNavn()),
         listOf(

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlDtoTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlDtoTest.kt
@@ -6,15 +6,6 @@ import org.junit.jupiter.api.Test
 class PdlDtoTest {
 
     @Test
-    fun `pdlSøkerData inneholder samme felter som blir spurt om i query`() {
-        val spørringsfelter = PdlTestUtil.parseSpørring("/pdl/søker.graphql")
-
-        val dtoFelter = PdlTestUtil.finnFeltStruktur(PdlTestdata.pdlSøkerData)!!
-
-        assertThat(dtoFelter).isEqualTo(spørringsfelter["data"])
-    }
-
-    @Test
     fun `navnBolk inneholder samme felter som blir spurt om i query`() {
         val spørringsfelter = PdlTestUtil.parseSpørring("/pdl/navn_bolk.graphql")
 

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlDtoTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlDtoTest.kt
@@ -6,6 +6,15 @@ import org.junit.jupiter.api.Test
 class PdlDtoTest {
 
     @Test
+    fun `pdlSøkerData inneholder samme felter som blir spurt om i query`() {
+        val spørringsfelter = PdlTestUtil.parseSpørring("/pdl/søker.graphql")
+
+        val dtoFelter = PdlTestUtil.finnFeltStruktur(PdlTestdata.pdlSøkerData)!!
+
+        assertThat(dtoFelter).isEqualTo(spørringsfelter["data"])
+    }
+
+    @Test
     fun `navnBolk inneholder samme felter som blir spurt om i query`() {
         val spørringsfelter = PdlTestUtil.parseSpørring("/pdl/navn_bolk.graphql")
 

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlTestdata.kt
@@ -42,6 +42,7 @@ object PdlTestdata {
                         LocalDate.now(),
                         LocalDate.now(),
                         "",
+                        "",
                         MotpartsRolle.FULLMAKTSGIVER,
                         listOf(""),
                     ),

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlTestdata.kt
@@ -37,16 +37,6 @@ object PdlTestdata {
                 dødsfall,
                 listOf(Kjønn(KjønnType.KVINNE)),
                 listOf(Folkeregisterpersonstatus("", "", metadataGjeldende)),
-                listOf(
-                    Fullmakt(
-                        LocalDate.now(),
-                        LocalDate.now(),
-                        "",
-                        "",
-                        MotpartsRolle.FULLMAKTSGIVER,
-                        listOf(""),
-                    ),
-                ),
                 navn,
                 listOf(
                     VergemaalEllerFremtidsfullmakt(

--- a/src/test/kotlin/no/nav/familie/klage/testutil/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/PdlTestdataHelper.kt
@@ -3,7 +3,6 @@ package no.nav.familie.klage.testutil
 import no.nav.familie.klage.personopplysninger.pdl.Adressebeskyttelse
 import no.nav.familie.klage.personopplysninger.pdl.Dødsfall
 import no.nav.familie.klage.personopplysninger.pdl.Folkeregisterpersonstatus
-import no.nav.familie.klage.personopplysninger.pdl.Fullmakt
 import no.nav.familie.klage.personopplysninger.pdl.Kjønn
 import no.nav.familie.klage.personopplysninger.pdl.KjønnType
 import no.nav.familie.klage.personopplysninger.pdl.Metadata
@@ -43,7 +42,6 @@ object PdlTestdataHelper {
         adressebeskyttelse: List<Adressebeskyttelse> = emptyList(),
         dødsfall: List<Dødsfall> = emptyList(),
         folkeregisterpersonstatus: List<Folkeregisterpersonstatus> = emptyList(),
-        fullmakt: List<Fullmakt> = emptyList(),
         kjønn: Kjønn? = null,
         navn: List<Navn> = emptyList(),
         vergemaalEllerFremtidsfullmakt: List<VergemaalEllerFremtidsfullmakt> = emptyList(),
@@ -53,7 +51,6 @@ object PdlTestdataHelper {
             dødsfall,
             listOfNotNull(kjønn),
             folkeregisterpersonstatus,
-            fullmakt,
             navn,
             vergemaalEllerFremtidsfullmakt,
         )


### PR DESCRIPTION
Henter fullmakt fra eget endepunkt. 
Team representasjon tar nå seg av forvaltning av fullmakt. 
Koden for fullmakt ligger fortsatt under pdl: https://github.com/navikt/pdl/tree/master/apps/fullmakt

Tilganger er gitt i dev og prod. Testet i preprod.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21485)