### PR TITLE
Håndter ny eventtype BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <felles.version>3.20240913110742_adb42f8</felles.version>
         <prosessering.version>2.20240902084316_04f17df</prosessering.version>
         <start-class>no.nav.familie.klage.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20240913135049_042822f</kontrakter.version>
+        <kontrakter.version>3.0_20240917094852_351320d</kontrakter.version>
         <saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
         <nav.security.version>5.0.5</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -70,6 +70,7 @@ data class BehandlingEvent(
             BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET ->
                 detaljer.ankeITrygderettenbehandlingOpprettet?.sendtTilTrygderetten ?: throw Feil(feilmelding)
             BehandlingEventType.BEHANDLING_FEILREGISTRERT -> detaljer.behandlingFeilregistrert?.feilregistrert ?: throw Feil("Fant ikke tidspunkt for feilregistrering")
+            BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET -> detaljer.ankebehandlingAvsluttet?.avsluttet ?: throw Feil(feilmelding)
         }
     }
 
@@ -97,6 +98,7 @@ data class BehandlingDetaljer(
     val ankebehandlingAvsluttet: AnkebehandlingAvsluttetDetaljer? = null,
     val behandlingFeilregistrert: BehandlingFeilregistrertDetaljer? = null,
     val ankeITrygderettenbehandlingOpprettet: AnkeITrygderettenbehandlingOpprettetDetaljer? = null,
+    val behandlingEtterTrygderettenOpphevetAvsluttet: BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer? = null,
 ) {
 
     fun oppgaveTekst(saksbehandlersEnhet: String): String {
@@ -148,3 +150,5 @@ data class AnkebehandlingAvsluttetDetaljer(
 data class BehandlingFeilregistrertDetaljer(val reason: String, val type: Type, val feilregistrert: LocalDateTime)
 
 data class AnkeITrygderettenbehandlingOpprettetDetaljer(val sendtTilTrygderetten: LocalDateTime, val utfall: KlageinstansUtfall?)
+
+data class BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(val avsluttet: LocalDateTime, val utfall: KlageinstansUtfall, val journalpostReferanser: List<String>)

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -70,7 +70,7 @@ data class BehandlingEvent(
             BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET ->
                 detaljer.ankeITrygderettenbehandlingOpprettet?.sendtTilTrygderetten ?: throw Feil(feilmelding)
             BehandlingEventType.BEHANDLING_FEILREGISTRERT -> detaljer.behandlingFeilregistrert?.feilregistrert ?: throw Feil("Fant ikke tidspunkt for feilregistrering")
-            BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET -> detaljer.ankebehandlingAvsluttet?.avsluttet ?: throw Feil(feilmelding)
+            BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET -> detaljer.behandlingEtterTrygderettenOpphevetAvsluttet?.avsluttet ?: throw Feil(feilmelding)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -105,6 +105,7 @@ data class BehandlingDetaljer(
         return klagebehandlingAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
             ?: ankebehandlingOpprettet?.oppgaveTekst(saksbehandlersEnhet)
             ?: ankebehandlingAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
+            ?: behandlingEtterTrygderettenOpphevetAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
             ?: "Ukjent"
     }
 }
@@ -151,4 +152,15 @@ data class BehandlingFeilregistrertDetaljer(val reason: String, val type: Type, 
 
 data class AnkeITrygderettenbehandlingOpprettetDetaljer(val sendtTilTrygderetten: LocalDateTime, val utfall: KlageinstansUtfall?)
 
-data class BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(val avsluttet: LocalDateTime, val utfall: KlageinstansUtfall, val journalpostReferanser: List<String>)
+data class BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(
+    val avsluttet: LocalDateTime,
+    val utfall: KlageinstansUtfall,
+    val journalpostReferanser: List<String>,
+) {
+    fun oppgaveTekst(saksbehandlersEnhet: String): String {
+        return "Hendelse fra klage av type behandling etter trygderetten opphevet avsluttet med utfall: $utfall mottatt. " +
+            "Avsluttet tidspunkt: $avsluttet. " +
+            "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
+            "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -56,19 +56,19 @@ class BehandlingEventService(
 
                 BehandlingEventType.ANKEBEHANDLING_OPPRETTET,
                 BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
+                BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
                 -> {
                     /*
-                     * Skal ikke gjøre noe dersom eventtype er ANKEBEHANDLING_OPPRETTET
-                     * eller ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET
+                     * Skal ikke gjøre noe dersom eventtype er ANKEBEHANDLING_OPPRETTET,
+                     * ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET eller BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET
                      * */
                 }
-
-                BehandlingEventType.BEHANDLING_FEILREGISTRERT -> opprettBehandlingFeilregistretTask(behandling.id)
+                BehandlingEventType.BEHANDLING_FEILREGISTRERT -> opprettBehandlingFeilregistrertTask(behandling.id)
             }
         }
     }
 
-    private fun opprettBehandlingFeilregistretTask(behandlingId: UUID) {
+    private fun opprettBehandlingFeilregistrertTask(behandlingId: UUID) {
         taskService.save(BehandlingFeilregistrertTask.opprettTask(behandlingId))
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -51,17 +51,13 @@ class BehandlingEventService(
 
             when (behandlingEvent.type) {
                 BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET -> behandleKlageAvsluttet(behandling, behandlingEvent)
-                BehandlingEventType.ANKEBEHANDLING_AVSLUTTET,
-                -> behandleAnkeAvsluttet(behandling, behandlingEvent)
+                BehandlingEventType.ANKEBEHANDLING_AVSLUTTET, BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
+                -> behandleAnkeAvsluttetEllerBehandlingEtterTrygderettenOpphevetAvsluttet(behandling, behandlingEvent)
 
                 BehandlingEventType.ANKEBEHANDLING_OPPRETTET,
                 BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
-                BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
                 -> {
-                    /*
-                     * Skal ikke gjøre noe dersom eventtype er ANKEBEHANDLING_OPPRETTET,
-                     * ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET eller BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET
-                     * */
+                    // Skal ikke gjøre noe dersom eventtype er ANKEBEHANDLING_OPPRETTET eller ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET
                 }
                 BehandlingEventType.BEHANDLING_FEILREGISTRERT -> opprettBehandlingFeilregistrertTask(behandling.id)
             }
@@ -95,7 +91,7 @@ class BehandlingEventService(
             null
         }
 
-    private fun behandleAnkeAvsluttet(behandling: Behandling, behandlingEvent: BehandlingEvent) {
+    private fun behandleAnkeAvsluttetEllerBehandlingEtterTrygderettenOpphevetAvsluttet(behandling: Behandling, behandlingEvent: BehandlingEvent) {
         opprettOppgaveTask(behandling, behandlingEvent)
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -52,7 +52,7 @@ class BehandlingEventService(
             when (behandlingEvent.type) {
                 BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET -> behandleKlageAvsluttet(behandling, behandlingEvent)
                 BehandlingEventType.ANKEBEHANDLING_AVSLUTTET, BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
-                -> behandleAnkeAvsluttetEllerBehandlingEtterTrygderettenOpphevetAvsluttet(behandling, behandlingEvent)
+                -> opprettOppgaveTask(behandling, behandlingEvent)
 
                 BehandlingEventType.ANKEBEHANDLING_OPPRETTET,
                 BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
@@ -91,10 +91,6 @@ class BehandlingEventService(
             null
         }
 
-    private fun behandleAnkeAvsluttetEllerBehandlingEtterTrygderettenOpphevetAvsluttet(behandling: Behandling, behandlingEvent: BehandlingEvent) {
-        opprettOppgaveTask(behandling, behandlingEvent)
-    }
-
     private fun behandleKlageAvsluttet(behandling: Behandling, behandlingEvent: BehandlingEvent) {
         when (behandling.status) {
             BehandlingStatus.FERDIGSTILT -> logger.error("Mottatt event på ferdigstilt behandling $behandlingEvent - event kan være lest fra før")
@@ -105,7 +101,7 @@ class BehandlingEventService(
         }
     }
 
-    private fun opprettOppgaveTask(behandling: Behandling, behandlingEvent: BehandlingEvent) {
+    fun opprettOppgaveTask(behandling: Behandling, behandlingEvent: BehandlingEvent) {
         val fagsakDomain = fagsakRepository.finnFagsakForBehandlingId(behandling.id)
             ?: error("Finner ikke fagsak for behandlingId: ${behandling.id}")
         val saksbehandlerIdent = behandling.sporbar.endret.endretAv

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
@@ -2,7 +2,6 @@ package no.nav.familie.klage.personopplysninger.fullmakt
 
 import no.nav.familie.http.client.AbstractRestClient
 import org.apache.hc.client5.http.utils.Base64
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/no/nav/familie/klage/test/TestController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/test/TestController.kt
@@ -27,7 +27,7 @@ class TestController(
     private val fagsakPersonService: FagsakPersonService,
     private val fagsakRepository: FagsakRepository,
     private val opprettBehandlingService: OpprettBehandlingService,
-    private val behandleSakOppgaveRepository: BehandleSakOppgaveRepository
+    private val behandleSakOppgaveRepository: BehandleSakOppgaveRepository,
 ) {
 
     @PostMapping("opprett")
@@ -49,7 +49,7 @@ class TestController(
             ),
         )
 
-        val behandleSakOppgave =  BehandleSakOppgave(
+        val behandleSakOppgave = BehandleSakOppgave(
             behandlingId,
             123,
         )
@@ -57,7 +57,7 @@ class TestController(
         behandleSakOppgaveRepository.insert(behandleSakOppgave)
 
         return Ressurs.success(
-            behandlingId
+            behandlingId,
         )
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -99,7 +99,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                 .withQueryParam("variantFormat", equalTo("ARKIV"))
                 .willReturn(okJson(objectMapper.writeValueAsString(Ressurs.success(pdfAsBase64String)))),
             get(urlPathMatching("${integrasjonerConfig.oppgaveUri.path}/([0-9]*)"))
-                .willReturn(okJson(objectMapper.writeValueAsString(Ressurs.success(Oppgave(Random.nextLong().absoluteValue, tilordnetRessurs = "Z994152", tema = Tema.ENF, status = StatusEnum.UNDER_BEHANDLING),)))),
+                .willReturn(okJson(objectMapper.writeValueAsString(Ressurs.success(Oppgave(Random.nextLong().absoluteValue, tilordnetRessurs = "Z994152", tema = Tema.ENF, status = StatusEnum.UNDER_BEHANDLING))))),
             get(urlPathMatching("${integrasjonerConfig.saksbehandlerUri.path}/Z994152"))
                 .willReturn(okJson(objectMapper.writeValueAsString(Ressurs.success(Saksbehandler(UUID.randomUUID(), "Z994152", "Luke", "Skywalker", "4405"))))),
             put(urlMatching("${integrasjonerConfig.dokarkivUri.path}.*"))

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.klage.kabal.KlagebehandlingAvsluttetDetaljer
 import no.nav.familie.klage.kabal.KlageresultatRepository
 import no.nav.familie.klage.kabal.Type
 import no.nav.familie.klage.kabal.domain.KlageinstansResultat
+import no.nav.familie.klage.oppgave.OpprettKabalEventOppgaveTask
 import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.kontrakter.felles.klage.BehandlingEventType
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
@@ -183,6 +184,20 @@ internal class BehandlingEventServiceTest {
 
         assertThat(taskSlot.captured.type).isEqualTo(BehandlingFeilregistrertTask.TYPE)
         assertThat(taskSlot.captured.payload).isEqualTo(behandlingMedStatusVenter.id.toString())
+    }
+
+    @Test
+    internal fun `Skal lage OpprettOppgave-task for behandlingsevent BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET`() {
+        val taskSlot = slot<Task>()
+
+        val behandlingEtterTrygderettenOpphevetAvsluttetDetaljer = BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(LocalDateTime.now(), KlageinstansUtfall.HEVET, emptyList())
+
+        every { taskService.save(capture(taskSlot)) } returns mockk()
+
+        behandlingEventService.handleEvent(lagBehandlingEvent(BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET, BehandlingDetaljer(behandlingEtterTrygderettenOpphevetAvsluttet = behandlingEtterTrygderettenOpphevetAvsluttetDetaljer)))
+
+        assertThat(taskSlot.captured.type).isEqualTo(OpprettKabalEventOppgaveTask.TYPE)
+        assertThat(taskSlot.captured.payload).contains("Hendelse fra klage av type behandling etter trygderetten opphevet avsluttet med utfall: HEVET mottatt.")
     }
 
     private fun lagBehandlingEvent(

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.kabal.AnkeITrygderettenbehandlingOpprettetDetaljer
 import no.nav.familie.klage.kabal.AnkebehandlingOpprettetDetaljer
 import no.nav.familie.klage.kabal.BehandlingDetaljer
+import no.nav.familie.klage.kabal.BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer
 import no.nav.familie.klage.kabal.BehandlingEvent
 import no.nav.familie.klage.kabal.BehandlingFeilregistrertDetaljer
 import no.nav.familie.klage.kabal.BehandlingFeilregistrertTask
@@ -136,6 +137,23 @@ internal class BehandlingEventServiceTest {
         verify(exactly = 1) { klageresultatRepository.insert(capture(klageinstansResultatSlot)) }
 
         assertThat(klageinstansResultatSlot.captured.type).isEqualTo(BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET)
+    }
+
+    @Test
+    internal fun `Skal kunne lagre resultat for behandlingsevent BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET`() {
+        val klageinstansResultatSlot = slot<KlageinstansResultat>()
+
+        behandlingEventService.handleEvent(
+            lagBehandlingEvent(
+                BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
+                BehandlingDetaljer(behandlingEtterTrygderettenOpphevetAvsluttet = BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(LocalDateTime.of(2023, 6, 21, 1, 1), KlageinstansUtfall.HEVET, emptyList())),
+            ),
+        )
+
+        verify(exactly = 1) { behandlingRepository.findByEksternBehandlingId(any()) }
+        verify(exactly = 1) { klageresultatRepository.insert(capture(klageinstansResultatSlot)) }
+
+        assertThat(klageinstansResultatSlot.captured.type).isEqualTo(BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET)
     }
 
     @Test


### PR DESCRIPTION
Lagt til håndtering av BehandlingEventType `BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET`.

Tolker ut ifra at slack-tråd: https://nav-it.slack.com/archives/C058Z17RTSR/p1725270224706149?thread_ts=1725264080.383119&cid=C058Z17RTSR at det ikke skal gjøres noe med denne type event.

Kontrakt for behandlingDetaljer er funnet her: https://github.com/navikt/kabal-api/pull/1199