### PR TITLE
Setter minnegrenser for preprod-config lik prod-config 

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -30,9 +30,9 @@ spec:
     max: 2
   resources:
     limits:
-      memory: 1024Mi
+      memory: 2048Mi
     requests:
-      memory: 512Mi
+      memory: 1024Mi
       cpu: 200m
   secureLogs:
     enabled: true


### PR DESCRIPTION
Vet ikke om det er dette som er årsaken til at det er vanskelig å deploye til dev akkurat nå, men prøver å endre limits ifm minne