### PR TITLE
Bruker `Fagsystem` fra kontrakter felles-pakke ved oversending til Kabal 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <felles.version>3.20240913110742_adb42f8</felles.version>
         <prosessering.version>2.20241011144712_deb1f2c</prosessering.version>
         <start-class>no.nav.familie.klage.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20241205134345_ebeccc9</kontrakter.version>
+        <kontrakter.version>3.0_20241219091130_a259c10</kontrakter.version>
         <saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
         <nav.security.version>5.0.5</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalService.kt
@@ -42,19 +42,19 @@ class KabalService(
         vurdering: Vurdering,
         saksbehandlersEnhet: String,
         brevMottakere: Brevmottakere,
-    ): OversendtKlageAnkeV3 {
-        return OversendtKlageAnkeV3(
+    ): OversendtKlageAnkeV3 =
+        OversendtKlageAnkeV3(
             type = Type.KLAGE,
             klager =
-            OversendtKlager(
-                id =
-                OversendtPartId(
-                    type = OversendtPartIdType.PERSON,
-                    verdi = fagsak.hentAktivIdent(),
+                OversendtKlager(
+                    id =
+                        OversendtPartId(
+                            type = OversendtPartIdType.PERSON,
+                            verdi = fagsak.hentAktivIdent(),
+                        ),
+                    klagersProsessfullmektig = utledFullmektigFraBrevmottakere(brevMottakere),
                 ),
-                klagersProsessfullmektig = utledFullmektigFraBrevmottakere(brevMottakere),
-            ),
-            fagsak = OversendtSak(fagsakId = fagsak.eksternId, fagsystem = fagsak.fagsystem),
+            fagsak = OversendtSak(fagsakId = fagsak.eksternId, fagsystem = fagsak.fagsystem.tilFellesFagsystem()),
             kildeReferanse = behandling.eksternBehandlingId.toString(),
             innsynUrl = lagInnsynUrl(fagsak, behandling.påklagetVedtak),
             hjemler = vurdering.hjemmel?.let { listOf(it.kabalHjemmel) } ?: emptyList(),
@@ -62,11 +62,10 @@ class KabalService(
             tilknyttedeJournalposter = listOf(),
             brukersHenvendelseMottattNavDato = behandling.klageMottatt,
             innsendtTilNav = behandling.klageMottatt,
-            kilde = fagsak.fagsystem,
+            kilde = fagsak.fagsystem.tilFellesFagsystem(),
             ytelse = fagsak.stønadstype.tilYtelse(),
             hindreAutomatiskSvarbrev = behandling.årsak == Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL,
         )
-    }
 
     private fun utledFullmektigFraBrevmottakere(brevMottakere: Brevmottakere): OversendtProsessfullmektig? {
         val fullmektigEllerVerge =
@@ -108,7 +107,10 @@ class KabalService(
                 Fagsystem.KS -> lenkeConfig.ksSakLenke
             }
         val påklagetVedtakDetaljer = påklagetVedtak.påklagetVedtakDetaljer
-        return if (påklagetVedtakDetaljer != null && påklagetVedtakDetaljer.fagsystemType == FagsystemType.ORDNIÆR && påklagetVedtakDetaljer.eksternFagsystemBehandlingId != null) {
+        return if (påklagetVedtakDetaljer != null &&
+            påklagetVedtakDetaljer.fagsystemType == FagsystemType.ORDNIÆR &&
+            påklagetVedtakDetaljer.eksternFagsystemBehandlingId != null
+        ) {
             "$fagsystemUrl/fagsak/${fagsak.eksternId}/${påklagetVedtakDetaljer.eksternFagsystemBehandlingId}"
         } else {
             "$fagsystemUrl/fagsak/${fagsak.eksternId}/saksoversikt"

--- a/src/main/kotlin/no/nav/familie/klage/kabal/domain/OversendtKlage.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/domain/OversendtKlage.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.klage.kabal
 
-import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.Fagsystem
 import java.time.LocalDate
 
 // objektet som skal sendes til kabal
@@ -23,7 +23,11 @@ data class OversendtKlageAnkeV3(
     val hindreAutomatiskSvarbrev: Boolean,
 )
 
-enum class Type(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
+enum class Type(
+    override val id: String,
+    override val navn: String,
+    override val beskrivelse: String,
+) : Kode {
     KLAGE("1", "Klage", "Klage"),
     ANKE("2", "Anke", "Anke"),
     ANKE_I_TRYGDERETTEN("3", "Anke i trygderetten", "Anke i trygderetten"),
@@ -87,7 +91,11 @@ interface Kode {
     val beskrivelse: String
 }
 
-enum class LovKilde(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
+enum class LovKilde(
+    override val id: String,
+    override val navn: String,
+    override val beskrivelse: String,
+) : Kode {
     FOLKETRYGDLOVEN("1", "Folketrygdloven", "Ftrl"),
     NORDISK_KONVENSJON("15", "Nordisk konvensjon", "Nordisk konvensjon"),
     ANDRE_TRYGDEAVTALER("21", "Andre trygdeavtaler", "Andre trygdeavtaler"),

--- a/src/test/kotlin/no/nav/familie/klage/kabal/KabalServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/KabalServiceTest.kt
@@ -19,7 +19,7 @@ import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
 import no.nav.familie.klage.testutil.DomainUtil.påklagetVedtakDetaljer
 import no.nav.familie.klage.testutil.DomainUtil.vurdering
 import no.nav.familie.klage.vurdering.domain.Hjemmel
-import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
@@ -103,7 +103,11 @@ internal class KabalServiceTest {
     internal fun `skal sette hindreAutomatiskSvarbrev til true dersom årsaken til behandlingen er henvendelse fra kabal`() {
         val påklagetVedtakDetaljer = påklagetVedtakDetaljer()
         val behandling =
-            behandling(fagsak, påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.VEDTAK, påklagetVedtakDetaljer), årsak = Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL)
+            behandling(
+                fagsak,
+                påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.VEDTAK, påklagetVedtakDetaljer),
+                årsak = Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL,
+            )
         val vurdering = vurdering(behandlingId = behandling.id, hjemmel = hjemmel)
 
         kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerB.navIdent, ingenBrevmottaker)
@@ -152,8 +156,16 @@ internal class KabalServiceTest {
             )
 
             val oversendelse = oversendelseSlot.captured
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.verdi).isEqualTo(verge.personIdent)
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.type).isEqualTo(OversendtPartIdType.PERSON)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.verdi,
+            ).isEqualTo(verge.personIdent)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.type,
+            ).isEqualTo(OversendtPartIdType.PERSON)
             assertThat(oversendelse.klager.klagersProsessfullmektig?.skalKlagerMottaKopi).isFalse()
         }
 
@@ -173,8 +185,16 @@ internal class KabalServiceTest {
             )
 
             val oversendelse = oversendelseSlot.captured
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.verdi).isEqualTo(verge.personIdent)
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.type).isEqualTo(OversendtPartIdType.PERSON)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.verdi,
+            ).isEqualTo(verge.personIdent)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.type,
+            ).isEqualTo(OversendtPartIdType.PERSON)
             assertThat(oversendelse.klager.klagersProsessfullmektig?.skalKlagerMottaKopi).isFalse()
         }
 
