### PR TITLE
Legg til auto-instrumentation

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -18,6 +18,10 @@ spec:
     path: /internal/status/isAlive
     initialDelay: 30
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
   prometheus:
     enabled: true
     path: /internal/prometheus

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -18,6 +18,10 @@ spec:
     path: /internal/status/isAlive
     initialDelay: 30
     failureThreshold: 10
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
   prometheus:
     enabled: true
     path: /internal/prometheus


### PR DESCRIPTION
Skrur på NAIS auto-instrumentation, som bruker OpenTelemetry for å samle inn telemetri. I vårt tilfelle tracing-data.

https://docs.nais.io/observability/how-to/auto-instrumentation/