### PR TITLE
NAV-23920: Flytter BrevmottakerUtil, korrigerer typos, legger til manglende tester, og forenkler oppretting av BrevmottakerPersonUtenIdent

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -6,8 +6,8 @@ import no.nav.familie.klage.behandling.domain.PåklagetVedtakDetaljer
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
-import no.nav.familie.klage.brev.BrevmottakerUtil.validerMinimumEnMottaker
-import no.nav.familie.klage.brev.BrevmottakerUtil.validerUnikeBrevmottakere
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtil.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.klage.brev
+package no.nav.familie.klage.brevmottaker
 
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/Brevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/Brevmottaker.kt
@@ -39,7 +39,25 @@ data class BrevmottakerPersonUtenIdent(
     val postnummer: String?,
     val poststed: String?,
     val landkode: String,
-) : BrevmottakerPerson
+) : BrevmottakerPerson {
+    companion object Fabrikk {
+        fun opprettFra(
+            id: UUID = UUID.randomUUID(),
+            nyBrevmottakerPersonUtenIdent: NyBrevmottakerPersonUtenIdent,
+        ): BrevmottakerPersonUtenIdent {
+            return BrevmottakerPersonUtenIdent(
+                id = id,
+                mottakerRolle = nyBrevmottakerPersonUtenIdent.mottakerRolle,
+                navn = nyBrevmottakerPersonUtenIdent.navn,
+                adresselinje1 = nyBrevmottakerPersonUtenIdent.adresselinje1,
+                adresselinje2 = nyBrevmottakerPersonUtenIdent.adresselinje2,
+                postnummer = nyBrevmottakerPersonUtenIdent.postnummer,
+                poststed = nyBrevmottakerPersonUtenIdent.poststed,
+                landkode = nyBrevmottakerPersonUtenIdent.landkode,
+            )
+        }
+    }
+}
 
 class BrevmottakerPersonDeserializer : JsonDeserializer<BrevmottakerPerson>() {
     override fun deserialize(jsonParser: JsonParser, context: DeserializationContext): BrevmottakerPerson {

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
@@ -2,7 +2,7 @@ package no.nav.familie.klage.distribusjon
 
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.brev.BrevService
-import no.nav.familie.klage.brev.BrevmottakerUtil.validerMinimumEnMottaker
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalpost
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/BrevmottakerKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/BrevmottakerKtTest.kt
@@ -1,16 +1,81 @@
 package no.nav.familie.klage.brevmottaker.domain
 
 import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.klage.testutil.DomainUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class BrevmottakerKtTest {
-    private val brevmottakerPersonDeserializer: BrevmottakerPersonDeserializer = BrevmottakerPersonDeserializer()
+    @Nested
+    inner class BrevmottakerPersonUtenIdentTest {
+        @Test
+        fun `skal opprette BrevmottakerPersonUtenIdent fra NyBrevmottakerPersonUtenIdent med oppgitt ID`() {
+            // Arrange
+            val id = UUID.randomUUID()
+
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresselinje 1",
+                adresselinje2 = "Adresselinje 2",
+                postnummer = "0010",
+                poststed = "Oslo",
+                landkode = "NO",
+            )
+
+            // Act
+            val brevmottakerPersonUtenIdent = BrevmottakerPersonUtenIdent.opprettFra(
+                id = id,
+                nyBrevmottakerPersonUtenIdent = nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Assert
+            assertThat(brevmottakerPersonUtenIdent.id).isEqualTo(id)
+            assertThat(brevmottakerPersonUtenIdent.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+            assertThat(brevmottakerPersonUtenIdent.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+            assertThat(brevmottakerPersonUtenIdent.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+            assertThat(brevmottakerPersonUtenIdent.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+            assertThat(brevmottakerPersonUtenIdent.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+            assertThat(brevmottakerPersonUtenIdent.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+            assertThat(brevmottakerPersonUtenIdent.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+        }
+
+        @Test
+        fun `skal opprette BrevmottakerPersonUtenIdent fra NyBrevmottakerPersonUtenIdent med default ID`() {
+            // Arrange
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent(
+                mottakerRolle = MottakerRolle.FULLMAKT,
+                navn = "Navn Navnesen",
+                adresselinje1 = "Adresselinje 1",
+                adresselinje2 = "Adresselinje 2",
+                postnummer = "0010",
+                poststed = "Oslo",
+                landkode = "NO",
+            )
+
+            // Act
+            val brevmottakerPersonUtenIdent = BrevmottakerPersonUtenIdent.opprettFra(
+                nyBrevmottakerPersonUtenIdent = nyBrevmottakerPersonUtenIdent,
+            )
+
+            // Assert
+            assertThat(brevmottakerPersonUtenIdent.id).isNotNull()
+            assertThat(brevmottakerPersonUtenIdent.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+            assertThat(brevmottakerPersonUtenIdent.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+            assertThat(brevmottakerPersonUtenIdent.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+            assertThat(brevmottakerPersonUtenIdent.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+            assertThat(brevmottakerPersonUtenIdent.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+            assertThat(brevmottakerPersonUtenIdent.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+            assertThat(brevmottakerPersonUtenIdent.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+        }
+    }
 
     @Nested
     inner class BrevmottakerPersonDeserializerTest {
+        private val brevmottakerPersonDeserializer: BrevmottakerPersonDeserializer = BrevmottakerPersonDeserializer()
+
         @Test
         fun `skal deserialisere BrevmottakerPersonMedIdent`() {
             // Arrange

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/BrevmottakereDtoTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/BrevmottakereDtoTest.kt
@@ -1,0 +1,94 @@
+package no.nav.familie.klage.brevmottaker.dto
+
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+class BrevmottakereDtoTest {
+    @Nested
+    inner class ValiderTest {
+        @Test
+        fun `skal kaste exception om både personer og organisasjoner er tom`() {
+            // Arrange
+            val brevmottakereDto = BrevmottakereDto(
+                personer = emptyList(),
+                organisasjoner = emptyList(),
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                brevmottakereDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.feilmelding).isEqualTo("Må ha minimum en brevmottaker.")
+            assertThat(exception.message).isEqualTo("Må ha minimum en brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste exception det er en duplikat ident for person med ident`() {
+            // Arrange
+            val brevmottakereDto = BrevmottakereDto(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                ),
+                organisasjoner = emptyList(),
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                brevmottakereDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.feilmelding).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste exception det er en duplikat id for person uten ident`() {
+            // Arrange
+            val id = UUID.randomUUID()
+
+            val brevmottakereDto = BrevmottakereDto(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonUtenIdent(id = id),
+                    DomainUtil.lagBrevmottakerPersonUtenIdent(id = id),
+                ),
+                organisasjoner = emptyList(),
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                brevmottakereDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.feilmelding).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste exception det er et duplikat orgnr for organisasjoner`() {
+            // Arrange
+            val brevmottakereDto = BrevmottakereDto(
+                personer = emptyList(),
+                organisasjoner = listOf(
+                    DomainUtil.lagBrevmottakerOrganisasjon(organisasjonsnummer = "123"),
+                    DomainUtil.lagBrevmottakerOrganisasjon(organisasjonsnummer = "123"),
+                ),
+            )
+
+            // Act & assert
+            val exception = assertThrows<ApiFeil> {
+                brevmottakereDto.valider()
+            }
+            assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(exception.feilmelding).isEqualTo("En organisasjon kan bare legges til en gang som brevmottaker.")
+            assertThat(exception.message).isEqualTo("En organisasjon kan bare legges til en gang som brevmottaker.")
+        }
+    }
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23920

Så noen forbedringspotensialer etter merge av forrige PR, tenkte det var greit å ta de i en egen PR. 

Flytter BrevmottakerUtil, korrigerer typos, legger til manglende tester, og forenkler oppretting av BrevmottakerPersonUtenIdent.

Har kjørt opp løsningen lokalt og det ser ut til å fungere fint. 