@@ -194,8 +214,16 @@ internal class KabalServiceTest {
             )
 
             val oversendelse = oversendelseSlot.captured
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.verdi).isEqualTo(fullmektig.personIdent)
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.type).isEqualTo(OversendtPartIdType.PERSON)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.verdi,
+            ).isEqualTo(fullmektig.personIdent)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.type,
+            ).isEqualTo(OversendtPartIdType.PERSON)
             assertThat(oversendelse.klager.klagersProsessfullmektig?.skalKlagerMottaKopi).isFalse()
         }
 
@@ -215,8 +243,16 @@ internal class KabalServiceTest {
             )
 
             val oversendelse = oversendelseSlot.captured
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.verdi).isEqualTo(fullmektig.organisasjonsnummer)
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.type).isEqualTo(OversendtPartIdType.VIRKSOMHET)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.verdi,
+            ).isEqualTo(fullmektig.organisasjonsnummer)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.type,
+            ).isEqualTo(OversendtPartIdType.VIRKSOMHET)
             assertThat(oversendelse.klager.klagersProsessfullmektig?.skalKlagerMottaKopi).isFalse()
         }
 
@@ -238,8 +274,16 @@ internal class KabalServiceTest {
             )
 
             val oversendelse = oversendelseSlot.captured
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.verdi).isEqualTo(fullmektig.personIdent)
-            assertThat(oversendelse.klager.klagersProsessfullmektig?.id?.type).isEqualTo(OversendtPartIdType.PERSON)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.verdi,
+            ).isEqualTo(fullmektig.personIdent)
+            assertThat(
+                oversendelse.klager.klagersProsessfullmektig
+                    ?.id
+                    ?.type,
+            ).isEqualTo(OversendtPartIdType.PERSON)
             assertThat(oversendelse.klager.klagersProsessfullmektig?.skalKlagerMottaKopi).isFalse()
         }
     }


### PR DESCRIPTION
Favro: [NAV-23745](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23745) 

Bruker `Fagsystem` fra felles-pakke i kontrakter fremfor fra klage-pakke. Kabal forventer enum verdiene vi har i felles-pakka. Dette medfører ingen endring for EF og BA, men det fører til at vi sender KONT fremfor KS.