### PR TITLE
NAV-23920: Oppretter kode for generering av brev for BAKS

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrev.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrev.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.felles.domain.Fil
+import no.nav.familie.klage.felles.domain.Sporbar
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Embedded
+import java.util.UUID
+
+data class BaksBrev(
+    @Id
+    val behandlingId: UUID,
+    val html: String,
+    val pdf: Fil,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar(),
+) {
+    fun pdfSomBytes(): ByteArray = pdf.bytes
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevController.kt
@@ -1,0 +1,40 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.felles.domain.AuditLoggerEvent
+import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/baks/brev"])
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class BaksBrevController(
+    private val baksBrevService: BaksBrevService,
+    private val tilgangService: TilgangService,
+) {
+    @GetMapping("/{behandlingId}/pdf")
+    fun hentBrev(
+        @PathVariable behandlingId: UUID,
+    ): Ressurs<ByteArray> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
+        return Ressurs.success(baksBrevService.hentBrev(behandlingId).pdfSomBytes())
+    }
+
+    @PostMapping("/{behandlingId}")
+    fun opprettEllerOppdaterBrev(
+        @PathVariable behandlingId: UUID,
+    ): Ressurs<ByteArray> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
+        return Ressurs.success(baksBrevService.opprettEllerOppdaterBrev(behandlingId).pdfSomBytes())
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevController.kt
@@ -21,7 +21,7 @@ class BaksBrevController(
     private val tilgangService: TilgangService,
 ) {
     @GetMapping("/{behandlingId}/pdf")
-    fun hentBrev(
+    fun hentBrevPdf(
         @PathVariable behandlingId: UUID,
     ): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevHenter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevHenter.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.repository.findByIdOrThrow
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class BaksBrevHenter(
+    private val baksBrevRepository: BaksBrevRepository,
+) {
+    private val logger = LoggerFactory.getLogger(BaksBrevHenter::class.java)
+
+    fun hentBrev(behandlingId: UUID): BaksBrev {
+        logger.debug("Henter brev for behandling {}", behandlingId)
+        return baksBrevRepository.findByIdOrThrow(behandlingId)
+    }
+
+    fun hentBrevEllerNull(behandlingId: UUID): BaksBrev? {
+        logger.debug("Henter brev eller null for behandling {}", behandlingId)
+        return baksBrevRepository.findByIdOrNull(behandlingId)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppdaterer.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppdaterer.kt
@@ -26,7 +26,7 @@ class BaksBrevOppdaterer(
         val behandling = behandlingService.hentBehandling(baksBrev.behandlingId)
         validerRedigerbarBehandling(behandling)
         validerKorrektBehandlingssteg(behandling)
-        validerEksiterendeBrev(behandling)
+        validerEksisterendeBrev(behandling)
         val fritekstbrevHtml = fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling)
         val pdfFraHtml = familieDokumentClient.genererPdfFraHtml(fritekstbrevHtml)
         val oppdatertBaksBrev = baksBrev.copy(html = fritekstbrevHtml, pdf = Fil(pdfFraHtml))
@@ -45,7 +45,7 @@ class BaksBrevOppdaterer(
         }
     }
 
-    private fun validerEksiterendeBrev(behandling: Behandling) {
+    private fun validerEksisterendeBrev(behandling: Behandling) {
         val brevFinnes = baksBrevRepository.existsByBehandlingId(behandling.id)
         if (!brevFinnes) {
             throw Feil("Brev finnes ikke for behandling ${behandling.id}. Opprett brevet først.")

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppdaterer.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppdaterer.kt
@@ -1,0 +1,54 @@
+package no.nav.familie.klage.brev.baks
+
+import jakarta.transaction.Transactional
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
+import no.nav.familie.klage.brev.FamilieDokumentClient
+import no.nav.familie.klage.felles.domain.Fil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class BaksBrevOppdaterer(
+    private val baksBrevRepository: BaksBrevRepository,
+    private val behandlingService: BehandlingService,
+    private val familieDokumentClient: FamilieDokumentClient,
+    private val fritekstbrevHtmlUtleder: FritekstbrevHtmlUtleder,
+) {
+    private val logger = LoggerFactory.getLogger(BaksBrevOppdaterer::class.java)
+
+    @Transactional
+    fun oppdaterBrev(baksBrev: BaksBrev): BaksBrev {
+        logger.debug("Oppdaterer brev for behandling {}", baksBrev.behandlingId)
+        val behandling = behandlingService.hentBehandling(baksBrev.behandlingId)
+        validerRedigerbarBehandling(behandling)
+        validerKorrektBehandlingssteg(behandling)
+        validerEksiterendeBrev(behandling)
+        val fritekstbrevHtml = fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling)
+        val pdfFraHtml = familieDokumentClient.genererPdfFraHtml(fritekstbrevHtml)
+        val oppdatertBaksBrev = baksBrev.copy(html = fritekstbrevHtml, pdf = Fil(pdfFraHtml))
+        return baksBrevRepository.update(oppdatertBaksBrev)
+    }
+
+    private fun validerRedigerbarBehandling(behandling: Behandling) {
+        if (behandling.status.erLåstForVidereBehandling()) {
+            throw Feil("Behandlingen ${behandling.id} er låst for videre behandling")
+        }
+    }
+
+    private fun validerKorrektBehandlingssteg(behandling: Behandling) {
+        if (behandling.steg != StegType.BREV) {
+            throw Feil("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}")
+        }
+    }
+
+    private fun validerEksiterendeBrev(behandling: Behandling) {
+        val brevFinnes = baksBrevRepository.existsByBehandlingId(behandling.id)
+        if (!brevFinnes) {
+            throw Feil("Brev finnes ikke for behandling ${behandling.id}. Opprett brevet først.")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppretter.kt
@@ -1,0 +1,55 @@
+package no.nav.familie.klage.brev.baks
+
+import jakarta.transaction.Transactional
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
+import no.nav.familie.klage.brev.FamilieDokumentClient
+import no.nav.familie.klage.felles.domain.Fil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class BaksBrevOppretter(
+    private val baksBrevRepository: BaksBrevRepository,
+    private val behandlingService: BehandlingService,
+    private val familieDokumentClient: FamilieDokumentClient,
+    private val fritekstbrevHtmlUtleder: FritekstbrevHtmlUtleder,
+) {
+    private val logger = LoggerFactory.getLogger(BaksBrevOppretter::class.java)
+
+    @Transactional
+    fun opprettBrev(behandlingId: UUID): BaksBrev {
+        logger.debug("Oppretter brev for behandling {}", behandlingId)
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        validerRedigerbarBehandling(behandling)
+        validerKorrektBehandlingssteg(behandling)
+        validerIngenEksiterendeBrev(behandling)
+        val fritekstbrevHtml = fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling)
+        val pdfFraHtml = familieDokumentClient.genererPdfFraHtml(fritekstbrevHtml)
+        val nyttBaksBrev = BaksBrev(behandlingId = behandlingId, html = fritekstbrevHtml, pdf = Fil(pdfFraHtml))
+        return baksBrevRepository.insert(nyttBaksBrev)
+    }
+
+    private fun validerRedigerbarBehandling(behandling: Behandling) {
+        if (behandling.status.erLåstForVidereBehandling()) {
+            throw Feil("Behandlingen ${behandling.id} er låst for videre behandling")
+        }
+    }
+
+    private fun validerKorrektBehandlingssteg(behandling: Behandling) {
+        if (behandling.steg != StegType.BREV) {
+            throw Feil("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}")
+        }
+    }
+
+    private fun validerIngenEksiterendeBrev(behandling: Behandling) {
+        val brevFinnes = baksBrevRepository.existsByBehandlingId(behandling.id)
+        if (brevFinnes) {
+            throw Feil("Brev finnes allerede for behandling ${behandling.id}. Oppdater heller brevet.")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppretter.kt
@@ -27,7 +27,7 @@ class BaksBrevOppretter(
         val behandling = behandlingService.hentBehandling(behandlingId)
         validerRedigerbarBehandling(behandling)
         validerKorrektBehandlingssteg(behandling)
-        validerIngenEksiterendeBrev(behandling)
+        validerIngenEksisterendeBrev(behandling)
         val fritekstbrevHtml = fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling)
         val pdfFraHtml = familieDokumentClient.genererPdfFraHtml(fritekstbrevHtml)
         val nyttBaksBrev = BaksBrev(behandlingId = behandlingId, html = fritekstbrevHtml, pdf = Fil(pdfFraHtml))
@@ -46,7 +46,7 @@ class BaksBrevOppretter(
         }
     }
 
-    private fun validerIngenEksiterendeBrev(behandling: Behandling) {
+    private fun validerIngenEksisterendeBrev(behandling: Behandling) {
         val brevFinnes = baksBrevRepository.existsByBehandlingId(behandling.id)
         if (brevFinnes) {
             throw Feil("Brev finnes allerede for behandling ${behandling.id}. Oppdater heller brevet.")

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevRepository.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.repository.InsertUpdateRepository
+import no.nav.familie.klage.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface BaksBrevRepository : RepositoryInterface<BaksBrev, UUID>, InsertUpdateRepository<BaksBrev> {
+    fun existsByBehandlingId(behandlingId: UUID): Boolean
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/BaksBrevService.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.klage.brev.baks
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class BaksBrevService(
+    private val baksBrevHenter: BaksBrevHenter,
+    private val baksBrevOppretter: BaksBrevOppretter,
+    private val baksBrevOppdaterer: BaksBrevOppdaterer,
+) {
+    fun hentBrev(behandlingId: UUID): BaksBrev {
+        return baksBrevHenter.hentBrev(behandlingId)
+    }
+
+    @Transactional
+    fun opprettEllerOppdaterBrev(behandlingId: UUID): BaksBrev {
+        val baksBrev = baksBrevHenter.hentBrevEllerNull(behandlingId)
+        if (baksBrev != null) {
+            return baksBrevOppdaterer.oppdaterBrev(baksBrev)
+        }
+        return baksBrevOppretter.opprettBrev(behandlingId)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/FritekstBrevRequestDtoUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/FritekstBrevRequestDtoUtleder.kt
@@ -1,0 +1,102 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
+import no.nav.familie.klage.brev.BrevInnholdUtleder
+import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
+import no.nav.familie.klage.fagsak.domain.Fagsak
+import no.nav.familie.klage.formkrav.FormService
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.vurdering.VurderingService
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class FritekstBrevRequestDtoUtleder(
+    private val formService: FormService,
+    private val vurderingService: VurderingService,
+    private val brevInnholdUtleder: BrevInnholdUtleder,
+) {
+    fun utled(
+        fagsak: Fagsak,
+        behandling: Behandling,
+        navn: String,
+    ): FritekstBrevRequestDto {
+        val behandlingResultat = utledBehandlingResultat(behandling.id)
+        return when (behandlingResultat) {
+            BehandlingResultat.IKKE_MEDHOLD,
+            -> vedIkkeMedhold(fagsak, behandling, navn)
+
+            BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+            -> vedIkkeMedholdFormkravAvvist(fagsak, behandling, navn)
+
+            BehandlingResultat.MEDHOLD,
+            BehandlingResultat.IKKE_SATT,
+            BehandlingResultat.HENLAGT,
+            -> throw Feil("Kan ikke lage brev for behandling med behandlingResultat=$behandlingResultat")
+        }
+    }
+
+    private fun utledBehandlingResultat(behandlingId: UUID): BehandlingResultat {
+        val erFormkravErOppfyltForBehandling = formService.formkravErOppfyltForBehandling(behandlingId)
+        return if (erFormkravErOppfyltForBehandling) {
+            val vurdering = vurderingService.hentVurdering(behandlingId)
+            if (vurdering == null) {
+                throw Feil("Vurdering er null for behandling $behandlingId")
+            }
+            vurdering.vedtak.tilBehandlingResultat()
+        } else {
+            BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST
+        }
+    }
+
+    private fun vedIkkeMedhold(
+        fagsak: Fagsak,
+        behandling: Behandling,
+        navn: String,
+    ): FritekstBrevRequestDto {
+        if (behandling.påklagetVedtak.påklagetVedtakDetaljer == null) {
+            // TODO : Dette burde byttes ut med et exception fra domenelaget
+            throw ApiFeil.badRequest("Kan ikke opprette brev til klageinstansen når det ikke er valgt et påklaget vedtak")
+        }
+        val instillingKlageinstans = vurderingService.hentVurdering(behandling.id)?.innstillingKlageinstans
+        if (instillingKlageinstans == null) {
+            throw Feil("Behandling med resultat ${BehandlingResultat.IKKE_MEDHOLD} mangler instillingKlageinstans for generering av brev")
+        }
+        return brevInnholdUtleder.lagOpprettholdelseBrev(
+            ident = fagsak.hentAktivIdent(),
+            instillingKlageinstans = instillingKlageinstans,
+            navn = navn,
+            stønadstype = fagsak.stønadstype,
+            påklagetVedtakDetaljer = behandling.påklagetVedtak.påklagetVedtakDetaljer,
+            klageMottatt = behandling.klageMottatt,
+        )
+    }
+
+    private fun vedIkkeMedholdFormkravAvvist(
+        fagsak: Fagsak,
+        behandling: Behandling,
+        navn: String,
+    ): FritekstBrevRequestDto {
+        val formkrav = formService.hentForm(behandling.id)
+        return when (behandling.påklagetVedtak.påklagetVedtakstype) {
+            PåklagetVedtakstype.UTEN_VEDTAK -> brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
+                ident = fagsak.hentAktivIdent(),
+                navn = navn,
+                formkrav = formkrav,
+                stønadstype = fagsak.stønadstype,
+            )
+
+            else -> brevInnholdUtleder.lagFormkravAvvistBrev(
+                ident = fagsak.hentAktivIdent(),
+                navn = navn,
+                form = formkrav,
+                stønadstype = fagsak.stønadstype,
+                påklagetVedtakDetaljer = behandling.påklagetVedtak.påklagetVedtakDetaljer,
+                fagsystem = fagsak.fagsystem,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brev/baks/FritekstbrevHtmlUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/baks/FritekstbrevHtmlUtleder.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.brev.BrevClient
+import no.nav.familie.klage.brev.BrevsignaturService
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import org.springframework.stereotype.Component
+
+@Component
+class FritekstbrevHtmlUtleder(
+    private val brevClient: BrevClient,
+    private val brevsignaturService: BrevsignaturService,
+    private val fagsakService: FagsakService,
+    private val personopplysningerService: PersonopplysningerService,
+    private val fritekstBrevRequestDtoUtleder: FritekstBrevRequestDtoUtleder,
+) {
+    fun utledFritekstbrevHtml(behandling: Behandling): String {
+        val fagsak = fagsakService.hentFagsak(behandling.fagsakId)
+        val personopplysninger = personopplysningerService.hentPersonopplysninger(behandling.id)
+
+        val fritekstBrevRequestDto = fritekstBrevRequestDtoUtleder.utled(
+            fagsak,
+            behandling,
+            personopplysninger.navn,
+        )
+
+        val signaturDto = brevsignaturService.lagSignatur(
+            personopplysninger,
+            fagsak.fagsystem,
+        )
+
+        return brevClient.genererHtmlFritekstbrev(
+            fritekstBrev = fritekstBrevRequestDto,
+            saksbehandlerNavn = signaturDto.navn,
+            enhet = signaturDto.enhet,
+        )
+    }
+}

--- a/src/main/resources/db/migration/V23__baks_brev.sql
+++ b/src/main/resources/db/migration/V23__baks_brev.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS baks_brev
+(
+    behandling_id      UUID                                NOT NULL PRIMARY KEY REFERENCES behandling (id),
+    html               VARCHAR                             NOT NULL,
+    pdf                BYTEA                               NOT NULL,
+    opprettet_av       VARCHAR      DEFAULT 'VL'           NOT NULL,
+    opprettet_tid      TIMESTAMP(3) DEFAULT LOCALTIMESTAMP NOT NULL,
+    endret_av          VARCHAR                             NOT NULL,
+    endret_tid         TIMESTAMP    DEFAULT LOCALTIMESTAMP NOT NULL
+);

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevControllerTest.kt
@@ -1,0 +1,259 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.baks.brevmottaker.BrevmottakerDto
+import no.nav.familie.klage.fagsak.domain.FagsakPerson
+import no.nav.familie.klage.fagsak.domain.PersonIdent
+import no.nav.familie.klage.formkrav.FormRepository
+import no.nav.familie.klage.formkrav.domain.Form
+import no.nav.familie.klage.formkrav.domain.FormVilkår
+import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
+import no.nav.familie.klage.infrastruktur.config.RolleConfig
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+
+class BaksBrevControllerTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var baksBrevRepository: BaksBrevRepository
+
+    @Autowired
+    private lateinit var formRepository: FormRepository
+
+    @Autowired
+    private lateinit var rolleConfig: RolleConfig
+
+    private val baseUrl = "/api/baks/brev"
+
+    @Nested
+    inner class HentBrevTest {
+        @Test
+        fun `skal returnere 403 forbidden når man ikke har tilgang til personen med relasjoner for behandlingen`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(
+                    stønadstype = Stønadstype.BARNETRYGD,
+                    person = FagsakPerson(
+                        identer = setOf(
+                            PersonIdent(".*ikkeTilgang.*"),
+                        ),
+                    ),
+                ),
+            )
+            val behandling = testoppsettService.lagreBehandling(DomainUtil.behandling(fagsak = fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<List<BrevmottakerDto>>>(
+                localhost("$baseUrl/${behandling.id}/pdf"),
+                HttpMethod.GET,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo(
+                "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
+            )
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
+                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+            )
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når token ikke har påkrevd role`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(DomainUtil.behandling(fagsak = fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = "ukjent"))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<List<BrevmottakerDto>>>(
+                localhost("$baseUrl/${behandling.id}/pdf"),
+                HttpMethod.GET,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo("Bruker har ikke tilgang til saksbehandlingsløsningen")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Du mangler tilgang til denne saksbehandlingsløsningen")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal hente brev`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(DomainUtil.behandling(fagsak = fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            val baksBrev = DomainUtil.lagBaksBrev(behandlingId = behandling.id)
+
+            baksBrevRepository.insert(baksBrev)
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<ByteArray>>(
+                localhost("$baseUrl/${behandling.id}/pdf"),
+                HttpMethod.GET,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.data).isEqualTo(baksBrev.pdfSomBytes())
+        }
+    }
+
+    @Nested
+    inner class OpprettEllerOppdaterBrevTest {
+        @Test
+        fun `skal returnere 403 forbidden når man ikke har tilgang til personen med relasjoner for behandlingen`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(
+                    stønadstype = Stønadstype.BARNETRYGD,
+                    person = FagsakPerson(
+                        identer = setOf(
+                            PersonIdent(".*ikkeTilgang.*"),
+                        ),
+                    ),
+                ),
+            )
+            val behandling = testoppsettService.lagreBehandling(
+                DomainUtil.behandling(fagsak = fagsak, steg = StegType.BREV),
+            )
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<List<BrevmottakerDto>>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo(
+                "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
+            )
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
+                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+            )
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når token ikke har påkrevd role`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD),
+            )
+            val behandling = testoppsettService.lagreBehandling(
+                DomainUtil.behandling(fagsak = fagsak, steg = StegType.BREV),
+            )
+            headers.setBearerAuth(onBehalfOfToken(role = "ukjent"))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<List<BrevmottakerDto>>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo("Bruker har ikke tilgang til saksbehandlingsløsningen")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Du mangler tilgang til denne saksbehandlingsløsningen")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal oppdatere brev`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD),
+            )
+            val behandling = testoppsettService.lagreBehandling(
+                DomainUtil.behandling(fagsak = fagsak, steg = StegType.BREV),
+            )
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            val baksBrev = DomainUtil.lagBaksBrev(behandlingId = behandling.id)
+
+            baksBrevRepository.insert(baksBrev)
+
+            formRepository.insert(
+                Form(
+                    behandlingId = behandling.id,
+                    klagePart = FormVilkår.IKKE_OPPFYLT,
+                    brevtekst = "brevtekts",
+                ),
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<ByteArray>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.data).isNotNull()
+        }
+
+        @Test
+        fun `skal opprette brev`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD),
+            )
+            val behandling = testoppsettService.lagreBehandling(
+                DomainUtil.behandling(fagsak = fagsak, steg = StegType.BREV),
+            )
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            formRepository.insert(
+                Form(
+                    behandlingId = behandling.id,
+                    klagePart = FormVilkår.IKKE_OPPFYLT,
+                    brevtekst = "brevtekts",
+                ),
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<ByteArray>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.data).isNotNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevHenterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevHenterTest.kt
@@ -1,0 +1,88 @@
+package no.nav.familie.klage.brev.baks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.felles.domain.Fil
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BaksBrevHenterTest {
+    private val baksBrevRepository: BaksBrevRepository = mockk()
+    private val baksBrevHenter: BaksBrevHenter = BaksBrevHenter(
+        baksBrevRepository = baksBrevRepository,
+    )
+
+    @Nested
+    inner class HentBrevTest {
+        @Test
+        fun `skal hente brev`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val html = "<html />"
+            val pdf = Fil("data".toByteArray())
+
+            every {
+                baksBrevHenter.hentBrev(behandlingId)
+            } returns DomainUtil.lagBaksBrev(
+                behandlingId = behandlingId,
+                html = html,
+                pdf = pdf,
+            )
+
+            // Act
+            val baksBrev = baksBrevHenter.hentBrev(behandlingId)
+
+            // Assert
+            assertThat(baksBrev.behandlingId).isEqualTo(behandlingId)
+            assertThat(baksBrev.html).isEqualTo(html)
+            assertThat(baksBrev.pdf).isEqualTo(pdf)
+        }
+    }
+
+    @Nested
+    inner class HentBrevEllerNullTest {
+        @Test
+        fun `skal hente brev`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val html = "<html />"
+            val pdf = Fil("data".toByteArray())
+
+            every {
+                baksBrevHenter.hentBrevEllerNull(behandlingId)
+            } returns DomainUtil.lagBaksBrev(
+                behandlingId = behandlingId,
+                html = html,
+                pdf = pdf,
+            )
+
+            // Act
+            val baksBrev = baksBrevHenter.hentBrevEllerNull(behandlingId)
+
+            // Assert
+            assertThat(baksBrev).isNotNull()
+            assertThat(baksBrev?.behandlingId).isEqualTo(behandlingId)
+            assertThat(baksBrev?.html).isEqualTo(html)
+            assertThat(baksBrev?.pdf).isEqualTo(pdf)
+        }
+
+        @Test
+        fun `skal returnere null om ingen brev finnes for behandlingen`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            every {
+                baksBrevHenter.hentBrevEllerNull(behandlingId)
+            } returns null
+
+            // Act
+            val baksBrev = baksBrevHenter.hentBrevEllerNull(behandlingId)
+
+            // Assert
+            assertThat(baksBrev).isNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppdatererTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppdatererTest.kt
@@ -1,0 +1,157 @@
+package no.nav.familie.klage.brev.baks
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.FamilieDokumentClient
+import no.nav.familie.klage.felles.domain.Fil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class BaksBrevOppdatererTest {
+    private val baksBrevRepository: BaksBrevRepository = mockk()
+    private val behandlingService: BehandlingService = mockk()
+    private val familieDokumentClient: FamilieDokumentClient = mockk()
+    private val fritekstbrevHtmlUtleder: FritekstbrevHtmlUtleder = mockk()
+    private val baksBrevOppdaterer = BaksBrevOppdaterer(
+        baksBrevRepository = baksBrevRepository,
+        behandlingService = behandlingService,
+        familieDokumentClient = familieDokumentClient,
+        fritekstbrevHtmlUtleder = fritekstbrevHtmlUtleder,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(any()) } returns "saksbehandler"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class BaksBrevOppdatererTest {
+        @Test
+        fun `skal kaste exception om behandlingen er låst for redigering`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.FERDIGSTILT,
+                steg = StegType.BREV,
+            )
+
+            val baksBrev = DomainUtil.lagBaksBrev(
+                behandlingId = behandling.id,
+                html = "<html><p>gammelt</p></html>",
+                pdf = Fil("gammel data".toByteArray()),
+            )
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                baksBrevOppdaterer.oppdaterBrev(baksBrev)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen ${behandling.id} er låst for videre behandling")
+        }
+
+        @Test
+        fun `skal kaste exception om behandlingen ikke er i korrekt behandlingssteg`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.OPPRETTET,
+                steg = StegType.FORMKRAV,
+            )
+
+            val baksBrev = DomainUtil.lagBaksBrev(
+                behandlingId = behandling.id,
+                html = "<html><p>gammelt</p></html>",
+                pdf = Fil("gammel data".toByteArray()),
+            )
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                baksBrevOppdaterer.oppdaterBrev(baksBrev)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}")
+        }
+
+        @Test
+        fun `skal kaste exception om det ikke finnes et brev å oppdatere`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.OPPRETTET,
+                steg = StegType.BREV,
+            )
+
+            val baksBrev = DomainUtil.lagBaksBrev(
+                behandlingId = behandling.id,
+                html = "<html><p>gammelt</p></html>",
+                pdf = Fil("gammel data".toByteArray()),
+            )
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { baksBrevRepository.existsByBehandlingId(behandling.id) } returns false
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                baksBrevOppdaterer.oppdaterBrev(baksBrev)
+            }
+            assertThat(exception.message).isEqualTo("Brev finnes ikke for behandling ${behandling.id}. Opprett brevet først.")
+        }
+
+        @Test
+        fun `skal oppdatere brev`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.OPPRETTET,
+                steg = StegType.BREV,
+            )
+
+            val baksBrev = DomainUtil.lagBaksBrev(
+                behandlingId = behandling.id,
+                html = "<html><p>gammelt</p></html>",
+                pdf = Fil("gammel data".toByteArray()),
+            )
+
+            val nyHtml = "<html><p>ny</p></html>"
+            val nyPdfBytes = "ny data".toByteArray()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { baksBrevRepository.existsByBehandlingId(behandling.id) } returns true
+            every { fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling) } returns nyHtml
+            every { familieDokumentClient.genererPdfFraHtml(nyHtml) } returns nyPdfBytes
+            every { baksBrevRepository.update(any()) } returnsArgument 0
+
+            // Act
+            val oppdatertBrev = baksBrevOppdaterer.oppdaterBrev(baksBrev)
+
+            // Assert
+            verify(exactly = 1) { baksBrevRepository.update(any()) }
+            assertThat(oppdatertBrev.behandlingId).isEqualTo(behandling.id)
+            assertThat(oppdatertBrev.html).isEqualTo(nyHtml)
+            assertThat(oppdatertBrev.pdf.bytes).isEqualTo(nyPdfBytes)
+            assertThat(oppdatertBrev.sporbar).isNotNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppretterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevOppretterTest.kt
@@ -1,0 +1,130 @@
+package no.nav.familie.klage.brev.baks
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.FamilieDokumentClient
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class BaksBrevOppretterTest {
+    private val baksBrevRepository: BaksBrevRepository = mockk()
+    private val behandlingService: BehandlingService = mockk()
+    private val familieDokumentClient: FamilieDokumentClient = mockk()
+    private val fritekstbrevHtmlUtleder: FritekstbrevHtmlUtleder = mockk()
+    private val baksBrevOppretter: BaksBrevOppretter = BaksBrevOppretter(
+        baksBrevRepository = baksBrevRepository,
+        behandlingService = behandlingService,
+        familieDokumentClient = familieDokumentClient,
+        fritekstbrevHtmlUtleder = fritekstbrevHtmlUtleder,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(any()) } returns "saksbehandler"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class BaksBrevOppretterTest {
+        @Test
+        fun `skal kaste exception om behandlingen er låst for videre behandling`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.FERDIGSTILT,
+                steg = StegType.BREV,
+            )
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                baksBrevOppretter.opprettBrev(behandling.id)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen ${behandling.id} er låst for videre behandling")
+        }
+
+        @Test
+        fun `skal kaste exception om behandlingen ikke er i rett steg`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.OPPRETTET,
+                steg = StegType.FORMKRAV,
+            )
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                baksBrevOppretter.opprettBrev(behandling.id)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}")
+        }
+
+        @Test
+        fun `skal kaste exception om brev allerde finnes for behandlingen`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.OPPRETTET,
+                steg = StegType.BREV,
+            )
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { baksBrevRepository.existsByBehandlingId(behandling.id) } returns true
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                baksBrevOppretter.opprettBrev(behandling.id)
+            }
+            assertThat(exception.message).isEqualTo("Brev finnes allerede for behandling ${behandling.id}. Oppdater heller brevet.")
+        }
+
+        @Test
+        fun `skal opprette brev`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(
+                id = UUID.randomUUID(),
+                status = BehandlingStatus.OPPRETTET,
+                steg = StegType.BREV,
+            )
+
+            val html = "<html><p>data</p></html>"
+            val pdfBytes = "data".toByteArray()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { baksBrevRepository.existsByBehandlingId(behandling.id) } returns false
+            every { fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling) } returns html
+            every { familieDokumentClient.genererPdfFraHtml(html) } returns pdfBytes
+            every { baksBrevRepository.insert(any()) } returnsArgument 0
+
+            // Act
+            val opprettetBrev = baksBrevOppretter.opprettBrev(behandling.id)
+
+            // Assert
+            assertThat(opprettetBrev.behandlingId).isEqualTo(behandling.id)
+            assertThat(opprettetBrev.html).isEqualTo(html)
+            assertThat(opprettetBrev.pdf.bytes).isEqualTo(pdfBytes)
+            assertThat(opprettetBrev.sporbar).isNotNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevRepositoryTest.kt
@@ -1,0 +1,51 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.klage.testutil.DomainUtil.behandling
+import no.nav.familie.klage.testutil.DomainUtil.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class BaksBrevRepositoryTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var baksBrevRepository: BaksBrevRepository
+
+    private val fagsak = fagsak()
+    private val behandling = behandling(fagsak)
+
+    @BeforeEach
+    internal fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+        testoppsettService.lagreBehandling(behandling)
+    }
+
+    @Nested
+    inner class ExistsByBehandlingIdTest {
+        @Test
+        fun `skal returnere true om brev finnes for behandling`() {
+            // Arrange
+            val detachedBaksBrev = DomainUtil.lagBaksBrev(behandlingId = behandling.id)
+
+            baksBrevRepository.insert(detachedBaksBrev)
+
+            // Act
+            val eksisterer = baksBrevRepository.existsByBehandlingId(behandling.id)
+
+            // Assert
+            assertThat(eksisterer).isTrue()
+        }
+
+        @Test
+        fun `skal returnere false om brev ikke finnes for behandling`() {
+            // Act
+            val eksisterer = baksBrevRepository.existsByBehandlingId(behandling.id)
+
+            // Assert
+            assertThat(eksisterer).isFalse()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevServiceTest.kt
@@ -1,0 +1,75 @@
+package no.nav.familie.klage.brev.baks
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BaksBrevServiceTest {
+    private val baksBrevHenter: BaksBrevHenter = mockk()
+    private val baksBrevOppdaterer: BaksBrevOppdaterer = mockk()
+    private val baksBrevOppretter: BaksBrevOppretter = mockk()
+    private val baksBrevService: BaksBrevService = BaksBrevService(
+        baksBrevHenter = baksBrevHenter,
+        baksBrevOppretter = baksBrevOppretter,
+        baksBrevOppdaterer = baksBrevOppdaterer,
+    )
+
+    @Nested
+    inner class HentBrevTest {
+        @Test
+        fun `skal hente brev`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val baksBrev = DomainUtil.lagBaksBrev(behandlingId)
+            every { baksBrevHenter.hentBrev(behandlingId) } returns baksBrev
+
+            // Act
+            val hentetBaksBrev = baksBrevService.hentBrev(behandlingId)
+
+            // Assert
+            assertThat(hentetBaksBrev).isEqualTo(baksBrev)
+        }
+    }
+
+    @Nested
+    inner class OpprettEllerOppdaterBrevTest {
+        @Test
+        fun `skal oppdatere brev`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val baksBrev = DomainUtil.lagBaksBrev(behandlingId)
+            every { baksBrevHenter.hentBrevEllerNull(behandlingId) } returns baksBrev
+            every { baksBrevOppdaterer.oppdaterBrev(any()) } returnsArgument 0
+
+            // Act
+            val oppdatertBaksBrev = baksBrevService.opprettEllerOppdaterBrev(behandlingId)
+
+            // Assert
+            verify(exactly = 1) { baksBrevOppdaterer.oppdaterBrev(baksBrev) }
+            verify(exactly = 0) { baksBrevOppretter.opprettBrev(baksBrev.behandlingId) }
+            assertThat(oppdatertBaksBrev).isEqualTo(baksBrev)
+        }
+
+        @Test
+        fun `skal opprette brev`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val baksBrev = DomainUtil.lagBaksBrev(behandlingId)
+            every { baksBrevHenter.hentBrevEllerNull(behandlingId) } returns null
+            every { baksBrevOppretter.opprettBrev(any()) } returns baksBrev
+
+            // Act
+            val opprettetBaksBrev = baksBrevService.opprettEllerOppdaterBrev(behandlingId)
+
+            // Assert
+            verify(exactly = 1) { baksBrevOppretter.opprettBrev(baksBrev.behandlingId) }
+            verify(exactly = 0) { baksBrevOppdaterer.oppdaterBrev(baksBrev) }
+            assertThat(opprettetBaksBrev).isEqualTo(baksBrev)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/BaksBrevTest.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.klage.brev.baks
+
+import no.nav.familie.klage.felles.domain.Fil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BaksBrevTest {
+    @Nested
+    inner class PdfSomBytesTest {
+        @Test
+        fun `skal konvertere pdf til bytes`() {
+            // Arrange
+            val bytes = "data".toByteArray()
+
+            val baksBrev = BaksBrev(
+                UUID.randomUUID(),
+                "<div/>",
+                Fil(bytes),
+            )
+
+            // Act
+            val pdfSomBytes = baksBrev.pdfSomBytes()
+
+            // Assert
+            assertThat(pdfSomBytes).isEqualTo(bytes)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/FritekstBrevRequestDtoUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/FritekstBrevRequestDtoUtlederTest.kt
@@ -1,0 +1,328 @@
+package no.nav.familie.klage.brev.baks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
+import no.nav.familie.klage.brev.BrevInnholdUtleder
+import no.nav.familie.klage.formkrav.FormService
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.klage.vurdering.VurderingService
+import no.nav.familie.kontrakter.felles.Regelverk
+import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.FagsystemType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.util.UUID
+
+class FritekstBrevRequestDtoUtlederTest {
+    private val formService: FormService = mockk()
+    private val vurderingService: VurderingService = mockk()
+    private val brevInnholdUtleder: BrevInnholdUtleder = mockk()
+    private val fritekstBrevRequestDtoUtleder: FritekstBrevRequestDtoUtleder = FritekstBrevRequestDtoUtleder(
+        formService = formService,
+        vurderingService = vurderingService,
+        brevInnholdUtleder = brevInnholdUtleder,
+    )
+
+    @Nested
+    inner class UtledTest {
+        @Test
+        fun `skal kaste exception om vurdering er null`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+
+            val behandling = DomainUtil.behandling(
+                fagsak = fagsak,
+                påklagetVedtak = DomainUtil.lagPåklagetVedtak(
+                    påklagetVedtakstype = PåklagetVedtakstype.VEDTAK,
+                    påklagetVedtakDetaljer = DomainUtil.lagPåklagetVedtakDetaljer(
+                        fagsystemType = FagsystemType.ORDNIÆR,
+                        eksternFagsystemBehandlingId = UUID.randomUUID().toString(),
+                        behandlingstype = "type",
+                        resultat = "resultat",
+                        vedtakstidspunkt = LocalDateTime.now(),
+                        regelverk = Regelverk.NASJONAL,
+                    ),
+                ),
+            )
+
+            every {
+                formService.formkravErOppfyltForBehandling(behandling.id)
+            } returns true
+
+            every {
+                vurderingService.hentVurdering(behandling.id)
+            } returns null
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                fritekstBrevRequestDtoUtleder.utled(fagsak, behandling, "navn")
+            }
+            assertThat(exception.message).isEqualTo("Vurdering er null for behandling ${behandling.id}")
+        }
+
+        @Test
+        fun `skal kaste exception hvis påklagetVedtakDetaljer er null for ikke medhold brev`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+
+            val behandling = DomainUtil.behandling(
+                fagsak = fagsak,
+                påklagetVedtak = DomainUtil.lagPåklagetVedtak(
+                    påklagetVedtakstype = PåklagetVedtakstype.VEDTAK,
+                    påklagetVedtakDetaljer = null,
+                ),
+            )
+
+            val vurdering = DomainUtil.vurdering(behandlingId = behandling.id)
+
+            every {
+                formService.formkravErOppfyltForBehandling(behandling.id)
+            } returns true
+
+            every {
+                vurderingService.hentVurdering(behandling.id)
+            } returns vurdering
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                fritekstBrevRequestDtoUtleder.utled(fagsak, behandling, "navn")
+            }
+            assertThat(exception.message).isEqualTo("Kan ikke opprette brev til klageinstansen når det ikke er valgt et påklaget vedtak")
+        }
+
+        @Test
+        fun `skal kaste exception hvis innstillingKlageinstans er null for ikke medhold brev`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+
+            val påklagetVedtakDetaljer = DomainUtil.lagPåklagetVedtakDetaljer(
+                fagsystemType = FagsystemType.ORDNIÆR,
+                eksternFagsystemBehandlingId = UUID.randomUUID().toString(),
+                behandlingstype = "type",
+                resultat = "resultat",
+                vedtakstidspunkt = LocalDateTime.now(),
+                regelverk = Regelverk.NASJONAL,
+            )
+
+            val behandling = DomainUtil.behandling(
+                fagsak = fagsak,
+                påklagetVedtak = DomainUtil.lagPåklagetVedtak(
+                    påklagetVedtakstype = PåklagetVedtakstype.VEDTAK,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                ),
+            )
+
+            val vurdering = DomainUtil.vurdering(
+                behandlingId = behandling.id,
+                innstillingKlageinstans = null,
+            )
+
+            val fakeFritekstBrevRequestDto = DomainUtil.lagFritekstBrevRequestDto(
+                overskrift = "overskrift",
+                avsnitt = listOf(),
+                personIdent = "123",
+                navn = "navn",
+            )
+
+            every {
+                formService.formkravErOppfyltForBehandling(behandling.id)
+            } returns true
+
+            every {
+                vurderingService.hentVurdering(behandling.id)
+            } returns vurdering
+
+            every {
+                brevInnholdUtleder.lagOpprettholdelseBrev(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    eq(påklagetVedtakDetaljer),
+                    any(),
+                )
+            } returns fakeFritekstBrevRequestDto
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                fritekstBrevRequestDtoUtleder.utled(fagsak, behandling, "navn")
+            }
+            assertThat(exception.message).isEqualTo(
+                "Behandling med resultat ${BehandlingResultat.IKKE_MEDHOLD} mangler instillingKlageinstans for generering av brev",
+            )
+        }
+
+        @Test
+        fun `skal utlede ikke medhold FritekstBrevRequestDto`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+
+            val påklagetVedtakDetaljer = DomainUtil.lagPåklagetVedtakDetaljer(
+                fagsystemType = FagsystemType.ORDNIÆR,
+                eksternFagsystemBehandlingId = UUID.randomUUID().toString(),
+                behandlingstype = "type",
+                resultat = "resultat",
+                vedtakstidspunkt = LocalDateTime.now(),
+                regelverk = Regelverk.NASJONAL,
+            )
+
+            val behandling = DomainUtil.behandling(
+                fagsak = fagsak,
+                påklagetVedtak = DomainUtil.lagPåklagetVedtak(
+                    påklagetVedtakstype = PåklagetVedtakstype.VEDTAK,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                ),
+            )
+
+            val vurdering = DomainUtil.vurdering(behandlingId = behandling.id)
+
+            val fakeFritekstBrevRequestDto = DomainUtil.lagFritekstBrevRequestDto(
+                overskrift = "overskrift",
+                avsnitt = listOf(),
+                personIdent = "123",
+                navn = "navn",
+            )
+
+            every {
+                formService.formkravErOppfyltForBehandling(behandling.id)
+            } returns true
+
+            every {
+                vurderingService.hentVurdering(behandling.id)
+            } returns vurdering
+
+            every {
+                brevInnholdUtleder.lagOpprettholdelseBrev(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    eq(påklagetVedtakDetaljer),
+                    any(),
+                )
+            } returns fakeFritekstBrevRequestDto
+
+            // Act
+            val fritekstBrevRequestDto = fritekstBrevRequestDtoUtleder.utled(fagsak, behandling, "navn")
+
+            // Assert
+            assertThat(fritekstBrevRequestDto).isEqualTo(fakeFritekstBrevRequestDto)
+        }
+
+        @Test
+        fun `skal utlede ikke medhold formkrav avvist FritekstBrevRequestDto`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+
+            val påklagetVedtakDetaljer = DomainUtil.lagPåklagetVedtakDetaljer(
+                fagsystemType = FagsystemType.ORDNIÆR,
+                eksternFagsystemBehandlingId = UUID.randomUUID().toString(),
+                behandlingstype = "type",
+                resultat = "resultat",
+                vedtakstidspunkt = LocalDateTime.now(),
+                regelverk = Regelverk.NASJONAL,
+            )
+
+            val behandling = DomainUtil.behandling(
+                fagsak = fagsak,
+                påklagetVedtak = DomainUtil.lagPåklagetVedtak(
+                    påklagetVedtakstype = PåklagetVedtakstype.VEDTAK,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                ),
+            )
+
+            val fakeFritekstBrevRequestDto = DomainUtil.lagFritekstBrevRequestDto(
+                overskrift = "overskrift",
+                avsnitt = listOf(),
+                personIdent = "123",
+                navn = "navn",
+            )
+
+            val form = DomainUtil.oppfyltForm(behandlingId = behandling.id)
+
+            every {
+                formService.formkravErOppfyltForBehandling(behandling.id)
+            } returns false
+
+            every {
+                formService.hentForm(behandlingId = behandling.id)
+            } returns form
+
+            every {
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    any(),
+                    any(),
+                    eq(form),
+                    any(),
+                    eq(påklagetVedtakDetaljer),
+                    any(),
+                )
+            } returns fakeFritekstBrevRequestDto
+
+            // Act
+            val fritekstBrevRequestDto = fritekstBrevRequestDtoUtleder.utled(fagsak, behandling, "navn")
+
+            // Assert
+            assertThat(fritekstBrevRequestDto).isEqualTo(fakeFritekstBrevRequestDto)
+        }
+
+        @Test
+        fun `skal utlede ikke medhold formkrav avvist ikke påklaget vedtak FritekstBrevRequestDto`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+
+            val behandling = DomainUtil.behandling(
+                fagsak = fagsak,
+                påklagetVedtak = DomainUtil.lagPåklagetVedtak(
+                    påklagetVedtakstype = PåklagetVedtakstype.UTEN_VEDTAK,
+                    påklagetVedtakDetaljer = DomainUtil.lagPåklagetVedtakDetaljer(
+                        fagsystemType = FagsystemType.ORDNIÆR,
+                        eksternFagsystemBehandlingId = UUID.randomUUID().toString(),
+                        behandlingstype = "type",
+                        resultat = "resultat",
+                        vedtakstidspunkt = LocalDateTime.now(),
+                        regelverk = Regelverk.NASJONAL,
+                    ),
+                ),
+            )
+
+            val fakeFritekstBrevRequestDto = DomainUtil.lagFritekstBrevRequestDto(
+                overskrift = "overskrift",
+                avsnitt = listOf(),
+                personIdent = "123",
+                navn = "navn",
+            )
+
+            val form = DomainUtil.oppfyltForm(behandlingId = behandling.id)
+
+            every {
+                formService.formkravErOppfyltForBehandling(behandling.id)
+            } returns false
+
+            every {
+                formService.hentForm(behandlingId = behandling.id)
+            } returns form
+
+            every {
+                brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
+                    any(),
+                    any(),
+                    eq(form),
+                    any(),
+                )
+            } returns fakeFritekstBrevRequestDto
+
+            // Act
+            val fritekstBrevRequestDto = fritekstBrevRequestDtoUtleder.utled(fagsak, behandling, "navn")
+
+            // Assert
+            assertThat(fritekstBrevRequestDto).isEqualTo(fakeFritekstBrevRequestDto)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/baks/FritekstbrevHtmlUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/baks/FritekstbrevHtmlUtlederTest.kt
@@ -1,0 +1,84 @@
+package no.nav.familie.klage.brev.baks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.brev.BrevClient
+import no.nav.familie.klage.brev.BrevsignaturService
+import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
+import no.nav.familie.klage.brev.dto.SignaturDto
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FritekstbrevHtmlUtlederTest {
+    private val brevClient: BrevClient = mockk()
+    private val brevsignaturService: BrevsignaturService = mockk()
+    private val fagsakService: FagsakService = mockk()
+    private val personopplysningerService: PersonopplysningerService = mockk()
+    private val fritekstBrevRequestDtoUtleder: FritekstBrevRequestDtoUtleder = mockk()
+    private val fritekstbrevHtmlUtleder: FritekstbrevHtmlUtleder = FritekstbrevHtmlUtleder(
+        brevClient = brevClient,
+        brevsignaturService = brevsignaturService,
+        fagsakService = fagsakService,
+        personopplysningerService = personopplysningerService,
+        fritekstBrevRequestDtoUtleder = fritekstBrevRequestDtoUtleder,
+    )
+
+    @Nested
+    inner class UtledFritekstbrevHtmlTest {
+        @Test
+        fun `skal utlede html for fritekstbrev`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD)
+            val behandling = DomainUtil.behandling(fagsak)
+            val personopplysningerDto = DomainUtil.personopplysningerDto()
+            val fritekstBrevRequestDto = FritekstBrevRequestDto(
+                "overskrift",
+                emptyList(),
+                "personIdent",
+                "navn",
+            )
+            val signaturDto = SignaturDto("navn", "enhet")
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns fagsak
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns personopplysningerDto
+
+            every {
+                fritekstBrevRequestDtoUtleder.utled(
+                    fagsak,
+                    behandling,
+                    personopplysningerDto.navn,
+                )
+            } returns fritekstBrevRequestDto
+
+            every {
+                brevsignaturService.lagSignatur(
+                    personopplysningerDto, fagsak.fagsystem,
+                )
+            } returns signaturDto
+
+            every {
+                brevClient.genererHtmlFritekstbrev(
+                    fritekstBrevRequestDto,
+                    signaturDto.navn,
+                    signaturDto.enhet,
+                )
+            } returns "<html />"
+
+            // Act
+            val html = fritekstbrevHtmlUtleder.utledFritekstbrevHtml(behandling)
+
+            // Assert
+            assertThat(html).isEqualTo("<html />")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/OppslagSpringRunnerTest.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import no.nav.familie.klage.ApplicationLocal
 import no.nav.familie.klage.behandling.domain.Behandling
 import no.nav.familie.klage.behandlingshistorikk.domain.Behandlingshistorikk
+import no.nav.familie.klage.brev.baks.BaksBrev
 import no.nav.familie.klage.brev.domain.Avsnitt
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.Brevmottaker
@@ -110,6 +111,7 @@ abstract class OppslagSpringRunnerTest {
             Behandlingshistorikk::class,
             Avsnitt::class,
             Brev::class,
+            BaksBrev::class,
             Vurdering::class,
             Form::class,
             KlageinstansResultat::class,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23920

Legger inn kode for å generere og lagre brev for BAKS. Brevet skiller seg fra EF brevet med at brevmottakerene blir laget i en egen tabell. 

`FritekstBrevRequestDtoUtleder` og `FritekstbrevHtmlUtleder` er kode som er kopiert fra EF sin kode men flyttet inn i egne klasser for å enklere gjenbruke/testes. Tanken er at EF koden også kan benytte disse i en senere PR. 