### PR TITLE
Fjerner gammel brevmottaker kode som var knyttet tett opp til brevklassene

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevController.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.klage.brev
 
-import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
-import no.nav.familie.klage.brevmottaker.dto.tilDto
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -10,7 +8,6 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -23,7 +20,6 @@ class BrevController(
     private val brevService: BrevService,
     private val tilgangService: TilgangService,
 ) {
-
     @GetMapping("/{behandlingId}/pdf")
     fun hentBrevPdf(@PathVariable behandlingId: UUID): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
@@ -36,23 +32,5 @@ class BrevController(
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(brevService.lagBrev(behandlingId))
-    }
-
-    @GetMapping("/{behandlingId}/mottakere")
-    fun hentBrevmottakere(@PathVariable behandlingId: UUID): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
-        return Ressurs.success(brevService.hentBrevmottakere(behandlingId).tilDto())
-    }
-
-    @PostMapping("/{behandlingId}/mottakere")
-    fun oppdaterBrevmottakere(
-        @PathVariable behandlingId: UUID,
-        @RequestBody mottakere: BrevmottakereDto,
-    ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
-        brevService.settBrevmottakere(behandlingId, mottakere)
-        return Ressurs.success(mottakere)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -15,13 +15,9 @@ import no.nav.familie.klage.brev.dto.Flettefelter
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
 import no.nav.familie.klage.brev.dto.Henleggelsesbrev
 import no.nav.familie.klage.brev.dto.SignaturDto
-import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
-import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
-import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
-import no.nav.familie.klage.brevmottaker.dto.tilDomene
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.fagsak.domain.Fagsak
@@ -71,27 +67,6 @@ class BrevService(
     private val taskService: TaskService,
 ) {
     fun hentBrev(behandlingId: UUID): Brev = brevRepository.findByIdOrThrow(behandlingId)
-
-    fun hentBrevmottakere(behandlingId: UUID): Brevmottakere {
-        val brev = brevRepository.findByIdOrThrow(behandlingId)
-        return brev.mottakere ?: Brevmottakere()
-    }
-
-    fun settBrevmottakere(
-        behandlingId: UUID,
-        brevmottakere: BrevmottakereDto,
-    ) {
-        val behandling = behandlingService.hentBehandling(behandlingId)
-        validerKanLageBrev(behandling)
-
-        val mottakere = brevmottakere.tilDomene()
-
-        validerUnikeBrevmottakere(mottakere)
-        validerMinimumEnMottaker(mottakere)
-
-        val brev = brevRepository.findByIdOrThrow(behandlingId)
-        brevRepository.update(brev.copy(mottakere = mottakere))
-    }
 
     fun lagBrev(behandlingId: UUID): ByteArray {
         val personopplysninger = personopplysningerService.hentPersonopplysninger(behandlingId)

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtil.kt
@@ -1,29 +1,9 @@
 package no.nav.familie.klage.brevmottaker
 
-import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
-import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
-import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 
 object BrevmottakerUtil {
-    fun validerUnikeBrevmottakere(mottakere: Brevmottakere) {
-        val personmottakerIdentifikatorer = mottakere.personer.map {
-            when (it) {
-                is BrevmottakerPersonMedIdent -> it.personIdent
-                is BrevmottakerPersonUtenIdent -> it.id.toString()
-            }
-        }
-        brukerfeilHvisIkke(personmottakerIdentifikatorer.distinct().size == personmottakerIdentifikatorer.size) {
-            "En person kan bare legges til en gang som brevmottaker"
-        }
-
-        val organisasjonsmottakerIdenter = mottakere.organisasjoner.map { it.organisasjonsnummer }
-        brukerfeilHvisIkke(organisasjonsmottakerIdenter.distinct().size == organisasjonsmottakerIdenter.size) {
-            "En organisasjon kan bare legges til en gang som brevmottaker"
-        }
-    }
-
     fun validerMinimumEnMottaker(mottakere: Brevmottakere) {
         feilHvis(mottakere.personer.isEmpty() && mottakere.organisasjoner.isEmpty()) {
             "Må ha minimum en mottaker"

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.klage.distribusjon
 
 import no.nav.familie.klage.behandling.BehandlingService
-import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.BrevmottakerService
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.util.TaskMetadata
 import no.nav.familie.klage.kabal.KabalService
@@ -26,7 +26,7 @@ class SendTilKabalTask(
     private val behandlingService: BehandlingService,
     private val kabalService: KabalService,
     private val vurderingService: VurderingService,
-    private val brevService: BrevService,
+    private val brevmottakerService: BrevmottakerService,
 ) : AsyncTaskStep {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -43,7 +43,7 @@ class SendTilKabalTask(
 
         val brevmottakere =
             if (behandling.årsak != Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL) {
-                brevService.hentBrevmottakere(behandlingId)
+                brevmottakerService.hentBrevmottakere(behandlingId)
             } else {
                 null
             }

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTaskTest.kt
@@ -6,7 +6,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.klage.behandling.BehandlingService
-import no.nav.familie.klage.brev.BrevService
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey
@@ -24,6 +23,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
 import java.util.Properties
 import kotlin.test.Test
+import no.nav.familie.klage.brevmottaker.BrevmottakerService
 
 internal class SendTilKabalTaskTest {
 
@@ -31,14 +31,14 @@ internal class SendTilKabalTaskTest {
     private val behandlingService: BehandlingService = mockk()
     private val kabalService: KabalService = mockk()
     private val vurderingService: VurderingService = mockk()
-    private val brevService: BrevService = mockk()
+    private val brevmottakerService: BrevmottakerService = mockk()
 
     private val sendTilKabalTask = SendTilKabalTask(
         fagsakService = fagsakService,
         behandlingService = behandlingService,
         kabalService = kabalService,
         vurderingService = vurderingService,
-        brevService = brevService,
+        brevmottakerService = brevmottakerService,
     )
 
     @Test
@@ -52,7 +52,7 @@ internal class SendTilKabalTaskTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { fagsakService.hentFagsakForBehandling(behandling.id) } returns mockk()
         every { vurderingService.hentVurdering(behandling.id) } returns mockk()
-        every { brevService.hentBrevmottakere(behandling.id) } returns Brevmottakere()
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns Brevmottakere()
 
         every { kabalService.sendTilKabal(any(), any(), any(), any(), any()) } throws HttpClientErrorException(HttpStatus.CONFLICT)
         assertDoesNotThrow { sendTilKabalTask.doTask(task) }
@@ -76,7 +76,7 @@ internal class SendTilKabalTaskTest {
         every { behandlingService.hentBehandling(behandling.id) } returns behandling
         every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
         every { vurderingService.hentVurdering(behandling.id) } returns vurdering
-        every { brevService.hentBrevmottakere(behandling.id) } returns brevmottakere
+        every { brevmottakerService.hentBrevmottakere(behandling.id) } returns brevmottakere
         every { kabalService.sendTilKabal(any(), any(), any(), any(), any()) } just Runs
 
         sendTilKabalTask.doTask(task)
@@ -105,7 +105,7 @@ internal class SendTilKabalTaskTest {
 
         sendTilKabalTask.doTask(task)
 
-        verify(exactly = 0) { brevService.hentBrevmottakere(any()) }
+        verify(exactly = 0) { brevmottakerService.hentBrevmottakere(any()) }
         verify(exactly = 1) { kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerIdent, null) }
     }
 }


### PR DESCRIPTION
Denne PRen må merges først: https://github.com/navikt/familie-klage-frontend/pull/891

Går over til ny kode som ligger under `brevmottaker` pakke, altså `BrevmottakerController`, `BrevmottakerService`, etc. 