### PR TITLE
Feature - deliger oppgave til saksbehandler som tar klagebehandling av vent

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentService.kt
@@ -26,7 +26,7 @@ class BehandlingPåVentService(
     private val oppgaveService: OppgaveService,
     private val behandlinghistorikkService: BehandlingshistorikkService,
     private val taskService: TaskService,
-    private val tilordnetRessursService: TilordnetRessursService
+    private val tilordnetRessursService: TilordnetRessursService,
 ) {
     val logger: Logger = LoggerFactory.getLogger(javaClass)
 
@@ -91,13 +91,13 @@ class BehandlingPåVentService(
         )
     }
 
-    private fun validerKanSettePåVent(behandlingStatus: BehandlingStatus) {
+    fun validerKanSettePåVent(behandlingStatus: BehandlingStatus) {
         brukerfeilHvis(behandlingStatus.erLåstForVidereBehandling()) {
             "Kan ikke sette behandling med status $behandlingStatus på vent"
         }
     }
 
-    private fun validerKanTaAvVent(behandlingStatus: BehandlingStatus) {
+    fun validerKanTaAvVent(behandlingStatus: BehandlingStatus) {
         brukerfeilHvis(behandlingStatus != BehandlingStatus.SATT_PÅ_VENT) {
             "Kan ikke ta behandling med status $behandlingStatus av vent"
         }
@@ -111,7 +111,7 @@ class BehandlingPåVentService(
             oppgaveService.fordelOppgave(
                 gsakOppgaveId = oppgaveId,
                 saksbehandler = SikkerhetContext.hentSaksbehandler(),
-                versjon = oppgave.versjon
+                versjon = oppgave.versjon,
             )
         } else {
             logger.warn("Fant ikke oppgave med id $behandlingId")

--- a/src/main/kotlin/no/nav/familie/klage/behandling/dto/OppgaveDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/dto/OppgaveDto.kt
@@ -10,4 +10,5 @@ data class OppgaveDto(
     val prioritet: OppgavePrioritet? = null,
     val fristFerdigstillelse: String,
     val mappeId: Long? = null,
+    val versjon: Int? = null,
 )

--- a/src/main/kotlin/no/nav/familie/klage/behandling/dto/SettPåVentRequest.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/dto/SettPåVentRequest.kt
@@ -10,5 +10,5 @@ data class SettPåVentRequest(
     val mappe: Long?,
     val beskrivelse: String,
     val oppgaveVersjon: Int,
-    val innstillingsoppgaveBeskjed: String?,
+    val innstillingsoppgaveBeskjed: String?
 )

--- a/src/main/kotlin/no/nav/familie/klage/behandling/dto/SettPåVentRequest.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/dto/SettPåVentRequest.kt
@@ -10,5 +10,5 @@ data class SettPåVentRequest(
     val mappe: Long?,
     val beskrivelse: String,
     val oppgaveVersjon: Int,
-    val innstillingsoppgaveBeskjed: String?
+    val innstillingsoppgaveBeskjed: String?,
 )

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.klage.oppgave
 
 import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.http.client.RessursException
 import no.nav.familie.klage.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.klage.infrastruktur.config.IntegrasjonerConfig
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
 import no.nav.familie.klage.infrastruktur.exception.IntegrasjonException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
@@ -12,6 +14,7 @@ import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
@@ -56,6 +59,52 @@ class OppgaveClient(
             HttpHeaders().medContentTypeJsonUTF8(),
         )
         return pakkUtRespons(respons, uri, "oppdaterOppgave").oppgaveId
+    }
+
+    fun fordelOppgave(
+        oppgaveId: Long,
+        saksbehandler: String?,
+        versjon: Int? = null,
+    ): Long {
+        var uri = URI.create("$oppgaveUri/$oppgaveId/fordel")
+
+        if (saksbehandler != null) {
+            uri =
+                UriComponentsBuilder
+                    .fromUri(uri)
+                    .queryParam("saksbehandler", saksbehandler)
+                    .build()
+                    .toUri()
+        }
+
+        if (versjon != null) {
+            uri =
+                UriComponentsBuilder
+                    .fromUri(uri)
+                    .queryParam("versjon", versjon)
+                    .build()
+                    .toUri()
+        }
+
+        try {
+            val respons = postForEntity<Ressurs<OppgaveResponse>>(uri, HttpHeaders().medContentTypeJsonUTF8())
+            return pakkUtRespons(respons, uri, "fordelOppgave").oppgaveId
+        } catch (e: RessursException) {
+            when {
+                e.ressurs.melding.contains("allerede er ferdigstilt") ->
+                    throw ApiFeil(
+                        "Oppgaven med id=$oppgaveId er allerede ferdigstilt. Prøv å hente oppgaver på nytt.",
+                        HttpStatus.BAD_REQUEST,
+                    )
+
+                e.httpStatus == HttpStatus.CONFLICT -> throw ApiFeil(
+                    "Oppgaven har endret seg siden du sist hentet oppgaver. For å kunne gjøre endringer må du hente oppgaver på nytt.",
+                    HttpStatus.CONFLICT,
+                )
+
+                else -> throw e
+            }
+        }
     }
 
     fun finnMapper(

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
@@ -38,6 +38,24 @@ class OppgaveService(
         oppgaveClient.oppdaterOppgave(oppdatertOppgave)
     }
 
+    fun fordelOppgave(
+        gsakOppgaveId: Long,
+        saksbehandler: String,
+        versjon: Int? = null,
+    ): Long {
+        val oppgave = hentOppgave(gsakOppgaveId)
+
+        return if (oppgave.tilordnetRessurs == saksbehandler) {
+            gsakOppgaveId
+        } else {
+            oppgaveClient.fordelOppgave(
+                oppgaveId = gsakOppgaveId,
+                saksbehandler = saksbehandler,
+                versjon = versjon,
+            )
+        }
+    }
+
     fun finnMapper(enheter: List<String>): List<MappeDto> {
         val mapper = enheter.flatMap { enhet -> finnMapperFraCache(enhet = enhet) }
         return mapper.sortedBy { mappe -> mappe.navn }

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/TilordnetRessursService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/TilordnetRessursService.kt
@@ -48,6 +48,7 @@ class TilordnetRessursService(
                 prioritet = oppgave.prioritet,
                 fristFerdigstillelse = oppgave.fristFerdigstillelse ?: "",
                 mappeId = oppgave.mappeId,
+                versjon = oppgave.versjon,
             )
         } else {
             throw ApiFeil(

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentServiceTest.kt
@@ -143,6 +143,7 @@ class BehandlingPåVentServiceTest {
                     status = BehandlingStatus.UTREDES,
                 )
             }
+
             verify {
                 oppgaveService.fordelOppgave(
                     gsakOppgaveId = oppgaveId,
@@ -161,6 +162,7 @@ class BehandlingPåVentServiceTest {
 
     private fun mockSettSaksbehandlerPåOppgave(oppgaveId: Long) {
         val oppgave = oppgave(oppgaveId)
+
         every { tilordnetRessursService.hentOppgave(behandlingId) } returns OppgaveDto(
             oppgaveId = oppgave.id,
             tildeltEnhetsnr = oppgave.tildeltEnhetsnr,
@@ -171,6 +173,7 @@ class BehandlingPåVentServiceTest {
             mappeId = oppgave.mappeId,
             versjon = oppgave.versjon,
         )
+
         every { oppgaveService.fordelOppgave(any(), any(), any()) } returns oppgaveId
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentServiceTest.kt
@@ -63,7 +63,7 @@ class BehandlingPåVentServiceTest {
     @Nested
     inner class SettPåVent {
         @Test
-        fun `skal feile når behandling settes på vent og oppgave er ferdigstilt`() {
+        fun `skal feile når behandling settes på vent og klagebehandling er ferdigstilt`() {
             mockHentBehandling(BehandlingStatus.FERDIGSTILT)
 
             val feil: ApiFeil = assertThrows { behandlingPåVentService.validerKanSettePåVent(BehandlingStatus.FERDIGSTILT) }
@@ -122,7 +122,7 @@ class BehandlingPåVentServiceTest {
         }
 
         @Test
-        fun `skal feile når man tar behandling av vent og status ikke er SATT_PÅ_VENT`() {
+        fun `skal feile når man tar klagebehandling av vent og status ikke er SATT_PÅ_VENT`() {
             mockHentBehandling(BehandlingStatus.FERDIGSTILT)
 
             val feil: ApiFeil = assertThrows { behandlingPåVentService.validerKanTaAvVent(BehandlingStatus.FERDIGSTILT) }

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingPåVentServiceTest.kt
@@ -1,0 +1,117 @@
+package no.nav.familie.klage.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.klage.behandling.dto.OppgaveDto
+import no.nav.familie.klage.behandlingshistorikk.BehandlingshistorikkService
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.oppgave.OppgaveService
+import no.nav.familie.klage.oppgave.TilordnetRessursService
+import no.nav.familie.klage.testutil.DomainUtil.behandling
+import no.nav.familie.klage.testutil.DomainUtil.fagsak
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
+import no.nav.familie.prosessering.internal.TaskService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.Month
+
+class BehandlingPåVentServiceTest {
+    private val behandlingService = mockk<BehandlingService>(relaxed = true)
+    private val oppgaveService = mockk<OppgaveService>(relaxed = true)
+    private val behandlinghistorikkService = mockk<BehandlingshistorikkService>(relaxed = true)
+    private val taskService = mockk<TaskService>(relaxed = true)
+    private val tilordnetRessursService = mockk<TilordnetRessursService>(relaxed = true)
+
+    private val fagsakEf = fagsak()
+    private val behandling = behandling(fagsakEf)
+    private val behandlingId = behandling.id
+
+    private val behandlingPåVentService = BehandlingPåVentService(
+        behandlingService = behandlingService,
+        oppgaveService = oppgaveService,
+        behandlinghistorikkService = behandlinghistorikkService,
+        taskService = taskService,
+        tilordnetRessursService = tilordnetRessursService,
+    )
+
+    @BeforeEach
+    internal fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(any()) } returns "Ny saksbehandler"
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class TaAvVent {
+        @BeforeEach
+        internal fun setUp() {
+            mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT)
+        }
+
+        @Test
+        internal fun `sett ny saksbehandler oppgave når behandling tas av vent`() {
+            val oppgaveId = 1234567L
+            mockSettSaksbehandlerPåOppgave(oppgaveId)
+
+            behandlingPåVentService.taAvVent(behandlingId)
+
+            verify {
+                behandlingService.oppdaterStatusPåBehandling(
+                    behandlingId = behandlingId,
+                    status = BehandlingStatus.UTREDES,
+                )
+            }
+            verify {
+                oppgaveService.fordelOppgave(
+                    gsakOppgaveId = oppgaveId,
+                    saksbehandler = "Ny saksbehandler",
+                    versjon = any(),
+                )
+            }
+        }
+    }
+
+    private fun mockHentBehandling(
+        behandlingStatus: BehandlingStatus,
+    ) {
+        every { behandlingService.hentBehandling(behandlingId = behandlingId) } returns behandling.copy(status = behandlingStatus)
+    }
+
+    private fun mockSettSaksbehandlerPåOppgave(oppgaveId: Long) {
+        val oppgave = oppgave(oppgaveId)
+        every { tilordnetRessursService.hentOppgave(behandlingId) } returns OppgaveDto(
+            oppgaveId = oppgave.id,
+            tildeltEnhetsnr = oppgave.tildeltEnhetsnr,
+            beskrivelse = oppgave.beskrivelse,
+            tilordnetRessurs = oppgave.tilordnetRessurs ?: "",
+            prioritet = oppgave.prioritet,
+            fristFerdigstillelse = oppgave.fristFerdigstillelse ?: "",
+            mappeId = oppgave.mappeId,
+            versjon = oppgave.versjon,
+        )
+        every { oppgaveService.fordelOppgave(any(), any(), any()) } returns oppgaveId
+    }
+
+    private fun oppgave(oppgaveId: Long) =
+        Oppgave(
+            id = oppgaveId,
+            tildeltEnhetsnr = "4489",
+            tilordnetRessurs = "Saksbehandler",
+            beskrivelse = "Beskrivelse",
+            mappeId = 101,
+            fristFerdigstillelse = LocalDate.of(2025, Month.JANUARY, 1).toString(),
+            prioritet = OppgavePrioritet.NORM,
+        )
+}


### PR DESCRIPTION
# Feature - deliger oppgave til saksbehandler som tar klagebehandling av vent

Denne PRen har som hensikt å addresse et funn fra testing, der den som tar behandlingen av vent blir deligert som ansvarlig saksbehandler.

Denne [PRen](https://github.com/navikt/familie-klage/pull/571) depender på denne [PRen](https://github.com/navikt/familie-klage-frontend/compare/main...feature/vent-oppgave-versjon) (front-end).

Funn fra test og oppgave kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22627).