### PR TITLE
NAV-23920: Legger til ny kode for brevmottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
@@ -1,0 +1,77 @@
+package no.nav.familie.klage.brevmottaker
+
+import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerDto
+import no.nav.familie.klage.brevmottaker.dto.SlettbarBrevmottakerDto
+import no.nav.familie.klage.brevmottaker.dto.tilDomene
+import no.nav.familie.klage.brevmottaker.dto.tilDto
+import no.nav.familie.klage.felles.domain.AuditLoggerEvent
+import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/brevmottaker"])
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class BrevmottakerController(
+    private val brevmottakerService: BrevmottakerService,
+    private val tilgangService: TilgangService,
+) {
+    @GetMapping("/{behandlingId}")
+    fun hentBrevmottakere(
+        @PathVariable behandlingId: UUID,
+    ): Ressurs<BrevmottakereDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
+        val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
+        return Ressurs.success(brevmottakere.tilDto())
+    }
+
+    @PutMapping("/{behandlingId}")
+    fun erstattBrevmottakere(
+        @PathVariable behandlingId: UUID,
+        @RequestBody brevmottakereDto: BrevmottakereDto,
+    ): Ressurs<BrevmottakereDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
+        brevmottakereDto.valider()
+        val nyeBrevmottakere = brevmottakerService.erstattBrevmottakere(behandlingId, brevmottakereDto.tilDomene())
+        return Ressurs.success(nyeBrevmottakere.tilDto())
+    }
+
+    @PostMapping("/{behandlingId}")
+    fun opprettBrevmottaker(
+        @PathVariable behandlingId: UUID,
+        @RequestBody nyBrevmottakerDto: NyBrevmottakerDto,
+    ): Ressurs<BrevmottakereDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.CREATE)
+        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
+        nyBrevmottakerDto.valider()
+        brevmottakerService.opprettBrevmottaker(behandlingId, nyBrevmottakerDto.tilDomene())
+        val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
+        return Ressurs.success(brevmottakere.tilDto())
+    }
+
+    @DeleteMapping("/{behandlingId}")
+    fun slettBrevmottaker(
+        @PathVariable behandlingId: UUID,
+        @RequestBody slettbarBrevmottakerDto: SlettbarBrevmottakerDto,
+    ): Ressurs<BrevmottakereDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.DELETE)
+        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
+        brevmottakerService.slettBrevmottaker(behandlingId, slettbarBrevmottakerDto.tilDomene())
+        val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
+        return Ressurs.success(brevmottakere.tilDto())
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatter.kt
@@ -1,0 +1,65 @@
+package no.nav.familie.klage.brevmottaker
+
+import jakarta.transaction.Transactional
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.repository.findByIdOrThrow
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class BrevmottakerErstatter(
+    private val behandlingService: BehandlingService,
+    private val brevRepository: BrevRepository,
+) {
+    private val logger = LoggerFactory.getLogger(BrevmottakerErstatter::class.java)
+
+    @Transactional
+    fun erstattBrevmottakere(behandlingId: UUID, brevmottakere: Brevmottakere): Brevmottakere {
+        logger.debug("Erstatter brevmottakere for behandling {}.", behandlingId)
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        validerRedigerbarBehandling(behandling)
+        validerKorrektBehandlingssteg(behandling)
+        validerUnikeBrevmottakere(brevmottakere)
+        val eksisterendeBrev = brevRepository.findByIdOrThrow(behandlingId)
+        val oppdatertBrev = brevRepository.update(eksisterendeBrev.copy(mottakere = brevmottakere))
+        return oppdatertBrev.mottakere ?: error("Fant ikke brevmottakere for behandling $behandlingId.")
+    }
+
+    private fun validerRedigerbarBehandling(behandling: Behandling) {
+        if (behandling.status.erLåstForVidereBehandling()) {
+            throw Feil("Behandling ${behandling.id} er låst for videre behandling.")
+        }
+    }
+
+    private fun validerKorrektBehandlingssteg(behandling: Behandling) {
+        if (behandling.steg != StegType.BREV) {
+            throw Feil("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}.")
+        }
+    }
+
+    private fun validerUnikeBrevmottakere(brevmottakere: Brevmottakere) {
+        val personmottakerIdentifikatorer = brevmottakere.personer.map {
+            when (it) {
+                is BrevmottakerPersonMedIdent -> it.personIdent
+                is BrevmottakerPersonUtenIdent -> it.id.toString()
+            }
+        }
+        if (personmottakerIdentifikatorer.distinct().size != personmottakerIdentifikatorer.size) {
+            throw Feil("En person kan bare legges til en gang som brevmottaker.")
+        }
+
+        val organisasjonsmottakerIdenter = brevmottakere.organisasjoner.map { it.organisasjonsnummer }
+        if (organisasjonsmottakerIdenter.distinct().size != organisasjonsmottakerIdenter.size) {
+            throw Feil("En organisasjon kan bare legges til en gang som brevmottaker.")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatter.kt
@@ -47,18 +47,18 @@ class BrevmottakerErstatter(
     }
 
     private fun validerUnikeBrevmottakere(brevmottakere: Brevmottakere) {
-        val personmottakerIdentifikatorer = brevmottakere.personer.map {
+        val personBrevmottakerIdentifikatorer = brevmottakere.personer.map {
             when (it) {
                 is BrevmottakerPersonMedIdent -> it.personIdent
                 is BrevmottakerPersonUtenIdent -> it.id.toString()
             }
         }
-        if (personmottakerIdentifikatorer.distinct().size != personmottakerIdentifikatorer.size) {
+        if (personBrevmottakerIdentifikatorer.distinct().size != personBrevmottakerIdentifikatorer.size) {
             throw Feil("En person kan bare legges til en gang som brevmottaker.")
         }
 
-        val organisasjonsmottakerIdenter = brevmottakere.organisasjoner.map { it.organisasjonsnummer }
-        if (organisasjonsmottakerIdenter.distinct().size != organisasjonsmottakerIdenter.size) {
+        val organisasjonBrevmottakerIdenter = brevmottakere.organisasjoner.map { it.organisasjonsnummer }
+        if (organisasjonBrevmottakerIdenter.distinct().size != organisasjonBrevmottakerIdenter.size) {
             throw Feil("En organisasjon kan bare legges til en gang som brevmottaker.")
         }
     }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerHenter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerHenter.kt
@@ -1,0 +1,20 @@
+package no.nav.familie.klage.brevmottaker
+
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class BrevmottakerHenter(
+    private val brevService: BrevService,
+) {
+    private val logger = LoggerFactory.getLogger(BrevmottakerHenter::class.java)
+
+    fun hentBrevmottakere(behandlingId: UUID): Brevmottakere {
+        logger.debug("Henter brevmottakere for behandling {}.", behandlingId)
+        val brev = brevService.hentBrev(behandlingId)
+        return brev.mottakere ?: Brevmottakere()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretter.kt
@@ -1,0 +1,167 @@
+package no.nav.familie.klage.brevmottaker
+
+import jakarta.transaction.Transactional
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.domain.Brevmottaker
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottaker
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+private val MOTTAKER_ROLLER_HVOR_BRUKER_SKAL_SLETTES_VED_OPPRETTELSE = setOf(
+    MottakerRolle.DØDSBO,
+    MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+)
+
+@Component
+class BrevmottakerOppretter(
+    private val behandlingService: BehandlingService,
+    private val fagsakService: FagsakService,
+    private val brevService: BrevService,
+    private val brevRepository: BrevRepository,
+    private val personopplysningerService: PersonopplysningerService,
+) {
+    private val logger = LoggerFactory.getLogger(BrevmottakerOppretter::class.java)
+
+    @Transactional
+    fun opprettBrevmottaker(
+        behandlingId: UUID,
+        nyBrevmottaker: NyBrevmottaker,
+    ): Brevmottaker {
+        return when (nyBrevmottaker) {
+            is NyBrevmottakerOrganisasjon -> throw UnsupportedOperationException("${nyBrevmottaker::class.simpleName} er ikke støttet.")
+            is NyBrevmottakerPersonMedIdent -> throw UnsupportedOperationException("${nyBrevmottaker::class.simpleName} er ikke støttet.")
+            is NyBrevmottakerPersonUtenIdent -> opprettBrevmottakerPersonUtenIdent(behandlingId, nyBrevmottaker)
+        }
+    }
+
+    private fun opprettBrevmottakerPersonUtenIdent(
+        behandlingId: UUID,
+        nyBrevmottaker: NyBrevmottakerPersonUtenIdent,
+    ): Brevmottaker {
+        logger.debug("Oppretter brevmottaker for behandling {}.", behandlingId)
+
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        validerRedigerbarBehandling(behandling)
+        validerKorrektBehandlingssteg(behandling)
+
+        val brev = brevService.hentBrev(behandlingId)
+        val brevmottakerPersoner = brev.mottakere?.personer ?: emptyList()
+
+        val brevmottakerePersonerUtenIdent = brevmottakerPersoner.filterIsInstance<BrevmottakerPersonUtenIdent>()
+        validerNyBrevmottaker(behandlingId, nyBrevmottaker, brevmottakerePersonerUtenIdent)
+
+        val aktivIdentForFagsak = fagsakService.hentFagsak(behandling.fagsakId).hentAktivIdent()
+
+        val harBrevmottakerPersonBruker = brevmottakerPersoner
+            .filterIsInstance<BrevmottakerPersonMedIdent>()
+            .filter { it.mottakerRolle == MottakerRolle.BRUKER }
+            .any { it.personIdent == aktivIdentForFagsak }
+
+        val skalSletteBrevmottakerPersonBruker = harBrevmottakerPersonBruker &&
+            nyBrevmottaker.mottakerRolle in MOTTAKER_ROLLER_HVOR_BRUKER_SKAL_SLETTES_VED_OPPRETTELSE
+
+        val nyBrevmottakerPersonUtenIdent = BrevmottakerPersonUtenIdent(
+            id = UUID.randomUUID(),
+            mottakerRolle = nyBrevmottaker.mottakerRolle,
+            navn = nyBrevmottaker.navn,
+            adresselinje1 = nyBrevmottaker.adresselinje1,
+            adresselinje2 = nyBrevmottaker.adresselinje2,
+            postnummer = nyBrevmottaker.postnummer,
+            poststed = nyBrevmottaker.poststed,
+            landkode = nyBrevmottaker.landkode,
+        )
+
+        brevRepository.update(
+            brev.copy(
+                mottakere = Brevmottakere(
+                    personer = if (skalSletteBrevmottakerPersonBruker) {
+                        val filtrerteBrevmottakerPersoner = brevmottakerPersoner.filter {
+                            when (it) {
+                                is BrevmottakerPersonMedIdent -> it.personIdent != aktivIdentForFagsak
+                                is BrevmottakerPersonUtenIdent -> true
+                            }
+                        }
+                        filtrerteBrevmottakerPersoner + nyBrevmottakerPersonUtenIdent
+                    } else {
+                        brevmottakerPersoner + nyBrevmottakerPersonUtenIdent
+                    },
+                ),
+            ),
+        )
+
+        return nyBrevmottakerPersonUtenIdent
+    }
+
+    private fun validerRedigerbarBehandling(behandling: Behandling) {
+        if (behandling.status.erLåstForVidereBehandling()) {
+            throw Feil("Behandling ${behandling.id} er låst for videre behandling.")
+        }
+    }
+
+    private fun validerKorrektBehandlingssteg(behandling: Behandling) {
+        if (behandling.steg != StegType.BREV) {
+            throw Feil("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}.")
+        }
+    }
+
+    private fun validerNyBrevmottaker(
+        behandlingId: UUID,
+        nyBrevmottakerPersonUtenIdent: NyBrevmottakerPersonUtenIdent,
+        eksisterendeBrevmottakerePersonerUtenIdent: List<BrevmottakerPersonUtenIdent>,
+    ) {
+        val brukerensNavn = personopplysningerService.hentPersonopplysninger(behandlingId).navn
+        val eksisterendeMottakerRoller = eksisterendeBrevmottakerePersonerUtenIdent.map { it.mottakerRolle }
+        when {
+            eksisterendeMottakerRoller.any { it == nyBrevmottakerPersonUtenIdent.mottakerRolle } -> {
+                throw Feil("Kan ikke ha duplikate MottakerRolle. ${nyBrevmottakerPersonUtenIdent.mottakerRolle} finnes allerede.")
+            }
+
+            nyBrevmottakerPersonUtenIdent.mottakerRolle == MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE &&
+                nyBrevmottakerPersonUtenIdent.navn != brukerensNavn -> {
+                throw Feil("Ved bruker med utenlandsk adresse skal brevmottakerens navn være brukerens navn.")
+            }
+
+            nyBrevmottakerPersonUtenIdent.mottakerRolle == MottakerRolle.DØDSBO &&
+                !nyBrevmottakerPersonUtenIdent.navn.contains(brukerensNavn) -> {
+                throw Feil("Ved dødsbo skal brevmottakerens navn inneholde brukerens navn.")
+            }
+
+            nyBrevmottakerPersonUtenIdent.mottakerRolle == MottakerRolle.DØDSBO &&
+                eksisterendeBrevmottakerePersonerUtenIdent.isNotEmpty() -> {
+                throw Feil("Kan ikke legge til dødsbo når det allerede finnes brevmottakere.")
+            }
+
+            eksisterendeMottakerRoller.any { it == MottakerRolle.DØDSBO } -> {
+                throw Feil("Kan ikke legge til flere brevmottakere når det allerede finnes et dødsbo.")
+            }
+
+            MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE in eksisterendeMottakerRoller &&
+                nyBrevmottakerPersonUtenIdent.mottakerRolle !== MottakerRolle.VERGE &&
+                nyBrevmottakerPersonUtenIdent.mottakerRolle !== MottakerRolle.FULLMAKT -> {
+                throw Feil("Bruker med utenlandsk adresse kan kun kombineres med verge eller fullmektig.")
+            }
+
+            eksisterendeMottakerRoller.isNotEmpty() &&
+                MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE !in eksisterendeMottakerRoller &&
+                nyBrevmottakerPersonUtenIdent.mottakerRolle !== MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE -> {
+                throw Feil("Kan kun legge til bruker med utenlandsk adresse om det finnes en brevmottaker allerede.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerService.kt
@@ -1,0 +1,36 @@
+package no.nav.familie.klage.brevmottaker
+
+import jakarta.transaction.Transactional
+import no.nav.familie.klage.brevmottaker.domain.Brevmottaker
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottaker
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottaker
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class BrevmottakerService(
+    private val brevmottakerHenter: BrevmottakerHenter,
+    private val brevmottakerErstatter: BrevmottakerErstatter,
+    private val brevmottakerOppretter: BrevmottakerOppretter,
+    private val brevmottakerSletter: BrevmottakerSletter,
+) {
+    fun hentBrevmottakere(behandlingId: UUID): Brevmottakere {
+        return brevmottakerHenter.hentBrevmottakere(behandlingId)
+    }
+
+    @Transactional
+    fun erstattBrevmottakere(behandlingId: UUID, brevmottakere: Brevmottakere): Brevmottakere {
+        return brevmottakerErstatter.erstattBrevmottakere(behandlingId, brevmottakere)
+    }
+
+    @Transactional
+    fun opprettBrevmottaker(behandlingId: UUID, nyBrevmottaker: NyBrevmottaker): Brevmottaker {
+        return brevmottakerOppretter.opprettBrevmottaker(behandlingId, nyBrevmottaker)
+    }
+
+    @Transactional
+    fun slettBrevmottaker(behandlingId: UUID, slettbarBrevmottaker: SlettbarBrevmottaker) {
+        brevmottakerSletter.slettBrevmottaker(behandlingId, slettbarBrevmottaker)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerSletter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerSletter.kt
@@ -1,0 +1,118 @@
+package no.nav.familie.klage.brevmottaker
+
+import jakarta.transaction.Transactional
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottaker
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+private val MOTTAKER_ROLLER_HVOR_BRUKER_SKAL_LEGGES_TIL_VED_SLETTING = setOf(
+    MottakerRolle.DØDSBO,
+    MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+)
+
+@Component
+class BrevmottakerSletter(
+    private val behandlingService: BehandlingService,
+    private val brevService: BrevService,
+    private val brevRepository: BrevRepository,
+    private val fagsakService: FagsakService,
+    private val personopplysningerService: PersonopplysningerService,
+) {
+    private val logger = LoggerFactory.getLogger(BrevmottakerSletter::class.java)
+
+    @Transactional
+    fun slettBrevmottaker(behandlingId: UUID, slettbarBrevmottaker: SlettbarBrevmottaker) {
+        return when (slettbarBrevmottaker) {
+            is SlettbarBrevmottakerOrganisasjon -> throw UnsupportedOperationException("Sletting av organisasjon er ikke støttet.")
+            is SlettbarBrevmottakerPersonMedIdent -> throw UnsupportedOperationException("Sletting av person med ident er ikke støttet.")
+            is SlettbarBrevmottakerPersonUtenIdent -> slettBrevmottakerPersonUtenIdent(behandlingId, slettbarBrevmottaker)
+        }
+    }
+
+    private fun slettBrevmottakerPersonUtenIdent(
+        behandlingId: UUID,
+        slettBrevmottakerPersonUtenIdent: SlettbarBrevmottakerPersonUtenIdent,
+    ) {
+        logger.debug("Sletter brevmottaker {} for behandling {}.", slettBrevmottakerPersonUtenIdent.id, behandlingId)
+
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        validerRedigerbarBehandling(behandling)
+        validerKorrektBehandlingssteg(behandling)
+
+        val brev = brevService.hentBrev(behandlingId)
+        val brevmottakerPersoner = (brev.mottakere?.personer ?: emptyList())
+
+        val brevmottakerPersonSomSkalSlettes = brevmottakerPersoner
+            .filterIsInstance<BrevmottakerPersonUtenIdent>()
+            .find { it.id == slettBrevmottakerPersonUtenIdent.id }
+
+        if (brevmottakerPersonSomSkalSlettes == null) {
+            throw Feil("Brevmottaker ${slettBrevmottakerPersonUtenIdent.id} kan ikke slettes da den ikke finnes.")
+        }
+
+        val nyeBrevmottakerPersoner = brevmottakerPersoner.filter {
+            when (it) {
+                is BrevmottakerPersonMedIdent -> true
+                is BrevmottakerPersonUtenIdent -> it.id != slettBrevmottakerPersonUtenIdent.id
+            }
+        }
+
+        val fagsakAktivIdent = fagsakService.hentFagsak(behandling.fagsakId).hentAktivIdent()
+
+        val harBrevmottakerPersonBruker = brevmottakerPersoner
+            .filterIsInstance<BrevmottakerPersonMedIdent>()
+            .filter { it.mottakerRolle == MottakerRolle.BRUKER }
+            .any { it.personIdent == fagsakAktivIdent }
+
+        val skalLeggeTilBrevmottakerPersonBrukerVedSletting = !harBrevmottakerPersonBruker &&
+            MOTTAKER_ROLLER_HVOR_BRUKER_SKAL_LEGGES_TIL_VED_SLETTING.contains(brevmottakerPersonSomSkalSlettes.mottakerRolle)
+
+        val nyeBrevmottakere = Brevmottakere(
+            personer = if (skalLeggeTilBrevmottakerPersonBrukerVedSletting) {
+                val brevmottakerPersonBruker = BrevmottakerPersonMedIdent(
+                    personIdent = fagsakAktivIdent,
+                    navn = personopplysningerService.hentPersonopplysninger(behandlingId).navn,
+                    mottakerRolle = MottakerRolle.BRUKER,
+                )
+                nyeBrevmottakerPersoner + brevmottakerPersonBruker
+            } else {
+                nyeBrevmottakerPersoner
+            },
+        )
+
+        brevRepository.update(
+            brev.copy(
+                mottakere = nyeBrevmottakere,
+            ),
+        )
+    }
+
+    private fun validerRedigerbarBehandling(behandling: Behandling) {
+        if (behandling.status.erLåstForVidereBehandling()) {
+            throw Feil("Behandling ${behandling.id} er låst for videre behandling.")
+        }
+    }
+
+    private fun validerKorrektBehandlingssteg(behandling: Behandling) {
+        if (behandling.steg != StegType.BREV) {
+            throw Feil("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}.")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottaker.kt
@@ -1,0 +1,60 @@
+package no.nav.familie.klage.brevmottaker.domain
+
+private const val LANDKODE_NO = "NO"
+
+sealed interface NyBrevmottaker
+
+data class NyBrevmottakerPersonUtenIdent(
+    val mottakerRolle: MottakerRolle,
+    val navn: String,
+    val adresselinje1: String,
+    val adresselinje2: String? = null,
+    val postnummer: String?,
+    val poststed: String?,
+    val landkode: String,
+) : NyBrevmottaker {
+    init {
+        if (landkode.length != 2) {
+            throw IllegalStateException("Ugyldig landkode: $landkode.")
+        }
+        if (navn.isBlank()) {
+            throw IllegalStateException("Navn kan ikke være tomt.")
+        }
+        if (adresselinje1.isBlank()) {
+            throw IllegalStateException("Adresselinje1 kan ikke være tomt.")
+        }
+        if (landkode == LANDKODE_NO) {
+            if (postnummer.isNullOrBlank()) {
+                throw IllegalStateException("Når landkode er $LANDKODE_NO (Norge) må postnummer være satt.")
+            }
+            if (poststed.isNullOrBlank()) {
+                throw IllegalStateException("Når landkode er $LANDKODE_NO (Norge) må poststed være satt.")
+            }
+            if (postnummer.length != 4 || !postnummer.all { it.isDigit() }) {
+                throw IllegalStateException("Postnummer må være 4 siffer.")
+            }
+            if (mottakerRolle == MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE) {
+                throw IllegalStateException("Bruker med utenlandsk adresse kan ikke ha landkode $LANDKODE_NO.")
+            }
+        } else {
+            if (!postnummer.isNullOrBlank()) {
+                throw IllegalStateException("Ved utenlandsk landkode må postnummer settes i adresselinje 1.")
+            }
+            if (!poststed.isNullOrBlank()) {
+                throw IllegalStateException("Ved utenlandsk landkode må poststed settes i adresselinje 1.")
+            }
+        }
+    }
+}
+
+data class NyBrevmottakerPersonMedIdent(
+    val personIdent: String,
+    val mottakerRolle: MottakerRolle,
+    val navn: String,
+) : NyBrevmottaker
+
+data class NyBrevmottakerOrganisasjon(
+    val organisasjonsnummer: String,
+    val organisasjonsnavn: String,
+    val navnHosOrganisasjon: String,
+) : NyBrevmottaker

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/SlettbarBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/SlettbarBrevmottaker.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.klage.brevmottaker.domain
+
+import java.util.UUID
+
+sealed interface SlettbarBrevmottaker
+data class SlettbarBrevmottakerPersonUtenIdent(val id: UUID) : SlettbarBrevmottaker
+data class SlettbarBrevmottakerPersonMedIdent(val personIdent: String) : SlettbarBrevmottaker
+data class SlettbarBrevmottakerOrganisasjon(val organisasjonsnummer: String) : SlettbarBrevmottaker

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/BrevmottakereDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/BrevmottakereDto.kt
@@ -2,12 +2,36 @@ package no.nav.familie.klage.brevmottaker.dto
 
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerOrganisasjon
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPerson
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
 
 data class BrevmottakereDto(
     val personer: List<BrevmottakerPerson>,
     val organisasjoner: List<BrevmottakerOrganisasjon>,
-)
+) {
+    fun valider() {
+        if (personer.isEmpty() && organisasjoner.isEmpty()) {
+            throw ApiFeil.badRequest("Må ha minimum en brevmottaker.")
+        }
+
+        val personmottakerIdentifikatorer = personer.map {
+            when (it) {
+                is BrevmottakerPersonMedIdent -> it.personIdent
+                is BrevmottakerPersonUtenIdent -> it.id.toString()
+            }
+        }
+        if (personmottakerIdentifikatorer.distinct().size != personmottakerIdentifikatorer.size) {
+            throw ApiFeil.badRequest("En person kan bare legges til en gang som brevmottaker.")
+        }
+
+        val organisasjonsmottakerIdenter = organisasjoner.map { it.organisasjonsnummer }
+        if (organisasjonsmottakerIdenter.distinct().size != organisasjonsmottakerIdenter.size) {
+            throw ApiFeil.badRequest("En organisasjon kan bare legges til en gang som brevmottaker.")
+        }
+    }
+}
 
 fun Brevmottakere.tilDto() = BrevmottakereDto(
     personer = this.personer,

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDto.kt
@@ -1,0 +1,164 @@
+package no.nav.familie.klage.brevmottaker.dto
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottaker
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+
+private const val LANDKODE_NO = "NO"
+
+@JsonDeserialize(using = NyBrevmottakerDtoDeserializer::class)
+sealed interface NyBrevmottakerDto {
+    val type: Type
+
+    fun valider()
+
+    enum class Type {
+        PERSON_MED_IDENT,
+        PERSON_UTEN_IDENT,
+        ORGANISASJON,
+    }
+}
+
+fun NyBrevmottakerDto.tilDomene(): NyBrevmottaker {
+    return when (this) {
+        is NyBrevmottakerOrganisasjonDto -> {
+            NyBrevmottakerOrganisasjon(
+                organisasjonsnummer = organisasjonsnummer,
+                organisasjonsnavn = organisasjonsnavn,
+                navnHosOrganisasjon = navnHosOrganisasjon,
+            )
+        }
+
+        is NyBrevmottakerPersonMedIdentDto -> {
+            NyBrevmottakerPersonMedIdent(
+                personIdent = personIdent,
+                mottakerRolle = mottakerRolle,
+                navn = navn,
+            )
+        }
+
+        is NyBrevmottakerPersonUtenIdentDto -> {
+            NyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = navn,
+                adresselinje1 = adresselinje1,
+                adresselinje2 = adresselinje2,
+                postnummer = postnummer,
+                poststed = poststed,
+                landkode = landkode,
+            )
+        }
+    }
+}
+
+@JsonDeserialize(`as` = NyBrevmottakerPersonUtenIdentDto::class)
+data class NyBrevmottakerPersonUtenIdentDto(
+    val mottakerRolle: MottakerRolle,
+    val navn: String,
+    val adresselinje1: String,
+    val adresselinje2: String?,
+    val postnummer: String?,
+    val poststed: String?,
+    val landkode: String,
+) : NyBrevmottakerDto {
+    override val type: NyBrevmottakerDto.Type
+        get() = NyBrevmottakerDto.Type.PERSON_UTEN_IDENT
+
+    override fun valider() {
+        if (mottakerRolle == MottakerRolle.BRUKER) {
+            throw ApiFeil.badRequest("Det er ikke mulig å sette ${MottakerRolle.BRUKER} for saksbehandler.")
+        }
+        if (landkode.length != 2) {
+            throw ApiFeil.badRequest("Ugyldig landkode: $landkode.")
+        }
+        if (navn.isBlank()) {
+            throw ApiFeil.badRequest("Navn kan ikke være tomt.")
+        }
+        if (adresselinje1.isBlank()) {
+            throw ApiFeil.badRequest("Adresselinje 1 kan ikke være tomt.")
+        }
+        if (landkode == LANDKODE_NO) {
+            if (postnummer.isNullOrBlank()) {
+                throw ApiFeil.badRequest("Når landkode er $LANDKODE_NO (Norge) må postnummer være satt.")
+            }
+            if (poststed.isNullOrBlank()) {
+                throw ApiFeil.badRequest("Når landkode er $LANDKODE_NO (Norge) må poststed være satt.")
+            }
+            if (postnummer.length != 4 || !postnummer.all { it.isDigit() }) {
+                throw ApiFeil.badRequest("Postnummer må være 4 siffer.")
+            }
+            if (mottakerRolle == MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE) {
+                throw ApiFeil.badRequest("Bruker med utenlandsk adresse kan ikke ha landkode $LANDKODE_NO.")
+            }
+        } else {
+            if (!postnummer.isNullOrBlank()) {
+                throw ApiFeil.badRequest("Ved utenlandsk landkode må postnummer settes i adresselinje 1.")
+            }
+            if (!poststed.isNullOrBlank()) {
+                throw ApiFeil.badRequest("Ved utenlandsk landkode må poststed settes i adresselinje 1.")
+            }
+        }
+    }
+}
+
+@JsonDeserialize(`as` = NyBrevmottakerPersonMedIdentDto::class)
+data class NyBrevmottakerPersonMedIdentDto(
+    val personIdent: String,
+    val mottakerRolle: MottakerRolle,
+    val navn: String,
+) : NyBrevmottakerDto {
+    override val type: NyBrevmottakerDto.Type
+        get() = NyBrevmottakerDto.Type.PERSON_MED_IDENT
+
+    override fun valider() {
+        if (mottakerRolle == MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE) {
+            throw ApiFeil.badRequest("Person med ident kan ikke være ${MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE}")
+        }
+    }
+}
+
+@JsonDeserialize(`as` = NyBrevmottakerOrganisasjonDto::class)
+data class NyBrevmottakerOrganisasjonDto(
+    val organisasjonsnummer: String,
+    val organisasjonsnavn: String,
+    val navnHosOrganisasjon: String,
+) : NyBrevmottakerDto {
+    override val type: NyBrevmottakerDto.Type
+        get() = NyBrevmottakerDto.Type.ORGANISASJON
+
+    override fun valider() {
+        // Do nothing...
+    }
+}
+
+class NyBrevmottakerDtoDeserializer : JsonDeserializer<NyBrevmottakerDto>() {
+    override fun deserialize(jsonParser: JsonParser, context: DeserializationContext): NyBrevmottakerDto {
+        val tree = jsonParser.readValueAsTree<JsonNode>()
+        val type = NyBrevmottakerDto.Type.valueOf(tree.get("type").asText())
+        return when (type) {
+            NyBrevmottakerDto.Type.PERSON_MED_IDENT -> objectMapper.treeToValue(
+                tree,
+                NyBrevmottakerPersonMedIdentDto::class.java,
+            )
+
+            NyBrevmottakerDto.Type.PERSON_UTEN_IDENT -> objectMapper.treeToValue(
+                tree,
+                NyBrevmottakerPersonUtenIdentDto::class.java,
+            )
+
+            NyBrevmottakerDto.Type.ORGANISASJON -> objectMapper.treeToValue(
+                tree,
+                NyBrevmottakerOrganisasjonDto::class.java,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDto.kt
@@ -1,0 +1,73 @@
+package no.nav.familie.klage.brevmottaker.dto
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottaker
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
+import java.util.UUID
+
+@JsonDeserialize(using = SlettBrevmottakerDtoDeserializer::class)
+sealed interface SlettbarBrevmottakerDto {
+    val type: Type
+
+    enum class Type {
+        PERSON_MED_IDENT,
+        PERSON_UTEN_IDENT,
+        ORGANISASJON,
+    }
+}
+
+fun SlettbarBrevmottakerDto.tilDomene(): SlettbarBrevmottaker {
+    return when (this) {
+        is SlettbarBrevmottakerOrganisasjonDto -> SlettbarBrevmottakerOrganisasjon(organisasjonsnummer)
+        is SlettbarBrevmottakerPersonMedIdentDto -> SlettbarBrevmottakerPersonMedIdent(personIdent)
+        is SlettbarBrevmottakerPersonUtenIdentDto -> SlettbarBrevmottakerPersonUtenIdent(id)
+    }
+}
+
+@JsonDeserialize(`as` = SlettbarBrevmottakerPersonUtenIdentDto::class)
+data class SlettbarBrevmottakerPersonUtenIdentDto(val id: UUID) : SlettbarBrevmottakerDto {
+    override val type: SlettbarBrevmottakerDto.Type
+        get() = SlettbarBrevmottakerDto.Type.PERSON_UTEN_IDENT
+}
+
+@JsonDeserialize(`as` = SlettbarBrevmottakerPersonMedIdentDto::class)
+data class SlettbarBrevmottakerPersonMedIdentDto(val personIdent: String) : SlettbarBrevmottakerDto {
+    override val type: SlettbarBrevmottakerDto.Type
+        get() = SlettbarBrevmottakerDto.Type.PERSON_MED_IDENT
+}
+
+@JsonDeserialize(`as` = SlettbarBrevmottakerOrganisasjonDto::class)
+data class SlettbarBrevmottakerOrganisasjonDto(val organisasjonsnummer: String) : SlettbarBrevmottakerDto {
+    override val type: SlettbarBrevmottakerDto.Type
+        get() = SlettbarBrevmottakerDto.Type.ORGANISASJON
+}
+
+class SlettBrevmottakerDtoDeserializer : JsonDeserializer<SlettbarBrevmottakerDto>() {
+    override fun deserialize(jsonParser: JsonParser, context: DeserializationContext): SlettbarBrevmottakerDto {
+        val tree = jsonParser.readValueAsTree<JsonNode>()
+        val type = SlettbarBrevmottakerDto.Type.valueOf(tree.get("type").asText())
+        return when (type) {
+            SlettbarBrevmottakerDto.Type.PERSON_MED_IDENT -> objectMapper.treeToValue(
+                tree,
+                SlettbarBrevmottakerPersonMedIdentDto::class.java,
+            )
+
+            SlettbarBrevmottakerDto.Type.PERSON_UTEN_IDENT -> objectMapper.treeToValue(
+                tree,
+                SlettbarBrevmottakerPersonUtenIdentDto::class.java,
+            )
+
+            SlettbarBrevmottakerDto.Type.ORGANISASJON -> objectMapper.treeToValue(
+                tree,
+                SlettbarBrevmottakerOrganisasjonDto::class.java,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDto.kt
@@ -12,7 +12,7 @@ import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenId
 import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
 import java.util.UUID
 
-@JsonDeserialize(using = SlettBrevmottakerDtoDeserializer::class)
+@JsonDeserialize(using = SlettbarBrevmottakerDtoDeserializer::class)
 sealed interface SlettbarBrevmottakerDto {
     val type: Type
 
@@ -49,7 +49,7 @@ data class SlettbarBrevmottakerOrganisasjonDto(val organisasjonsnummer: String) 
         get() = SlettbarBrevmottakerDto.Type.ORGANISASJON
 }
 
-class SlettBrevmottakerDtoDeserializer : JsonDeserializer<SlettbarBrevmottakerDto>() {
+class SlettbarBrevmottakerDtoDeserializer : JsonDeserializer<SlettbarBrevmottakerDto>() {
     override fun deserialize(jsonParser: JsonParser, context: DeserializationContext): SlettbarBrevmottakerDto {
         val tree = jsonParser.readValueAsTree<JsonNode>()
         val type = SlettbarBrevmottakerDto.Type.valueOf(tree.get("type").asText())

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerControllerTest.kt
@@ -1,0 +1,552 @@
+package no.nav.familie.klage.brevmottaker
+
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerDto
+import no.nav.familie.klage.brevmottaker.dto.SlettbarBrevmottakerDto
+import no.nav.familie.klage.fagsak.domain.FagsakPerson
+import no.nav.familie.klage.fagsak.domain.PersonIdent
+import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
+import no.nav.familie.klage.infrastruktur.config.RolleConfig
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.klage.testutil.DomainUtil.behandling
+import no.nav.familie.klage.testutil.DtoTestUtil
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var brevRepository: BrevRepository
+
+    @Autowired
+    private lateinit var rolleConfig: RolleConfig
+
+    private val baseUrl = "/api/brevmottaker"
+
+    @Nested
+    inner class HentBrevmottakereTest {
+        @Test
+        fun `skal returnere 403 forbidden når man ikke har tilgang til personen med relasjoner for behandlingen`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(
+                    stønadstype = Stønadstype.BARNETRYGD,
+                    person = FagsakPerson(
+                        identer = setOf(
+                            PersonIdent(".*ikkeTilgang.*"),
+                        ),
+                    ),
+                ),
+            )
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.GET,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo(
+                "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
+            )
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
+                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+            )
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når token ikke har påkrevd role`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = "ukjent"))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.GET,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo("Bruker har ikke tilgang til saksbehandlingsløsningen")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Du mangler tilgang til denne saksbehandlingsløsningen")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal hente brevmottakere`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    brevmottakerPersonMedIdent,
+                    brevmottakerPersonUtenIdent,
+                ),
+            )
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = brevmottakere)
+            brevRepository.insert(brev)
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.GET,
+                HttpEntity<Void>(null, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.data?.organisasjoner).isEmpty()
+            assertThat(exchange.body?.data?.personer).hasSize(2)
+            assertThat(exchange.body?.data?.personer?.filterIsInstance<BrevmottakerPersonMedIdent>()).anySatisfy {
+                assertThat(it.personIdent).isEqualTo(brevmottakerPersonMedIdent.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonMedIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonMedIdent.navn)
+            }
+            assertThat(exchange.body?.data?.personer?.filterIsInstance<BrevmottakerPersonUtenIdent>()).anySatisfy {
+                assertThat(it.id).isEqualTo(brevmottakerPersonUtenIdent.id)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(brevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(brevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(brevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(brevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(brevmottakerPersonUtenIdent.landkode)
+            }
+        }
+    }
+
+    @Nested
+    inner class ErstattBrevmottakereTest {
+        @Test
+        fun `skal returnere 403 forbidden når man ikke har tilgang til personen med relasjoner for behandlingen`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(
+                    stønadstype = Stønadstype.BARNETRYGD,
+                    person = FagsakPerson(
+                        identer = setOf(
+                            PersonIdent(".*ikkeTilgang.*"),
+                        ),
+                    ),
+                ),
+            )
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            val brevmottakereDto = BrevmottakereDto(
+                personer = listOf(DomainUtil.lagBrevmottakerPersonMedIdent()),
+                organisasjoner = emptyList(),
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.PUT,
+                HttpEntity<BrevmottakereDto>(brevmottakereDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo(
+                "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
+            )
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
+                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+            )
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når token ikke har påkrevd role`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = "ukjent"))
+
+            val brevmottakereDto = BrevmottakereDto(
+                personer = listOf(DomainUtil.lagBrevmottakerPersonMedIdent()),
+                organisasjoner = emptyList(),
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.PUT,
+                HttpEntity<BrevmottakereDto>(brevmottakereDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo("Bruker har ikke tilgang til saksbehandlingsløsningen")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Du mangler tilgang til denne saksbehandlingsløsningen")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal retunere 400 Bad Request når dtoen ikke er gyldig`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            val brevmottakereDto = BrevmottakereDto(
+                personer = emptyList(),
+                organisasjoner = emptyList(),
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.PUT,
+                HttpEntity<BrevmottakereDto>(brevmottakereDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.FUNKSJONELL_FEIL)
+            assertThat(exchange.body?.melding).isEqualTo("Må ha minimum en brevmottaker.")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Må ha minimum en brevmottaker.")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal erstatte brevmottaker`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak = fagsak, steg = StegType.BREV))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            val gammelBrevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(gammelBrevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = brevmottakere)
+            brevRepository.insert(brev)
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent(
+                personIdent = "123",
+                mottakerRolle = MottakerRolle.BRUKER,
+                navn = "Navn Etternavn",
+            )
+            val brevmottakerOrganisasjon = DomainUtil.lagBrevmottakerOrganisasjon(
+                organisasjonsnummer = "321",
+                organisasjonsnavn = "Orgnavn",
+                navnHosOrganisasjon = "OG",
+            )
+            val brevmottakereDto = BrevmottakereDto(
+                personer = listOf(brevmottakerPersonMedIdent),
+                organisasjoner = listOf(brevmottakerOrganisasjon),
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.PUT,
+                HttpEntity<BrevmottakereDto>(brevmottakereDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.data?.personer).hasSize(1)
+            assertThat(exchange.body?.data?.personer?.filterIsInstance<BrevmottakerPersonMedIdent>()).anySatisfy {
+                assertThat(it.personIdent).isEqualTo(brevmottakerPersonMedIdent.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonMedIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonMedIdent.navn)
+            }
+            assertThat(exchange.body?.data?.organisasjoner).hasSize(1)
+            assertThat(exchange.body?.data?.organisasjoner).anySatisfy {
+                assertThat(it.organisasjonsnummer).isEqualTo(brevmottakerOrganisasjon.organisasjonsnummer)
+                assertThat(it.organisasjonsnavn).isEqualTo(brevmottakerOrganisasjon.organisasjonsnavn)
+                assertThat(it.navnHosOrganisasjon).isEqualTo(brevmottakerOrganisasjon.navnHosOrganisasjon)
+            }
+        }
+    }
+
+    @Nested
+    inner class OpprettBrevmottakereTest {
+        @Test
+        fun `skal returnere 403 forbidden når man ikke har tilgang til personen med relasjoner for behandlingen`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(
+                    stønadstype = Stønadstype.BARNETRYGD,
+                    person = FagsakPerson(
+                        identer = setOf(
+                            PersonIdent(".*ikkeTilgang.*"),
+                        ),
+                    ),
+                ),
+            )
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto()
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<NyBrevmottakerDto>(nyBrevmottakerDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo("Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
+                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+            )
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når token ikke har påkrevd role`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.veileder))
+
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto()
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<NyBrevmottakerDto>(nyBrevmottakerDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo(
+                "Saksbehandler julenissen har ikke tilgang til å utføre denne operasjonen som krever minimumsrolle SAKSBEHANDLER",
+            )
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Mangler nødvendig saksbehandlerrolle for å utføre handlingen")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal retunere 400 Bad Request når dtoen ikke er gyldig`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "Fornavn mellomnavn Etternavn",
+                adresselinje1 = "Marsveien 1, X771, Mars",
+                postnummer = "10",
+                poststed = "Mars",
+                landkode = "NO",
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<NyBrevmottakerDto>(nyBrevmottakerDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.FUNKSJONELL_FEIL)
+            assertThat(exchange.body?.melding).isEqualTo("Postnummer må være 4 siffer.")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Postnummer må være 4 siffer.")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal opprette brevmottaker`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak = fagsak, steg = StegType.BREV))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = brevmottakere)
+            brevRepository.insert(brev)
+
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "Fornavn mellomnavn Etternavn",
+                adresselinje1 = "Marsveien 1, X771, Mars",
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.POST,
+                HttpEntity<NyBrevmottakerDto>(nyBrevmottakerDto, headers),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.data?.organisasjoner).isEmpty()
+            assertThat(exchange.body?.data?.personer).hasSize(2)
+            assertThat(exchange.body?.data?.personer?.filterIsInstance<BrevmottakerPersonMedIdent>()).anySatisfy {
+                assertThat(it.personIdent).isEqualTo(brevmottakerPersonMedIdent.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonMedIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonMedIdent.navn)
+            }
+            assertThat(exchange.body?.data?.personer?.filterIsInstance<BrevmottakerPersonUtenIdent>()).anySatisfy {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerDto.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerDto.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerDto.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerDto.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerDto.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerDto.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerDto.landkode)
+            }
+        }
+    }
+
+    @Nested
+    inner class SlettBrevmottakereTest {
+        @Test
+        fun `skal returnere 403 forbidden når man ikke har tilgang til personen med relasjoner for behandlingen`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(
+                DomainUtil.fagsak(
+                    stønadstype = Stønadstype.BARNETRYGD,
+                    person = FagsakPerson(
+                        identer = setOf(
+                            PersonIdent(".*ikkeTilgang.*"),
+                        ),
+                    ),
+                ),
+            )
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.DELETE,
+                HttpEntity<SlettbarBrevmottakerDto>(
+                    DtoTestUtil.lagSlettbarBrevmottakerPersonUtenIdentDto(UUID.randomUUID()),
+                    headers,
+                ),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo(
+                "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
+            )
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
+                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+            )
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal returnere 403 forbidden når token ikke har påkrevd role`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
+            headers.setBearerAuth(onBehalfOfToken(role = "ukjent"))
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.DELETE,
+                HttpEntity<SlettbarBrevmottakerDto>(
+                    DtoTestUtil.lagSlettbarBrevmottakerPersonUtenIdentDto(UUID.randomUUID()),
+                    headers,
+                ),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+            assertThat(exchange.body?.melding).isEqualTo("Bruker har ikke tilgang til saksbehandlingsløsningen")
+            assertThat(exchange.body?.frontendFeilmelding).isEqualTo("Du mangler tilgang til denne saksbehandlingsløsningen")
+            assertThat(exchange.body?.data).isNull()
+        }
+
+        @Test
+        fun `skal slette brevmottaker`() {
+            // Arrange
+            val fagsak = testoppsettService.lagreFagsak(DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD))
+            val behandling = testoppsettService.lagreBehandling(behandling(fagsak = fagsak, steg = StegType.BREV))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.ba.saksbehandler))
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    brevmottakerPersonMedIdent,
+                    brevmottakerPersonUtenIdent,
+                ),
+            )
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = brevmottakere)
+            brevRepository.insert(brev)
+
+            // Act
+            val exchange = restTemplate.exchange<Ressurs<BrevmottakereDto>>(
+                localhost("$baseUrl/${behandling.id}"),
+                HttpMethod.DELETE,
+                HttpEntity<SlettbarBrevmottakerDto>(
+                    DtoTestUtil.lagSlettbarBrevmottakerPersonUtenIdentDto(brevmottakerPersonUtenIdent.id),
+                    headers,
+                ),
+            )
+
+            // Assert
+            assertThat(exchange.statusCode).isEqualTo(HttpStatus.OK)
+            assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.SUKSESS)
+            assertThat(exchange.body?.melding).isEqualTo("Innhenting av data var vellykket")
+            assertThat(exchange.body?.frontendFeilmelding).isNull()
+            assertThat(exchange.body?.data?.organisasjoner).isEmpty()
+            assertThat(exchange.body?.data?.personer).hasSize(1)
+            assertThat(exchange.body?.data?.personer?.filterIsInstance<BrevmottakerPersonMedIdent>()).anySatisfy {
+                assertThat(it.personIdent).isEqualTo(brevmottakerPersonMedIdent.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonMedIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonMedIdent.navn)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatterTest.kt
@@ -1,0 +1,227 @@
+package no.nav.familie.klage.brevmottaker
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.repository.findByIdOrThrow
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class BrevmottakerErstatterTest {
+    private val behandlingService: BehandlingService = mockk()
+    private val brevRepository: BrevRepository = mockk()
+    private val brevmottakerErstatter: BrevmottakerErstatter = BrevmottakerErstatter(
+        behandlingService = behandlingService,
+        brevRepository = brevRepository,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(any()) } returns "saksbehandler"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class ErstattBrevmottakereTest {
+        @Test
+        fun `skal kaste exception om behandling er låst for videre redigering`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(status = BehandlingStatus.FERDIGSTILT)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("Behandling ${behandling.id} er låst for videre behandling.")
+        }
+
+        @Test
+        fun `skal kaste exception om behandling ikke er i brev steg`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.OPPRETTET)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen er i steg ${StegType.OPPRETTET}, forventet steg ${StegType.BREV}.")
+        }
+
+        @Test
+        fun `skal kaste exception det er duplikate identer for person med ident`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                ),
+            )
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste exception det er duplikate ider for person uten ident`() {
+            // Arrange
+            val id = UUID.randomUUID()
+
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonUtenIdent(id = id),
+                    DomainUtil.lagBrevmottakerPersonUtenIdent(id = id),
+                ),
+            )
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste exception det er et duplikat orgnr for organisasjoner`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                organisasjoner = listOf(
+                    DomainUtil.lagBrevmottakerOrganisasjon(organisasjonsnummer = "123"),
+                    DomainUtil.lagBrevmottakerOrganisasjon(organisasjonsnummer = "123"),
+                ),
+            )
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("En organisasjon kan bare legges til en gang som brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste exception om brev ikke finnes`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                brevRepository.findByIdOrThrow(behandling.id)
+            } throws IllegalStateException("Ops! Noe gikk galt...")
+
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("Ops! Noe gikk galt...")
+        }
+
+        @Test
+        fun `skal kaste exception om brevmottakerne for brevet ikke finnes`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            val brev = DomainUtil.lagBrev(mottakere = null)
+
+            every {
+                brevRepository.findByIdOrThrow(behandling.id)
+            } returns brev
+
+            every {
+                brevRepository.update(any())
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("Fant ikke brevmottakere for behandling ${behandling.id}.")
+        }
+
+        @Test
+        fun `skal kaste erstatte brevmottakere`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                brevRepository.findByIdOrThrow(behandling.id)
+            } returns DomainUtil.lagBrev(mottakere = null)
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottakere = brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+
+            // Act & assert
+            assertThat(brevmottakere).isEqualTo(nyeBrevmottakere)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerHenterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerHenterTest.kt
@@ -1,0 +1,76 @@
+package no.nav.familie.klage.brevmottaker
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BrevmottakerHenterTest {
+    private val brevService: BrevService = mockk()
+    private val brevmottakerHenter: BrevmottakerHenter = BrevmottakerHenter(brevService)
+
+    @Nested
+    inner class HentBrevmottakereTest {
+        @Test
+        fun `skal håndtere at brevmottakere på brev er null`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val brev = DomainUtil.lagBrev(behandlingId = behandlingId, mottakere = null)
+
+            every { brevService.hentBrev(behandlingId) } returns brev
+
+            // Act
+            val brevmottakere = brevmottakerHenter.hentBrevmottakere(behandlingId)
+
+            // Assert
+            assertThat(brevmottakere.organisasjoner).isEmpty()
+            assertThat(brevmottakere.personer).isEmpty()
+        }
+
+        @Test
+        fun `skal hente brevmottaker`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    brevmottakerPersonMedIdent,
+                    brevmottakerPersonUtenIdent,
+                ),
+            )
+            val brev = DomainUtil.lagBrev(behandlingId = behandlingId, mottakere = brevmottakere)
+
+            every { brevService.hentBrev(behandlingId) } returns brev
+
+            // Act
+            val hentetBrevmottakere = brevmottakerHenter.hentBrevmottakere(behandlingId)
+
+            // Assert
+            assertThat(hentetBrevmottakere.organisasjoner).isEmpty()
+            assertThat(hentetBrevmottakere.personer).hasSize(2)
+            assertThat(hentetBrevmottakere.personer.filterIsInstance<BrevmottakerPersonMedIdent>()).anySatisfy {
+                assertThat(it.personIdent).isEqualTo(brevmottakerPersonMedIdent.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonMedIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonMedIdent.navn)
+            }
+            assertThat(hentetBrevmottakere.personer.filterIsInstance<BrevmottakerPersonUtenIdent>()).anySatisfy {
+                assertThat(it.id).isEqualTo(brevmottakerPersonUtenIdent.id)
+                assertThat(it.mottakerRolle).isEqualTo(brevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(brevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(brevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(brevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(brevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(brevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(brevmottakerPersonUtenIdent.landkode)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretterTest.kt
@@ -1,0 +1,958 @@
+package no.nav.familie.klage.brevmottaker
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brev.domain.Brev
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.fagsak.domain.PersonIdent
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class BrevmottakerOppretterTest {
+    private val behandlingService: BehandlingService = mockk()
+    private val fagsakService: FagsakService = mockk()
+    private val brevService: BrevService = mockk()
+    private val brevRepository: BrevRepository = mockk()
+    private val personopplysningerService: PersonopplysningerService = mockk()
+
+    private val brevmottakerOppretter: BrevmottakerOppretter = BrevmottakerOppretter(
+        behandlingService = behandlingService,
+        fagsakService = fagsakService,
+        brevService = brevService,
+        brevRepository = brevRepository,
+        personopplysningerService = personopplysningerService,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(any()) } returns "saksbehandler"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class OpprettBrevmottakerTest {
+        @Test
+        fun `skal kaste exception om man prøver å opprette for NyBrevmottakerOrganisasjon`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(status = BehandlingStatus.FERDIGSTILT)
+
+            val nyBrevmottakerOrganisasjon = DomainUtil.lagNyBrevmottakerOrganisasjon()
+
+            // Act & assert
+            val exception = assertThrows<UnsupportedOperationException> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerOrganisasjon)
+            }
+            assertThat(exception.message).isEqualTo("NyBrevmottakerOrganisasjon er ikke støttet.")
+        }
+
+        @Test
+        fun `skal kaste exception om man prøver å opprette for NyBrevmottakerPersonMedIdent`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(status = BehandlingStatus.FERDIGSTILT)
+
+            val nyBrevmottakerPersonMedIdent = DomainUtil.lagNyBrevmottakerPersonMedIdent()
+
+            // Act & assert
+            val exception = assertThrows<UnsupportedOperationException> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonMedIdent)
+            }
+            assertThat(exception.message).isEqualTo("NyBrevmottakerPersonMedIdent er ikke støttet.")
+        }
+
+        @Test
+        fun `skal kaste exception om behandling ikke er redigerbar`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(status = BehandlingStatus.FERDIGSTILT)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Behandling ${behandling.id} er låst for videre behandling.")
+        }
+
+        @Test
+        fun `skal kaste exception om behandling ikke er i brev steg`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.OPPRETTET)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen er i steg ${StegType.OPPRETTET}, forventet steg ${StegType.BREV}.")
+        }
+
+        @Test
+        fun `skal kaste exception om det allerede finnes en brevmottaker med samme MottakerRolle`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+                navn = "navn",
+                adresselinje1 = "adresse1",
+                adresselinje2 = "adresse2",
+                postnummer = "0010",
+                poststed = "Oslo",
+                landkode = "NO",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Kan ikke ha duplikate MottakerRolle. FULLMAKT finnes allerede.")
+        }
+
+        @Test
+        fun `skal kaste exception om bruker med utenlandsk adresse ikke har samme navn som i personopplysningene`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = "et annet navn")
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Ved bruker med utenlandsk adresse skal brevmottakerens navn være brukerens navn.")
+        }
+
+        @Test
+        fun `skal kaste exception om dødsbo ikke har samme navn som i personopplysningene`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.DØDSBO,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = "et annet navn")
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Ved dødsbo skal brevmottakerens navn inneholde brukerens navn.")
+        }
+
+        @Test
+        fun `skal kaste exception om man prøver å legge til dødsbo når det allerede finnes en brevmottaker`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.DØDSBO,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Kan ikke legge til dødsbo når det allerede finnes brevmottakere.")
+        }
+
+        @Test
+        fun `skal kaste exception om man prøver å legge til en brevmottaker når det allerede finnes en dødsbo brevmottaker`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.DØDSBO,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Kan ikke legge til flere brevmottakere når det allerede finnes et dødsbo.")
+        }
+
+        @Test
+        fun `skal kaste exception om man prøver å legge til en brevmottaker som ikke er VERGE eller FULLMEKTIG når det allerede finnes en brevmottaker med utenlandsk adresse`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo("Bruker med utenlandsk adresse kan kun kombineres med verge eller fullmektig.")
+        }
+
+        @Test
+        fun `skal kaste exception om man prøver å legge til en brevmottaker som ikke har mottakertype bruker med utenlandsk adresse om det allerede finnes en brevmottaker`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
+            }
+            assertThat(exception.message).isEqualTo(
+                "Kan kun legge til bruker med utenlandsk adresse om det finnes en brevmottaker allerede.",
+            )
+        }
+
+        @EnumSource(value = MottakerRolle::class)
+        @ParameterizedTest
+        fun `skal opprette brevmottaker når det allerede finnes brevmottakere`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(PersonIdent("01010199999")))
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+
+        @EnumSource(value = MottakerRolle::class)
+        @ParameterizedTest
+        fun `skal opprette brevmottaker når brevmottakere i brev er null`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brev = DomainUtil.lagBrev(mottakere = null)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(PersonIdent("01010199999")))
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+
+        @EnumSource(value = MottakerRolle::class)
+        @ParameterizedTest
+        fun `skal opprette brevmottaker når brevmottakere i brev er tom`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brev = DomainUtil.lagBrev(mottakere = DomainUtil.lagBrevmottakere(personer = emptyList()))
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(PersonIdent("01010199999")))
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["BRUKER_MED_UTENLANDSK_ADRESSE", "DØDSBO"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal opprette brevmottaker selv om personopplysningsnavnet er forskjellig for mottakertyper som ikke skal være preutfylt`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = "ikke samme navn")
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(PersonIdent("01010199999")))
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["VERGE", "FULLMAKT"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal opprette brevmottaker som kan kombineres med en allerede eksisterende brevmottaker med MottakeRrolle bruker med utenlandsk adresse`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(PersonIdent("01010199999")))
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["VERGE", "FULLMAKT"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal opprette brevmottaker med mottakertype bruker med utenlandsk adresse samtidig som det allerede eksisterede brevmottakere som lar seg kombinere med brukere med utenlandsk adresse`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(brevmottakerPersonMedIdent, brevmottakerPersonUtenIdent),
+            )
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(PersonIdent("01010199999")))
+
+            every {
+                brevRepository.update(any())
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["BRUKER_MED_UTENLANDSK_ADRESSE", "DØDSBO"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal slette bruker ved enkelte MottakerRoller`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val personIdent = PersonIdent("01010199999")
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent(
+                mottakerRolle = MottakerRolle.BRUKER,
+                personIdent = personIdent.ident,
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            val brevSlot = slot<Brev>()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(personIdent))
+
+            every {
+                brevRepository.update(capture(brevSlot))
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+
+            val capturedBrev = brevSlot.captured
+            assertThat(capturedBrev.mottakere?.organisasjoner).isEmpty()
+            assertThat(capturedBrev.mottakere?.personer).hasSize(1)
+            assertThat(capturedBrev.mottakere?.personer?.filterIsInstance(BrevmottakerPersonUtenIdent::class.java)).anySatisfy {
+                assertThat(it).isEqualTo(brevmottaker)
+            }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["BRUKER_MED_UTENLANDSK_ADRESSE", "DØDSBO"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal ikke slette bruker ved enkelte MottakerRoller når PersonIdent ikke stemmer overens med den aktive identen i fagsaken`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val personIdent = PersonIdent("01010199999")
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = mottakerRolle,
+                navn = "navn",
+                adresselinje1 = "Adresse 1, Mars, 1337",
+                adresselinje2 = null,
+                postnummer = null,
+                poststed = null,
+                landkode = "DK",
+            )
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent(
+                mottakerRolle = MottakerRolle.BRUKER,
+                personIdent = "11010199999",
+            )
+            val brevmottakere = DomainUtil.lagBrevmottakere(personer = listOf(brevmottakerPersonMedIdent))
+            val brev = DomainUtil.lagBrev(mottakere = brevmottakere)
+
+            val brevSlot = slot<Brev>()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(navn = nyBrevmottakerPersonUtenIdent.navn)
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns brev
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(identer = setOf(personIdent))
+
+            every {
+                brevRepository.update(capture(brevSlot))
+            } returnsArgument 0
+
+            // Act
+            val brevmottaker = brevmottakerOppretter.opprettBrevmottaker(
+                behandling.id,
+                nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Act & assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+
+            val capturedBrev = brevSlot.captured
+            assertThat(capturedBrev.mottakere?.organisasjoner).isEmpty()
+            assertThat(capturedBrev.mottakere?.personer).hasSize(2)
+            assertThat(capturedBrev.mottakere?.personer?.filterIsInstance(BrevmottakerPersonUtenIdent::class.java)).anySatisfy {
+                assertThat(it).isEqualTo(brevmottaker)
+            }
+            assertThat(capturedBrev.mottakere?.personer?.filterIsInstance(BrevmottakerPersonMedIdent::class.java)).anySatisfy {
+                assertThat(it).isEqualTo(brevmottakerPersonMedIdent)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
@@ -1,0 +1,160 @@
+package no.nav.familie.klage.brevmottaker
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BrevmottakerServiceTest {
+    private val brevmottakerHenter: BrevmottakerHenter = mockk()
+    private val brevmottakerErstatter: BrevmottakerErstatter = mockk()
+    private val brevmottakerOppretter: BrevmottakerOppretter = mockk()
+    private val brevmottakerSletter: BrevmottakerSletter = mockk()
+
+    private val brevmottakerService: BrevmottakerService = BrevmottakerService(
+        brevmottakerHenter = brevmottakerHenter,
+        brevmottakerErstatter = brevmottakerErstatter,
+        brevmottakerOppretter = brevmottakerOppretter,
+        brevmottakerSletter = brevmottakerSletter,
+    )
+
+    @Nested
+    inner class HentBrevmottakereTest {
+        @Test
+        fun `skal hente brevmottakere`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    brevmottakerPersonMedIdent,
+                    brevmottakerPersonUtenIdent,
+                ),
+            )
+
+            every {
+                brevmottakerService.hentBrevmottakere(behandlingId)
+            } returns brevmottakere
+
+            // Act
+            val hentetBrevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
+
+            // Assert
+            assertThat(hentetBrevmottakere.organisasjoner).isEmpty()
+            assertThat(hentetBrevmottakere.personer).containsExactly(
+                brevmottakerPersonMedIdent,
+                brevmottakerPersonUtenIdent,
+            )
+        }
+    }
+
+    @Nested
+    inner class ErstattBrevmottakereTest {
+        @Test
+        fun `skal erstatte brevmottakere`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brevmottakerPersonMedIdent = DomainUtil.lagBrevmottakerPersonMedIdent()
+            val brevmottakerPersonUtenIdent = DomainUtil.lagBrevmottakerPersonUtenIdent()
+            val brevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    brevmottakerPersonMedIdent,
+                    brevmottakerPersonUtenIdent,
+                ),
+            )
+
+            every {
+                brevmottakerService.erstattBrevmottakere(behandlingId, brevmottakere)
+            } returns brevmottakere
+
+            // Act
+            val hentetBrevmottakere = brevmottakerService.erstattBrevmottakere(behandlingId, brevmottakere)
+
+            // Assert
+            assertThat(hentetBrevmottakere.organisasjoner).isEmpty()
+            assertThat(hentetBrevmottakere.personer).containsExactly(
+                brevmottakerPersonMedIdent,
+                brevmottakerPersonUtenIdent,
+            )
+        }
+    }
+
+    @Nested
+    inner class OpprettBrevmottakerTeste {
+        @Test
+        fun `skal opprette brevmottaker`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val nyBrevmottaker = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER,
+                navn = "navn",
+                adresselinje1 = "adresse1",
+                adresselinje2 = "adresse2",
+                postnummer = "0010",
+                poststed = "Oslo",
+                landkode = "NO",
+            )
+
+            every {
+                brevmottakerOppretter.opprettBrevmottaker(behandlingId, nyBrevmottaker)
+            } returns DomainUtil.lagBrevmottakerPersonUtenIdent(
+                id = UUID.randomUUID(),
+                mottakerRolle = nyBrevmottaker.mottakerRolle,
+                navn = nyBrevmottaker.navn,
+                adresselinje1 = nyBrevmottaker.adresselinje1,
+                adresselinje2 = nyBrevmottaker.adresselinje2,
+                postnummer = nyBrevmottaker.postnummer,
+                poststed = nyBrevmottaker.poststed,
+                landkode = nyBrevmottaker.landkode,
+            )
+
+            // Act
+            val brevmottaker = brevmottakerService.opprettBrevmottaker(behandlingId, nyBrevmottaker)
+
+            // Assert
+            assertThat(brevmottaker).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottaker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottaker.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottaker.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottaker.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottaker.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottaker.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottaker.landkode)
+            }
+        }
+    }
+
+    @Nested
+    inner class SlettBrevmottakerTest {
+        @Test
+        fun `skal opprette brevmottaker`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            every {
+                brevmottakerSletter.slettBrevmottaker(behandlingId, slettbarBrevmottaker)
+            } just runs
+
+            // Act
+            brevmottakerService.slettBrevmottaker(behandlingId, slettbarBrevmottaker)
+
+            // Assert
+            verify(exactly = 1) { brevmottakerSletter.slettBrevmottaker(behandlingId, slettbarBrevmottaker) }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerSletterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerSletterTest.kt
@@ -1,0 +1,503 @@
+package no.nav.familie.klage.brevmottaker
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.StegType
+import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brev.domain.Brev
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.fagsak.domain.PersonIdent
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.UUID
+
+class BrevmottakerSletterTest {
+    private val behandlingService: BehandlingService = mockk()
+    private val fagsakService: FagsakService = mockk()
+    private val brevService: BrevService = mockk()
+    private val brevRepository: BrevRepository = mockk()
+    private val personopplysningerService: PersonopplysningerService = mockk()
+    private val brevmottakerSletter: BrevmottakerSletter = BrevmottakerSletter(
+        behandlingService = behandlingService,
+        brevService = brevService,
+        brevRepository = brevRepository,
+        fagsakService = fagsakService,
+        personopplysningerService = personopplysningerService,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(any()) } returns "saksbehandler"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class SlettBrevmottakerTest {
+        @Test
+        fun `skal kaste exception om brevmottaker er SlettbarBrevmottakerOrganisasjon`() {
+            // Arrange
+            val behandling = DomainUtil.behandling()
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerOrganisasjon("123")
+
+            // Act & assert
+            val exception = assertThrows<UnsupportedOperationException> {
+                brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+            }
+            assertThat(exception.message).isEqualTo("Sletting av organisasjon er ikke støttet.")
+        }
+
+        @Test
+        fun `skal kaste exception om brevmottaker er SlettbarBrevmottakerPersonMedIdent`() {
+            // Arrange
+            val behandling = DomainUtil.behandling()
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonMedIdent("123")
+
+            // Act & assert
+            val exception = assertThrows<UnsupportedOperationException> {
+                brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+            }
+            assertThat(exception.message).isEqualTo("Sletting av person med ident er ikke støttet.")
+        }
+
+        @Test
+        fun `skal kaste exception om behandling er låst for videre redigering`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV, status = BehandlingStatus.FERDIGSTILT)
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+            }
+            assertThat(exception.message).isEqualTo("Behandling ${behandling.id} er låst for videre behandling.")
+        }
+
+        @Test
+        fun `skal kaste exception om behandling er i feil steg`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.FORMKRAV)
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+            }
+            assertThat(exception.message).isEqualTo("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}.")
+        }
+
+        @Test
+        fun `skal kaste exception om brevmottakeren som skal slettes ikke finnes da mottakere i brev er null`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = null)
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+            }
+            assertThat(exception.message).isEqualTo("Brevmottaker ${slettbarBrevmottaker.id} kan ikke slettes da den ikke finnes.")
+        }
+
+        @Test
+        fun `skal kaste exception om brevmottakeren som skal slettes ikke finnes da mottakere i brev er en tom liste`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns DomainUtil.lagBrev(
+                behandlingId = behandling.id,
+                mottakere = DomainUtil.lagBrevmottakere(personer = emptyList()),
+            )
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+            }
+            assertThat(exception.message).isEqualTo("Brevmottaker ${slettbarBrevmottaker.id} kan ikke slettes da den ikke finnes.")
+        }
+
+        @Test
+        fun `skal kaste slette brevmottakeren`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            val brevSlot = slot<Brev>()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(
+                identer = setOf(PersonIdent("123")),
+            )
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns DomainUtil.lagBrev(
+                behandlingId = behandling.id,
+                mottakere = Brevmottakere(
+                    personer = listOf(
+                        DomainUtil.lagBrevmottakerPersonMedIdent(
+                            mottakerRolle = MottakerRolle.BRUKER,
+                        ),
+                        DomainUtil.lagBrevmottakerPersonUtenIdent(
+                            id = slettbarBrevmottaker.id,
+                            mottakerRolle = MottakerRolle.FULLMAKT,
+                        ),
+                        DomainUtil.lagBrevmottakerPersonUtenIdent(
+                            id = UUID.randomUUID(),
+                            mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                            adresselinje1 = "Adresse 1, Mars, 1337",
+                            adresselinje2 = null,
+                            poststed = null,
+                            postnummer = null,
+                            landkode = "DK",
+                        ),
+                    ),
+                ),
+            )
+
+            every {
+                brevRepository.update(capture(brevSlot))
+            } returnsArgument 0
+
+            // Act
+            brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+
+            // Assert
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(2)
+
+            val brevmottakerPersonUtenIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonUtenIdent::class.java)
+            assertThat(brevmottakerPersonUtenIdent).hasSize(1)
+            assertThat(brevmottakerPersonUtenIdent).allSatisfy {
+                assertThat(it.id).isNotEqualTo(slettbarBrevmottaker.id)
+            }
+
+            val brevmottakerPersonMedIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonMedIdent::class.java)
+            assertThat(brevmottakerPersonMedIdent).hasSize(1)
+            assertThat(brevmottakerPersonMedIdent).allSatisfy {
+                assertThat(it.personIdent).isNotEqualTo(slettbarBrevmottaker.id.toString())
+            }
+
+            verify(exactly = 1) { brevRepository.update(any()) }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["BRUKER_MED_UTENLANDSK_ADRESSE", "DØDSBO"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal kaste slette brevmottakeren og ikke legge til bruker selv om bruker ikke allerede eksisterer for visse mottaker roller`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+
+            val brevSlot = slot<Brev>()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(
+                identer = setOf(PersonIdent("123")),
+            )
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns DomainUtil.lagBrev(
+                behandlingId = behandling.id,
+                mottakere = Brevmottakere(
+                    personer = listOf(
+                        DomainUtil.lagBrevmottakerPersonUtenIdent(
+                            id = slettbarBrevmottaker.id,
+                            mottakerRolle = mottakerRolle,
+                        ),
+                        DomainUtil.lagBrevmottakerPersonUtenIdent(
+                            id = UUID.randomUUID(),
+                            mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                            adresselinje1 = "Adresse 1, Mars, 1337",
+                            adresselinje2 = null,
+                            poststed = null,
+                            postnummer = null,
+                            landkode = "DK",
+                        ),
+                    ),
+                ),
+            )
+
+            every {
+                brevRepository.update(capture(brevSlot))
+            } returnsArgument 0
+
+            // Act
+            brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+
+            // Assert
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+
+            val brevmottakerPersonUtenIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonUtenIdent::class.java)
+            assertThat(brevmottakerPersonUtenIdent).hasSize(1)
+            assertThat(brevmottakerPersonUtenIdent).allSatisfy {
+                assertThat(it.id).isNotEqualTo(slettbarBrevmottaker.id)
+            }
+
+            val brevmottakerPersonMedIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonMedIdent::class.java)
+            assertThat(brevmottakerPersonMedIdent).isEmpty()
+
+            verify(exactly = 1) { brevRepository.update(any()) }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["BRUKER_MED_UTENLANDSK_ADRESSE", "DØDSBO"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal kaste slette brevmottakeren og legge til bruker som ikke allerede eksisterer for visse mottaker roller`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val personIdent = PersonIdent("123")
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+            val brevSlot = slot<Brev>()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(
+                identer = setOf(personIdent),
+            )
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(
+                personIdent = personIdent.ident,
+                navn = "Navn Etternavn",
+            )
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns DomainUtil.lagBrev(
+                behandlingId = behandling.id,
+                mottakere = Brevmottakere(
+                    personer = listOf(
+                        DomainUtil.lagBrevmottakerPersonUtenIdent(
+                            id = slettbarBrevmottaker.id,
+                            mottakerRolle = mottakerRolle,
+                            adresselinje1 = "Adresse 1, Mars, 1337",
+                            adresselinje2 = null,
+                            poststed = null,
+                            postnummer = null,
+                            landkode = "DK",
+                        ),
+                    ),
+                ),
+            )
+
+            every {
+                brevRepository.update(capture(brevSlot))
+            } returnsArgument 0
+
+            // Act
+            brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+
+            // Assert
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+
+            val brevmottakerPersonUtenIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonUtenIdent::class.java)
+            assertThat(brevmottakerPersonUtenIdent).isEmpty()
+
+            val brevmottakerPersonMedIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonMedIdent::class.java)
+            assertThat(brevmottakerPersonMedIdent).hasSize(1)
+            assertThat(brevmottakerPersonMedIdent).allSatisfy {
+                assertThat(it.personIdent).isEqualTo(personIdent.ident)
+            }
+
+            verify(exactly = 1) { brevRepository.update(any()) }
+        }
+
+        @EnumSource(
+            value = MottakerRolle::class,
+            names = ["BRUKER_MED_UTENLANDSK_ADRESSE", "DØDSBO"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal kaste slette brevmottakeren men legge til bruker som allerede eksisterer for visse mottaker roller`(
+            mottakerRolle: MottakerRolle,
+        ) {
+            // Arrange
+            val personIdent = PersonIdent("123")
+            val behandling = DomainUtil.behandling(steg = StegType.BREV)
+            val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())
+            val brevSlot = slot<Brev>()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            every {
+                fagsakService.hentFagsak(behandling.fagsakId)
+            } returns DomainUtil.fagsak(
+                identer = setOf(personIdent),
+            )
+
+            every {
+                personopplysningerService.hentPersonopplysninger(behandling.id)
+            } returns DomainUtil.lagPersonopplysningerDto(
+                personIdent = personIdent.ident,
+                navn = "Navn Etternavn",
+            )
+
+            every {
+                brevService.hentBrev(behandling.id)
+            } returns DomainUtil.lagBrev(
+                behandlingId = behandling.id,
+                mottakere = Brevmottakere(
+                    personer = listOf(
+                        DomainUtil.lagBrevmottakerPersonMedIdent(
+                            personIdent = personIdent.ident,
+                            mottakerRolle = MottakerRolle.BRUKER,
+                        ),
+                        DomainUtil.lagBrevmottakerPersonUtenIdent(
+                            id = slettbarBrevmottaker.id,
+                            mottakerRolle = mottakerRolle,
+                            adresselinje1 = "Adresse 1, Mars, 1337",
+                            adresselinje2 = null,
+                            poststed = null,
+                            postnummer = null,
+                            landkode = "DK",
+                        ),
+                    ),
+                ),
+            )
+
+            every {
+                brevRepository.update(capture(brevSlot))
+            } returnsArgument 0
+
+            // Act
+            brevmottakerSletter.slettBrevmottaker(behandling.id, slettbarBrevmottaker)
+
+            // Assert
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+
+            val brevmottakerPersonUtenIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonUtenIdent::class.java)
+            assertThat(brevmottakerPersonUtenIdent).isEmpty()
+
+            val brevmottakerPersonMedIdent = brevSlot
+                .captured
+                .mottakere
+                ?.personer
+                ?.filterIsInstance(BrevmottakerPersonMedIdent::class.java)
+            assertThat(brevmottakerPersonMedIdent).hasSize(1)
+            assertThat(brevmottakerPersonMedIdent).allSatisfy {
+                assertThat(it.personIdent).isEqualTo(personIdent.ident)
+            }
+
+            verify(exactly = 1) { brevRepository.update(any()) }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottakerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottakerTest.kt
@@ -1,0 +1,184 @@
+package no.nav.familie.klage.brevmottaker.domain
+
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class NyBrevmottakerTest {
+    @Nested
+    inner class NyBrevmottakerPersonUtenIdentTest {
+        @Test
+        fun `skal kaste exception om landkode er mindre enn 2 tegn`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "N")
+            }
+            assertThat(exception.message).isEqualTo("Ugyldig landkode: N.")
+        }
+
+        @Test
+        fun `skal kaste exception om landkode er mer enn 2 tegn`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NOR")
+            }
+            assertThat(exception.message).isEqualTo("Ugyldig landkode: NOR.")
+        }
+
+        @Test
+        fun `skal kaste exception om navn er en tom string`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(navn = "")
+            }
+            assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om navn er en string med kun mellomrom`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(navn = " ")
+            }
+            assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om adresselinje1 er en tom string`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(adresselinje1 = "")
+            }
+            assertThat(exception.message).isEqualTo("Adresselinje1 kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om adresselinje1 er en string med kun mellomrom`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(adresselinje1 = " ")
+            }
+            assertThat(exception.message).isEqualTo("Adresselinje1 kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer er null og landkode er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = null)
+            }
+            assertThat(exception.message).isEqualTo("Når landkode er NO (Norge) må postnummer være satt.")
+        }
+
+        @Test
+        fun `skal kaste exception om poststed er null og landkode er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", poststed = null)
+            }
+            assertThat(exception.message).isEqualTo("Når landkode er NO (Norge) må poststed være satt.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer ikke inneholder kun tall og landkode er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = "123T")
+            }
+            assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer er mindre enn 4 tegn og landkode er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = "123")
+            }
+            assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer er mer enn 4 tegn og landkode er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = "12345")
+            }
+            assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
+        }
+
+        @Test
+        fun `skal kaste exception om mottakertype er bruker med utenlandsk adresse og landkode er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE)
+            }
+            assertThat(exception.message).isEqualTo("Bruker med utenlandsk adresse kan ikke ha landkode NO.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer ikke er null og landkode ikke er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "BR", postnummer = "1234", poststed = null)
+            }
+            assertThat(exception.message).isEqualTo("Ved utenlandsk landkode må postnummer settes i adresselinje 1.")
+        }
+
+        @Test
+        fun `skal kaste exception om poststed ikke er null og landkode ikke er NO`() {
+            // Act & assert
+            val exception = assertThrows<IllegalStateException> {
+                DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "BR", postnummer = null, poststed = "Harstad")
+            }
+            assertThat(exception.message).isEqualTo("Ved utenlandsk landkode må poststed settes i adresselinje 1.")
+        }
+
+        @Test
+        fun `skal opprette ny brevmottaker med utenlandsk landekode`() {
+            // Act
+            val nyBrevmottaker = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresseveien 1, Danmark, 0010",
+                adresselinje2 = null,
+                landkode = "DK",
+                postnummer = null,
+                poststed = null,
+            )
+
+            // Assert
+            assertThat(nyBrevmottaker.mottakerRolle).isEqualTo(MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE)
+            assertThat(nyBrevmottaker.navn).isEqualTo("Navn Navnesen")
+            assertThat(nyBrevmottaker.adresselinje1).isEqualTo("Adresseveien 1, Danmark, 0010")
+            assertThat(nyBrevmottaker.adresselinje2).isNull()
+            assertThat(nyBrevmottaker.postnummer).isNull()
+            assertThat(nyBrevmottaker.poststed).isNull()
+            assertThat(nyBrevmottaker.landkode).isEqualTo("DK")
+        }
+
+        @Test
+        fun `skal opprette ny brevmottaker med norsk landekode`() {
+            // Act
+            val nyBrevmottaker = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.BRUKER,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresseveien 1",
+                adresselinje2 = null,
+                landkode = "NO",
+                postnummer = "0010",
+                poststed = "Oslo",
+            )
+
+            // Assert
+            assertThat(nyBrevmottaker.mottakerRolle).isEqualTo(MottakerRolle.BRUKER)
+            assertThat(nyBrevmottaker.navn).isEqualTo("Navn Navnesen")
+            assertThat(nyBrevmottaker.adresselinje1).isEqualTo("Adresseveien 1")
+            assertThat(nyBrevmottaker.adresselinje2).isNull()
+            assertThat(nyBrevmottaker.postnummer).isEqualTo("0010")
+            assertThat(nyBrevmottaker.poststed).isEqualTo("Oslo")
+            assertThat(nyBrevmottaker.landkode).isEqualTo("NO")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDtoKtTest.kt
@@ -1,0 +1,514 @@
+package no.nav.familie.klage.brevmottaker.dto
+
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.testutil.DtoTestUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+
+class NyBrevmottakerDtoKtTest {
+    @Nested
+    inner class NyBrevmottakerDtoTest {
+        @Test
+        fun `skal mappe til domene for NyBrevmottakerPersonUtenIdentDto`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresselinje 1",
+                adresselinje2 = "Adresselinje 2",
+                postnummer = "0010",
+                poststed = "Oslo",
+                landkode = "NO",
+            )
+
+            // Act
+            val nyBrevmottaker = nyBrevmottakerDto.tilDomene()
+
+            // Assert
+            assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerDto.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerDto.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerDto.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerDto.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerDto.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerDto.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerDto.landkode)
+            }
+        }
+
+        @Test
+        fun `skal mappe til domene for NyBrevmottakerPersonMedIdentDto`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                personIdent = "123",
+                mottakerRolle = MottakerRolle.FULLMAKT,
+                navn = "Navn Navnesen",
+            )
+
+            // Act
+            val nyBrevmottaker = nyBrevmottakerDto.tilDomene()
+
+            // Assert
+            assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(nyBrevmottakerDto.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerDto.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerDto.navn)
+            }
+        }
+
+        @Test
+        fun `skal mappe til domene for NyBrevmottakerOrganisasjonDto`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerOrganisasjonDto(
+                organisasjonsnummer = "123",
+                organisasjonsnavn = "organisasjonsnavn",
+                navnHosOrganisasjon = "navnHosOrganisasjon",
+            )
+
+            // Act
+            val nyBrevmottaker = nyBrevmottakerDto.tilDomene()
+
+            // Assert
+            assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerOrganisasjon::class.java) {
+                assertThat(it.organisasjonsnummer).isEqualTo(nyBrevmottakerDto.organisasjonsnummer)
+                assertThat(it.organisasjonsnavn).isEqualTo(nyBrevmottakerDto.organisasjonsnavn)
+                assertThat(it.navnHosOrganisasjon).isEqualTo(nyBrevmottakerDto.navnHosOrganisasjon)
+            }
+        }
+    }
+
+    @Nested
+    inner class NyBrevmottakerOrganisasjonDtoTest {
+        @Test
+        fun `skal ha riktig type`() {
+            // Arrange
+            val dto = DtoTestUtil.lagNyBrevmottakerOrganisasjonDto()
+
+            // Act
+            val type = dto.type
+
+            // Assert
+            assertThat(type).isEqualTo(NyBrevmottakerDto.Type.ORGANISASJON)
+        }
+    }
+
+    @Nested
+    inner class NyBrevmottakerPersonMedIdentDtoTest {
+        @Test
+        fun `skal ha riktig type`() {
+            // Arrange
+            val dto = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto()
+
+            // Act
+            val type = dto.type
+
+            // Assert
+            assertThat(type).isEqualTo(NyBrevmottakerDto.Type.PERSON_MED_IDENT)
+        }
+
+        @Test
+        fun `skal kaste exception om MottakerRolle er BRUKER_MED_UTENLANDSK_ADRESSE`() {
+            // Arrange
+            val dto = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                dto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Person med ident kan ikke være ${MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE}")
+        }
+    }
+
+    @Nested
+    inner class NyBrevmottakerPersonUtenIdentDtoTest {
+        @Test
+        fun `skal ha riktig type`() {
+            // Arrange
+            val dto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto()
+
+            // Act
+            val type = dto.type
+
+            // Assert
+            assertThat(type).isEqualTo(NyBrevmottakerDto.Type.PERSON_UTEN_IDENT)
+        }
+
+        @Test
+        fun `skal kaste exception om mottakertype er bruker`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                mottakerRolle = MottakerRolle.BRUKER,
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Det er ikke mulig å sette ${MottakerRolle.BRUKER} for saksbehandler.")
+        }
+
+        @Test
+        fun `skal kaste exception om landkode er mindre enn 2 tegn`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "N")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Ugyldig landkode: N.")
+        }
+
+        @Test
+        fun `skal kaste exception om landkode er mer enn 2 tegn`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "NOR")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Ugyldig landkode: NOR.")
+        }
+
+        @Test
+        fun `skal kaste exception om navn er en tom string`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(navn = "")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om navn er en string med kun mellomrom`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(navn = " ")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om adresselinje1 er en tom string`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(adresselinje1 = "")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Adresselinje 1 kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om adresselinje1 er en string med kun mellomrom`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(adresselinje1 = " ")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Adresselinje 1 kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer er null og landkode er NO`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "NO", postnummer = null)
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Når landkode er NO (Norge) må postnummer være satt.")
+        }
+
+        @Test
+        fun `skal kaste exception om poststed er null og landkode er NO`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "NO", poststed = null)
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Når landkode er NO (Norge) må poststed være satt.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer ikke inneholder kun tall og landkode er NO`() {
+            // Arrange
+            val nyBrevmottakerDto =
+                DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "NO", postnummer = "123T")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer er mindre enn 4 tegn og landkode er NO`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "NO", postnummer = "123")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer er mer enn 4 tegn og landkode er NO`() {
+            // Arrange
+            val nyBrevmottakerDto =
+                DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(landkode = "NO", postnummer = "12345")
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
+        }
+
+        @Test
+        fun `skal kaste exception om MottakerRolle er bruker med utenlandsk adresse og landkode er NO`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                landkode = "NO",
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Bruker med utenlandsk adresse kan ikke ha landkode NO.")
+        }
+
+        @Test
+        fun `skal kaste exception om postnummer ikke er null og landkode ikke er NO`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                landkode = "BR",
+                postnummer = "1234",
+                poststed = null,
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Ved utenlandsk landkode må postnummer settes i adresselinje 1.")
+        }
+
+        @Test
+        fun `skal kaste exception om poststed ikke er null og landkode ikke er NO`() {
+            // Arrange
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                landkode = "BR",
+                postnummer = null,
+                poststed = "Harstad",
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                nyBrevmottakerDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.message).isEqualTo("Ved utenlandsk landkode må poststed settes i adresselinje 1.")
+        }
+
+        @Test
+        fun `skal opprette ny brevmottaker med utenlandsk landekode`() {
+            // Act
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresseveien 1, Danmark, 0010",
+                adresselinje2 = null,
+                landkode = "DK",
+                postnummer = null,
+                poststed = null,
+            )
+
+            // Assert
+            assertThat(nyBrevmottakerDto.mottakerRolle).isEqualTo(MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE)
+            assertThat(nyBrevmottakerDto.navn).isEqualTo("Navn Navnesen")
+            assertThat(nyBrevmottakerDto.adresselinje1).isEqualTo("Adresseveien 1, Danmark, 0010")
+            assertThat(nyBrevmottakerDto.adresselinje2).isNull()
+            assertThat(nyBrevmottakerDto.postnummer).isNull()
+            assertThat(nyBrevmottakerDto.poststed).isNull()
+            assertThat(nyBrevmottakerDto.landkode).isEqualTo("DK")
+        }
+
+        @Test
+        fun `skal opprette ny brevmottaker med norsk landekode`() {
+            // Act
+            val nyBrevmottakerDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresseveien 1",
+                adresselinje2 = null,
+                landkode = "NO",
+                postnummer = "0010",
+                poststed = "Oslo",
+            )
+
+            // Assert
+            assertThat(nyBrevmottakerDto.mottakerRolle).isEqualTo(MottakerRolle.FULLMAKT)
+            assertThat(nyBrevmottakerDto.navn).isEqualTo("Navn Navnesen")
+            assertThat(nyBrevmottakerDto.adresselinje1).isEqualTo("Adresseveien 1")
+            assertThat(nyBrevmottakerDto.adresselinje2).isNull()
+            assertThat(nyBrevmottakerDto.postnummer).isEqualTo("0010")
+            assertThat(nyBrevmottakerDto.poststed).isEqualTo("Oslo")
+            assertThat(nyBrevmottakerDto.landkode).isEqualTo("NO")
+        }
+    }
+
+    @Nested
+    inner class NyBrevmottakerDtoDeserializerTest {
+        private val nyBrevmottakerDtoDeserializer: NyBrevmottakerDtoDeserializer = NyBrevmottakerDtoDeserializer()
+
+        @Test
+        fun `skal deserialisere NyBrevmottakerOrganisasjon`() {
+            // Arrange
+            val json = "{" +
+                "\"type\":\"ORGANISASJON\"," +
+                "\"organisasjonsnummer\":\"123\"," +
+                "\"organisasjonsnavn\":\"Orgnavn\"," +
+                "\"navnHosOrganisasjon\":\"OG\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = nyBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(NyBrevmottakerOrganisasjonDto::class.java) {
+                assertThat(it.organisasjonsnummer).isEqualTo("123")
+                assertThat(it.organisasjonsnavn).isEqualTo("Orgnavn")
+                assertThat(it.navnHosOrganisasjon).isEqualTo("OG")
+            }
+        }
+
+        @Test
+        fun `skal deserialisere NyBrevmottakerPersonMedIdentDto`() {
+            // Arrange
+            val json = "{" +
+                "\"type\":\"PERSON_MED_IDENT\"," +
+                "\"personIdent\":\"01492350318\"," +
+                "\"mottakerRolle\":\"BRUKER\"," +
+                "\"navn\":\"Fornavn mellomnavn Etternavn\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = nyBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(NyBrevmottakerPersonMedIdentDto::class.java) {
+                assertThat(it.personIdent).isEqualTo("01492350318")
+                assertThat(it.mottakerRolle).isEqualTo(MottakerRolle.BRUKER)
+                assertThat(it.navn).isEqualTo("Fornavn mellomnavn Etternavn")
+            }
+        }
+
+        @Test
+        fun `skal deserialisere norsk NyBrevmottakerPersonUtenIdentDto`() {
+            // Arrange
+            val json = "{" +
+                "\"type\":\"PERSON_UTEN_IDENT\"," +
+                "\"mottakerRolle\":\"FULLMAKT\"," +
+                "\"navn\":\"Fornavn mellomnavn Etternavn\"," +
+                "\"adresselinje1\":\"Adresse 1\"," +
+                "\"adresselinje2\":\"Adresse 2\"," +
+                "\"postnummer\":\"0010\"," +
+                "\"poststed\":\"Oslo\"," +
+                "\"landkode\":\"NO\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = nyBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdentDto::class.java) {
+                assertThat(it.mottakerRolle).isEqualTo(MottakerRolle.FULLMAKT)
+                assertThat(it.navn).isEqualTo("Fornavn mellomnavn Etternavn")
+                assertThat(it.adresselinje1).isEqualTo("Adresse 1")
+                assertThat(it.adresselinje2).isEqualTo("Adresse 2")
+                assertThat(it.postnummer).isEqualTo("0010")
+                assertThat(it.poststed).isEqualTo("Oslo")
+                assertThat(it.landkode).isEqualTo("NO")
+            }
+        }
+
+        @Test
+        fun `skal deserialisere utenlandsk NyBrevmottakerPersonUtenIdentDto`() {
+            // Arrange
+            val json = "{" +
+                "\"type\":\"PERSON_UTEN_IDENT\"," +
+                "\"mottakerRolle\":\"BRUKER_MED_UTENLANDSK_ADRESSE\"," +
+                "\"navn\":\"Fornavn mellomnavn Etternavn\"," +
+                "\"adresselinje1\":\"Adresse 1, Mars, 1337\"," +
+                "\"landkode\":\"DK\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = nyBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdentDto::class.java) {
+                assertThat(it.mottakerRolle).isEqualTo(MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE)
+                assertThat(it.navn).isEqualTo("Fornavn mellomnavn Etternavn")
+                assertThat(it.adresselinje1).isEqualTo("Adresse 1, Mars, 1337")
+                assertThat(it.adresselinje2).isNull()
+                assertThat(it.postnummer).isNull()
+                assertThat(it.poststed).isNull()
+                assertThat(it.landkode).isEqualTo("DK")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDtoKtTest.kt
@@ -102,9 +102,9 @@ class SlettbarBrevmottakerDtoKtTest {
     }
 
     @Nested
-    inner class SlettBrevmottakerDtoDeserializerTest {
-        private val slettBrevmottakerDtoDeserializer: SlettBrevmottakerDtoDeserializer =
-            SlettBrevmottakerDtoDeserializer()
+    inner class SlettbarBrevmottakerDtoDeserializerTest {
+        private val slettbarBrevmottakerDtoDeserializer: SlettbarBrevmottakerDtoDeserializer =
+            SlettbarBrevmottakerDtoDeserializer()
 
         @Test
         fun `skal deserialisere SlettbarBrevmottakerOrganisasjonDto`() {
@@ -117,7 +117,10 @@ class SlettbarBrevmottakerDtoKtTest {
             val parser = objectMapper.factory.createParser(json)
 
             // Act
-            val deserialize = slettBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+            val deserialize = slettbarBrevmottakerDtoDeserializer.deserialize(
+                parser,
+                objectMapper.deserializationContext,
+            )
 
             // Assert
             assertThat(deserialize).isInstanceOfSatisfying(SlettbarBrevmottakerOrganisasjonDto::class.java) {
@@ -136,7 +139,10 @@ class SlettbarBrevmottakerDtoKtTest {
             val parser = objectMapper.factory.createParser(json)
 
             // Act
-            val deserialize = slettBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+            val deserialize = slettbarBrevmottakerDtoDeserializer.deserialize(
+                parser,
+                objectMapper.deserializationContext,
+            )
 
             // Assert
             assertThat(deserialize).isInstanceOfSatisfying(SlettbarBrevmottakerPersonMedIdentDto::class.java) {
@@ -157,7 +163,10 @@ class SlettbarBrevmottakerDtoKtTest {
             val parser = objectMapper.factory.createParser(json)
 
             // Act
-            val deserialize = slettBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+            val deserialize = slettbarBrevmottakerDtoDeserializer.deserialize(
+                parser,
+                objectMapper.deserializationContext,
+            )
 
             // Assert
             assertThat(deserialize).isInstanceOfSatisfying(SlettbarBrevmottakerPersonUtenIdentDto::class.java) {

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDtoKtTest.kt
@@ -1,0 +1,168 @@
+package no.nav.familie.klage.brevmottaker.dto
+
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenIdent
+import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class SlettbarBrevmottakerDtoKtTest {
+    @Nested
+    inner class SlettbarBrevmottakerDtoTest {
+        @Test
+        fun `skal mappe om til SlettbarBrevmottakerOrganisasjon`() {
+            // Arrange
+            val dto = SlettbarBrevmottakerOrganisasjonDto("123")
+
+            // Act
+            val domene = dto.tilDomene()
+
+            // Assert
+            assertThat(domene).isInstanceOfSatisfying(SlettbarBrevmottakerOrganisasjon::class.java) {
+                assertThat(it.organisasjonsnummer).isEqualTo("123")
+            }
+        }
+
+        @Test
+        fun `skal mappe om til SlettbarBrevmottakerPersonMedIdent`() {
+            // Arrange
+            val dto = SlettbarBrevmottakerPersonMedIdentDto("123")
+
+            // Act
+            val domene = dto.tilDomene()
+
+            // Assert
+            assertThat(domene).isInstanceOfSatisfying(SlettbarBrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo("123")
+            }
+        }
+
+        @Test
+        fun `skal mappe om til SlettbarBrevmottakerPersonUtenIdent`() {
+            // Arrange
+            val id = UUID.randomUUID()
+            val dto = SlettbarBrevmottakerPersonUtenIdentDto(id)
+
+            // Act
+            val domene = dto.tilDomene()
+
+            // Assert
+            assertThat(domene).isInstanceOfSatisfying(SlettbarBrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isEqualTo(id)
+            }
+        }
+    }
+
+    @Nested
+    inner class SlettbarBrevmottakerOrganisasjonDtoTest {
+        @Test
+        fun `skal ha riktig type`() {
+            // Arrange
+            val dto = SlettbarBrevmottakerOrganisasjonDto("123")
+
+            // Act
+            val type = dto.type
+
+            // Assert
+            assertThat(type).isEqualTo(SlettbarBrevmottakerDto.Type.ORGANISASJON)
+        }
+    }
+
+    @Nested
+    inner class SlettbarBrevmottakerPersonMedIdentDtoTest {
+        @Test
+        fun `skal ha riktig type`() {
+            // Arrange
+            val dto = SlettbarBrevmottakerPersonMedIdentDto("123")
+
+            // Act
+            val type = dto.type
+
+            // Assert
+            assertThat(type).isEqualTo(SlettbarBrevmottakerDto.Type.PERSON_MED_IDENT)
+        }
+    }
+
+    @Nested
+    inner class SlettbarBrevmottakerPersonUtenIdentDtoTest {
+        @Test
+        fun `skal ha riktig type`() {
+            // Arrange
+            val dto = SlettbarBrevmottakerPersonUtenIdentDto(UUID.randomUUID())
+
+            // Act
+            val type = dto.type
+
+            // Assert
+            assertThat(type).isEqualTo(SlettbarBrevmottakerDto.Type.PERSON_UTEN_IDENT)
+        }
+    }
+
+    @Nested
+    inner class SlettBrevmottakerDtoDeserializerTest {
+        private val slettBrevmottakerDtoDeserializer: SlettBrevmottakerDtoDeserializer =
+            SlettBrevmottakerDtoDeserializer()
+
+        @Test
+        fun `skal deserialisere SlettbarBrevmottakerOrganisasjonDto`() {
+            // Arrange
+            val json = "{" +
+                "\"type\":\"ORGANISASJON\"," +
+                "\"organisasjonsnummer\":\"321\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = slettBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(SlettbarBrevmottakerOrganisasjonDto::class.java) {
+                assertThat(it.organisasjonsnummer).isEqualTo("321")
+            }
+        }
+
+        @Test
+        fun `skal deserialisere SlettbarBrevmottakerPersonMedIdentDto`() {
+            // Arrange
+            val json = "{" +
+                "\"type\":\"PERSON_MED_IDENT\"," +
+                "\"personIdent\":\"123\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = slettBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(SlettbarBrevmottakerPersonMedIdentDto::class.java) {
+                assertThat(it.personIdent).isEqualTo("123")
+            }
+        }
+
+        @Test
+        fun `skal deserialisere SlettbarBrevmottakerPersonUtenIdentDto`() {
+            // Arrange
+            val id = UUID.randomUUID()
+
+            val json = "{" +
+                "\"type\":\"PERSON_UTEN_IDENT\"," +
+                "\"id\":\"${id}\"" +
+                "}"
+
+            val parser = objectMapper.factory.createParser(json)
+
+            // Act
+            val deserialize = slettBrevmottakerDtoDeserializer.deserialize(parser, objectMapper.deserializationContext)
+
+            // Assert
+            assertThat(deserialize).isInstanceOfSatisfying(SlettbarBrevmottakerPersonUtenIdentDto::class.java) {
+                assertThat(it.id).isEqualTo(id)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -7,12 +7,24 @@ import no.nav.familie.klage.behandling.domain.PåklagetVedtakDetaljer
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.behandling.dto.PåklagetVedtakDto
+import no.nav.familie.klage.brev.domain.Brev
+import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
 import no.nav.familie.klage.brev.dto.AvsnittDto
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPerson
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerOrganisasjon
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonUtenIdent
 import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.fagsak.domain.FagsakDomain
 import no.nav.familie.klage.fagsak.domain.FagsakPerson
 import no.nav.familie.klage.fagsak.domain.PersonIdent
+import no.nav.familie.klage.felles.domain.Fil
 import no.nav.familie.klage.felles.domain.Sporbar
 import no.nav.familie.klage.felles.domain.SporbarUtils
 import no.nav.familie.klage.formkrav.domain.Form
@@ -360,6 +372,124 @@ object DomainUtil {
         return PåklagetVedtak(
             påklagetVedtakstype = påklagetVedtakstype,
             påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+        )
+    }
+
+    fun lagBrevmottakerPersonUtenIdent(
+        id: UUID = UUID.randomUUID(),
+        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        navn: String = "Navn Navnesen",
+        adresselinje1: String = "Onkel Pølsemakers vei 10",
+        adresselinje2: String? = null,
+        postnummer: String? = "0010",
+        poststed: String? = "Oslo",
+        landkode: String = "NO",
+    ): BrevmottakerPersonUtenIdent {
+        return BrevmottakerPersonUtenIdent(
+            id,
+            mottakerRolle,
+            navn,
+            adresselinje1,
+            adresselinje2,
+            postnummer,
+            poststed,
+            landkode,
+        )
+    }
+
+    fun lagBrevmottakerPersonMedIdent(
+        personIdent: String = "23097825289",
+        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        navn: String = "Navn Navnesen",
+    ): BrevmottakerPersonMedIdent {
+        return BrevmottakerPersonMedIdent(
+            personIdent,
+            mottakerRolle,
+            navn,
+        )
+    }
+
+    fun lagBrevmottakere(
+        personer: List<BrevmottakerPerson> = emptyList(),
+        organisasjoner: List<BrevmottakerOrganisasjon> = emptyList(),
+    ): Brevmottakere {
+        return Brevmottakere(
+            personer = personer,
+            organisasjoner = organisasjoner,
+        )
+    }
+
+    fun lagBrev(
+        behandlingId: UUID = UUID.randomUUID(),
+        saksbehandlerHtml: String = "<html />",
+        pdf: Fil? = null,
+        mottakere: Brevmottakere? = null,
+        mottakereJournalposter: BrevmottakereJournalposter? = null,
+        sporbar: Sporbar = Sporbar(),
+    ): Brev {
+        return Brev(
+            behandlingId = behandlingId,
+            saksbehandlerHtml = saksbehandlerHtml,
+            pdf = pdf,
+            mottakere = mottakere,
+            mottakereJournalposter = mottakereJournalposter,
+            sporbar = sporbar,
+        )
+    }
+
+    fun lagNyBrevmottakerPersonUtenIdent(
+        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        navn: String = "Navn Navnesen",
+        adresselinje1: String = "Adresselinje 1",
+        adresselinje2: String? = null,
+        postnummer: String? = "0010",
+        poststed: String? = "Oslo",
+        landkode: String = "NO",
+    ): NyBrevmottakerPersonUtenIdent {
+        return NyBrevmottakerPersonUtenIdent(
+            mottakerRolle = mottakerRolle,
+            navn = navn,
+            adresselinje1 = adresselinje1,
+            adresselinje2 = adresselinje2,
+            postnummer = postnummer,
+            poststed = poststed,
+            landkode = landkode,
+        )
+    }
+
+    fun lagNyBrevmottakerPersonMedIdent(
+        personIdent: String = "23097825289",
+        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        navn: String = "Navn Navnesen",
+    ): NyBrevmottakerPersonMedIdent {
+        return NyBrevmottakerPersonMedIdent(
+            personIdent,
+            mottakerRolle,
+            navn,
+        )
+    }
+
+    fun lagNyBrevmottakerOrganisasjon(
+        organisasjonsnummer: String = "123",
+        organisasjonsnavn: String = "Orgnavn",
+        navnHosOrganisasjon: String = "navnHosOrganisasjon",
+    ): NyBrevmottakerOrganisasjon {
+        return NyBrevmottakerOrganisasjon(
+            organisasjonsnummer = organisasjonsnummer,
+            organisasjonsnavn = organisasjonsnavn,
+            navnHosOrganisasjon = navnHosOrganisasjon,
+        )
+    }
+
+    fun lagBrevmottakerOrganisasjon(
+        organisasjonsnummer: String = "123",
+        organisasjonsnavn: String = "Orgnavn",
+        navnHosOrganisasjon: String = "navnHosOrganisasjon",
+    ): BrevmottakerOrganisasjon {
+        return BrevmottakerOrganisasjon(
+            organisasjonsnummer = organisasjonsnummer,
+            organisasjonsnavn = organisasjonsnavn,
+            navnHosOrganisasjon = navnHosOrganisasjon,
         )
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.klage.testutil
+
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerOrganisasjonDto
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonMedIdentDto
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonUtenIdentDto
+import no.nav.familie.klage.brevmottaker.dto.SlettbarBrevmottakerPersonUtenIdentDto
+import java.util.UUID
+
+object DtoTestUtil {
+    fun lagNyBrevmottakerPersonUtenIdentDto(
+        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        navn: String = "Navn Navnesen",
+        adresselinje1: String = "Adresselinje 1",
+        adresselinje2: String? = null,
+        postnummer: String? = "0010",
+        poststed: String? = "Oslo",
+        landkode: String = "NO",
+    ): NyBrevmottakerPersonUtenIdentDto {
+        return NyBrevmottakerPersonUtenIdentDto(
+            mottakerRolle = mottakerRolle,
+            navn = navn,
+            adresselinje1 = adresselinje1,
+            adresselinje2 = adresselinje2,
+            postnummer = postnummer,
+            poststed = poststed,
+            landkode = landkode,
+        )
+    }
+
+    fun lagNyBrevmottakerPersonMedIdentDto(
+        personIdent: String = "23097825289",
+        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        navn: String = "Navn Navnesen",
+    ): NyBrevmottakerPersonMedIdentDto {
+        return NyBrevmottakerPersonMedIdentDto(
+            personIdent = personIdent,
+            mottakerRolle = mottakerRolle,
+            navn = navn,
+        )
+    }
+
+    fun lagNyBrevmottakerOrganisasjonDto(
+        organisasjonsnummer: String = "123",
+        organisasjonsnavn: String = "Orgnavn",
+        navnHosOrganisasjon: String = "navnHosOrganisasjon",
+    ): NyBrevmottakerOrganisasjonDto {
+        return NyBrevmottakerOrganisasjonDto(
+            organisasjonsnummer = organisasjonsnummer,
+            organisasjonsnavn = organisasjonsnavn,
+            navnHosOrganisasjon = navnHosOrganisasjon,
+        )
+    }
+
+    fun lagSlettbarBrevmottakerPersonUtenIdentDto(
+        id: UUID = UUID.randomUUID(),
+    ): SlettbarBrevmottakerPersonUtenIdentDto {
+        return SlettbarBrevmottakerPersonUtenIdentDto(
+            id,
+        )
+    }
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23920

Relatert frontend PR: https://github.com/navikt/familie-klage-frontend/pull/885

Legger til ny kode for å opprette, endre, slette, osv. brevmottakere. Dette skal i teorien fungere for både EF og BAKS.
