### PR TITLE
Gå over til å hente fullmakt i GCP

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -74,9 +74,8 @@ spec:
         - application: familie-dokument
         - application: kabal-api
           namespace: klage
-        - application: pdl-fullmakt
-          namespace: pdl
-          cluster: dev-fss
+        - application: repr-api
+          namespace: repr
       external:
         - host: api-gw-q1.oera.no
         - host: teamfamilie-unleash-api.nav.cloud.nais.io

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -72,9 +72,8 @@ spec:
         - application: familie-dokument
         - application: kabal-api
           namespace: klage
-        - application: pdl-fullmakt
-          namespace: pdl
-          cluster: prod-fss
+        - application: repr-api
+          namespace: repr
       external:
         - host: api-gw.oera.no
         - host: teamfamilie-unleash-api.nav.cloud.nais.io

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/fullmakt/FullmaktClient.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.klage.personopplysninger.fullmakt
 
 import no.nav.familie.http.client.AbstractRestClient
-import org.apache.hc.client5.http.utils.Base64
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -11,17 +10,15 @@ import java.time.LocalDate
 
 @Component
 class FullmaktClient(
-    @Value("\${PDL_FULLMAKT_URL}")
+    @Value("\${REPR_API_URL}")
     private val fullmaktUrl: String,
     @Qualifier("azure")
     private val restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "fullmakt") {
 
     fun hentFullmakt(ident: String): List<FullmaktResponse> {
-        val url = URI.create("$fullmaktUrl/api/internbruker/fullmaktsgiver")
-        val base64EncodedIdent = Base64.encodeBase64String(ident.toByteArray())
-
-        val fullmaktResponse = postForEntity<List<FullmaktResponse>>(url, FullmaktRequest(base64EncodedIdent))
+        val url = URI.create("$fullmaktUrl/api/internbruker/fullmakt/fullmaktsgiver")
+        val fullmaktResponse = postForEntity<List<FullmaktResponse>>(url, FullmaktRequest(ident))
         secureLogger.info("FullmaktResponse: $fullmaktResponse")
         return fullmaktResponse
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,20 +55,20 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      pdl-fullmakt:
-        resource-url: ${PDL_FULLMAKT_URL}
+      repr-api:
+        resource-url: ${REPR_API_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${PDL_FULLMAKT_SCOPE}
+        scope: ${REPR_API_SCOPE}
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      pdl-fullmakt-clientcredentials:
-        resource-url: ${PDL_FULLMAKT_URL}
+      repr-api-clientcredentials:
+        resource-url: ${REPR_API_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: client_credentials
-        scope: ${PDL_FULLMAKT_SCOPE}
+        scope: ${REPR_API_SCOPE}
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
@@ -141,7 +141,7 @@ no.nav.security.jwt:
 
 
 PDL_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-api/.default
-PDL_FULLMAKT_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-fullmakt/.default
+REPR_API_SCOPE: api://${DEPLOY_ENV}-gcp.repr.repr-api/.default
 KABAL_SCOPE: api://${DEPLOY_ENV}-gcp.klage.kabal-api/.default
 FAMILIE_EF_SAK_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-sak/.default
 FAMILIE_EF_PROXY_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-ef-proxy/.default
@@ -216,7 +216,7 @@ FAMILIE_DOKUMENT_URL: http://familie-dokument
 
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.${ON_PREM_URL_ENV}-fss-pub.nais.io
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
-PDL_FULLMAKT_URL: https://pdl-fullmakt.${ON_PREM_URL_ENV}-fss-pub.nais.io
+REPR_API_URL: http://repr-api.repr
 
 KABAL_URL: http://kabal-api.klage
 


### PR DESCRIPTION
**Hvorfor er denne endringen nødvendig? ✨**
Pdl-api har byttet til repr-api, og det er ikke lenge til pdl-api slutter å virke, ref: https://nav-it.slack.com/archives/C020Q1K6EAY/p1732611753116999
Repr-api finnes i gcp og url/scope må byttes til å gå mot gcp i stedet.
Dette må også gjøres for klage.

Testet OK i preprod.

Vi er gitt tilganger her:
https://github.com/navikt/representasjon/blob/cc057eab93023fb4a3d7b5572b6373b3ec5bc8ea/.nais/prod-gcp/repr-api.yaml