### PR TITLE
Vil håndtere events av type BEHANDLING_FEILREGISTRERT + OMGJOERINGSKRAV

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/kabal/domain/OversendtKlage.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/domain/OversendtKlage.kt
@@ -27,6 +27,7 @@ enum class Type(override val id: String, override val navn: String, override val
     KLAGE("1", "Klage", "Klage"),
     ANKE("2", "Anke", "Anke"),
     ANKE_I_TRYGDERETTEN("3", "Anke i trygderetten", "Anke i trygderetten"),
+    OMGJOERINGSKRAV("4", "Omgjøringskrav", "Omgjøringskrav"),
 }
 
 enum class OversendtPartIdType {


### PR DESCRIPTION
Event av type BEHANDLING_FEILREGISTRERT kan inneholde detaljer med type = OMGJOERINGSKRAV. 

Vil legge til OMGJOERINGSKRAV i Type for å kunne lese eventer av denne typen.

Eksempel på feil i preprod: 
```
value = {"eventId":"66685a8b-7fdf-4a43-afd8-e4aa082bc7f8","kildeReferanse":"abc6","kilde":"IT01","kabalReferanse":"a7847e67-fb33-45f6-a3ca-552f7210986d","type":"BEHANDLING_FEILREGISTRERT","detaljer":{"klagebehandlingAvsluttet":null,"ankebehandlingOpprettet":null,"ankebehandlingAvsluttet":null,"ankeITrygderettenbehandlingOpprettet":null,"behandlingFeilregistrert":{"feilregistrert":"2024-12-02T09:56:09.291636971","navIdent":"Z993258","reason":"E2E-test","type":"OMGJOERINGSKRAV"},"behandlingEtterTrygderettenOpphevetAvsluttet":null,"omgjoeringskravbehandlingAvsluttet":null}})] (Forsøk nr 11)
```

=> InvalidFormatException: Cannot deserialize value of type `no.nav.familie.klage.kabal.Type` from String "**OMGJOERINGSKRAV**": not one of the values accepted for Enum class: [KLAGE, ANKE_I_TRYGDERETTEN, ANKE]


