### PR TITLE
Vil håndtere omgjøringskrav avsluttet 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <felles.version>3.20240913110742_adb42f8</felles.version>
         <prosessering.version>2.20241011144712_deb1f2c</prosessering.version>
         <start-class>no.nav.familie.klage.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20241018104853_fa92410</kontrakter.version>
+        <kontrakter.version>3.0_20241112143850_7499aea</kontrakter.version>
         <saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
         <nav.security.version>5.0.5</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalføringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalføringUtil.kt
@@ -1,8 +1,8 @@
 package no.nav.familie.klage.distribusjon
 
 import no.nav.familie.klage.brev.domain.Brevmottakere
-import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 
 object JournalføringUtil {
 
@@ -12,13 +12,13 @@ object JournalføringUtil {
                 AvsenderMottaker(
                     id = it.personIdent,
                     navn = it.navn,
-                    idType = BrukerIdType.FNR,
+                    idType = AvsenderMottakerIdType.FNR,
                 )
             } + mottakere.organisasjoner.map {
                 AvsenderMottaker(
                     id = it.organisasjonsnummer,
                     navn = it.navnHosOrganisasjon,
-                    idType = BrukerIdType.ORGNR,
+                    idType = AvsenderMottakerIdType.ORGNR,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalKafkaListener.kt
@@ -71,6 +71,7 @@ data class BehandlingEvent(
                 detaljer.ankeITrygderettenbehandlingOpprettet?.sendtTilTrygderetten ?: throw Feil(feilmelding)
             BehandlingEventType.BEHANDLING_FEILREGISTRERT -> detaljer.behandlingFeilregistrert?.feilregistrert ?: throw Feil("Fant ikke tidspunkt for feilregistrering")
             BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET -> detaljer.behandlingEtterTrygderettenOpphevetAvsluttet?.avsluttet ?: throw Feil(feilmelding)
+            BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET -> detaljer.omgjoeringskravbehandlingAvsluttet?.avsluttet ?: throw Feil("Ikke implementert for OMGJOERINGSKRAV_AVSLUTTET")
         }
     }
 
@@ -99,6 +100,7 @@ data class BehandlingDetaljer(
     val behandlingFeilregistrert: BehandlingFeilregistrertDetaljer? = null,
     val ankeITrygderettenbehandlingOpprettet: AnkeITrygderettenbehandlingOpprettetDetaljer? = null,
     val behandlingEtterTrygderettenOpphevetAvsluttet: BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer? = null,
+    val omgjoeringskravbehandlingAvsluttet: OmgjoeringskravbehandlingAvsluttetDetaljer? = null,
 ) {
 
     fun oppgaveTekst(saksbehandlersEnhet: String): String {
@@ -106,6 +108,7 @@ data class BehandlingDetaljer(
             ?: ankebehandlingOpprettet?.oppgaveTekst(saksbehandlersEnhet)
             ?: ankebehandlingAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
             ?: behandlingEtterTrygderettenOpphevetAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
+            ?: omgjoeringskravbehandlingAvsluttet?.oppgaveTekst(saksbehandlersEnhet)
             ?: "Ukjent"
     }
 }
@@ -163,4 +166,16 @@ data class BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(
             "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
             "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
     }
+}
+
+data class OmgjoeringskravbehandlingAvsluttetDetaljer(
+    val avsluttet: LocalDateTime,
+    val utfall: KlageinstansUtfall,
+    val journalpostReferanser: List<String>,
+) {
+    fun oppgaveTekst(saksbehandlersEnhet: String) =
+        "Hendelse fra klage etter omgjøringskrav med utfall $utfall mottatt. " +
+            "Avsluttet tidspunkt: $avsluttet. " +
+            "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
+            "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
 }

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -51,9 +51,10 @@ class BehandlingEventService(
 
             when (behandlingEvent.type) {
                 BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET -> behandleKlageAvsluttet(behandling, behandlingEvent)
-                BehandlingEventType.ANKEBEHANDLING_AVSLUTTET, BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
+                BehandlingEventType.ANKEBEHANDLING_AVSLUTTET,
+                BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
+                BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET,
                 -> opprettOppgaveTask(behandling, behandlingEvent)
-
                 BehandlingEventType.ANKEBEHANDLING_OPPRETTET,
                 BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
                 -> {

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTaskTest.kt
@@ -17,8 +17,8 @@ import no.nav.familie.klage.brev.domain.MottakerRolle
 import no.nav.familie.klage.felles.domain.Fil
 import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.klage.testutil.DomainUtil.fagsak
-import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottakerIdType
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -90,9 +90,9 @@ internal class JournalførBrevTaskTest {
     @Nested
     inner class JournalførMottakere {
 
-        val mottakerPerson = AvsenderMottaker("1", BrukerIdType.FNR, "1navn")
-        val mottakerPerson2 = AvsenderMottaker("2", BrukerIdType.FNR, "2navn")
-        val mottakerOrganisasjon = AvsenderMottaker("org1", BrukerIdType.ORGNR, "mottaker")
+        val mottakerPerson = AvsenderMottaker("1", AvsenderMottakerIdType.FNR, "1navn")
+        val mottakerPerson2 = AvsenderMottaker("2", AvsenderMottakerIdType.FNR, "2navn")
+        val mottakerOrganisasjon = AvsenderMottaker("org1", AvsenderMottakerIdType.ORGNR, "mottaker")
 
         val mottakere = Brevmottakere(
             listOf(

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.familie.klage.kabal.BehandlingFeilregistrertDetaljer
 import no.nav.familie.klage.kabal.BehandlingFeilregistrertTask
 import no.nav.familie.klage.kabal.KlagebehandlingAvsluttetDetaljer
 import no.nav.familie.klage.kabal.KlageresultatRepository
+import no.nav.familie.klage.kabal.OmgjoeringskravbehandlingAvsluttetDetaljer
 import no.nav.familie.klage.kabal.Type
 import no.nav.familie.klage.kabal.domain.KlageinstansResultat
 import no.nav.familie.klage.oppgave.OpprettKabalEventOppgaveTask
@@ -138,6 +139,23 @@ internal class BehandlingEventServiceTest {
         verify(exactly = 1) { klageresultatRepository.insert(capture(klageinstansResultatSlot)) }
 
         assertThat(klageinstansResultatSlot.captured.type).isEqualTo(BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET)
+    }
+
+    @Test
+    internal fun `Skal kunne lagre resultat for behandlingsevent omgjøringskrav`() {
+        val klageinstansResultatSlot = slot<KlageinstansResultat>()
+
+        behandlingEventService.handleEvent(
+            lagBehandlingEvent(
+                BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET,
+                BehandlingDetaljer(omgjoeringskravbehandlingAvsluttet = OmgjoeringskravbehandlingAvsluttetDetaljer(LocalDateTime.of(2023, 6, 21, 1, 1), KlageinstansUtfall.MEDHOLD_ETTER_FVL_35, emptyList())),
+            ),
+        )
+
+        verify(exactly = 1) { behandlingRepository.findByEksternBehandlingId(any()) }
+        verify(exactly = 1) { klageresultatRepository.insert(capture(klageinstansResultatSlot)) }
+
+        assertThat(klageinstansResultatSlot.captured.type).isEqualTo(BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET)
     }
 
     @Test


### PR DESCRIPTION

Nytt utfall og type fra KA -> medhold etter omgjøringskrav. (https://github.com/navikt/familie-kontrakter/pull/965)
"Medhold etter fvl. § 35 KA"
Brukere kan sende krav om at klageinstansen omgjør et av sine tidligere vedtak, og dette kalles omgjøringskrav. Dersom et omgjøringskrav fører til et medhold, må vedtaksinstans kobles på for å effektuere. familie-klage må kunne håndtere hendelser med denne typen og dette utfallet.