### PR TITLE
Legacy - fjerne deprecated work flow variabler fra build & deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,8 +30,6 @@ jobs:
         id: docker-push
         with:
           team: teamfamilie
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           byosbom: target/classes/META-INF/sbom/application.cdx.json
     outputs:
       image: ${{ steps.docker-push.outputs.image }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           team: teamfamilie
           tag: latest
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           byosbom: target/classes/META-INF/sbom/application.cdx.json
 
       - name: Post build failures to Slack


### PR DESCRIPTION
# Fjerne deprecated work flow variabler fra build & deploy 

### Hvorfor er denne endringen nødvendig? ✨ 

Denne PRen prøver å fjerne deprecated work flow variabler fra bygg og deploy taskene. NAIS har satt og `identity_provider` og `project_id` deprecated og skal fjernes, da alle setter de samme verdiene her og utledes derfor automatisk av nais-plattformen nå. Workflows med disse parameterene satt vil ikke lenger virke etter 3. mars.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24100).

### Verdt å nevne

Dette er en av mange PRer der denne samme endringen gjøres for repoer tilhørende enslig-forsørger. 