### PR TITLE
Ved tilgangsfeil ved opprett behandleSakOppgave ønsker vi å forsøke i…

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -6,11 +6,11 @@ import no.nav.familie.klage.behandling.domain.PåklagetVedtakDetaljer
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.behandling.domain.erLåstForVidereBehandling
-import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
-import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
 import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.brevmottaker.domain.MottakerRolle

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
@@ -2,10 +2,10 @@ package no.nav.familie.klage.distribusjon
 
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.brev.BrevService
-import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalpost
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.distribusjon.JournalføringUtil.mapAvsenderMottaker
 import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
@@ -33,7 +33,8 @@ class OpprettBehandleSakOppgaveTask(
         val behandlingId = UUID.fromString(task.payload)
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
-        val klageGjelderTilbakekreving: Boolean = task.metadata.getProperty(klageGjelderTilbakekrevingMetadataKey).toBoolean()
+        val klageGjelderTilbakekreving: Boolean =
+            task.metadata.getProperty(klageGjelderTilbakekrevingMetadataKey).toBoolean()
 
         val oppgaveRequest = OpprettOppgaveRequest(
             ident = OppgaveIdentV2(ident = fagsak.hentAktivIdent(), gruppe = IdentGruppe.FOLKEREGISTERIDENT),
@@ -48,12 +49,26 @@ class OpprettBehandleSakOppgaveTask(
             tilordnetRessurs = task.metadata.getProperty(saksbehandlerMetadataKey),
             behandlingstema = if (klageGjelderTilbakekreving) Behandlingstema.Tilbakebetaling.value else null,
         )
+        try {
+            opprettOppgaveOgLagre(oppgaveRequest, behandlingId)
+        } catch (e: Exception) {
+            if (navIdentHarIkkeTilgangTilEnheten(e)) {
+                opprettOppgaveOgLagre(oppgaveRequest.copy(tilordnetRessurs = null), behandlingId)
+            } else {
+                throw e
+            }
+        }
+    }
 
-        val oppgaveId = oppgaveClient.opprettOppgave(opprettOppgaveRequest = oppgaveRequest)
+    private fun opprettOppgaveOgLagre(request: OpprettOppgaveRequest, behandlingId: UUID) {
+        val oppgaveId = oppgaveClient.opprettOppgave(opprettOppgaveRequest = request)
         behandleSakOppgaveRepository.insert(
-            BehandleSakOppgave(behandlingId = behandling.id, oppgaveId = oppgaveId),
+            BehandleSakOppgave(behandlingId = behandlingId, oppgaveId = oppgaveId),
         )
     }
+
+    private fun navIdentHarIkkeTilgangTilEnheten(e: Exception): Boolean =
+        e.message?.contains("navIdent har ikke tilgang til enheten") ?: false
 
     companion object {
         const val TYPE = "opprettBehandleSakoppgave"

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/PdlClientMock.kt
@@ -52,13 +52,13 @@ class PdlClientMock {
                 listOf(
                     PdlIdent(
                         firstArg(),
-                        false
+                        false,
                     ),
                     PdlIdent(
                         "98765432109",
-                        true
-                    )
-                )
+                        true,
+                    ),
+                ),
             )
         }
 

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -190,15 +190,15 @@ object DomainUtil {
             sporbar = sporbar,
             eksternId = "1",
             fagsystem =
-                when (stønadstype) {
-                    Stønadstype.OVERGANGSSTØNAD,
-                    Stønadstype.BARNETILSYN,
-                    Stønadstype.SKOLEPENGER,
-                    -> Fagsystem.EF
+            when (stønadstype) {
+                Stønadstype.OVERGANGSSTØNAD,
+                Stønadstype.BARNETILSYN,
+                Stønadstype.SKOLEPENGER,
+                -> Fagsystem.EF
 
-                    Stønadstype.BARNETRYGD -> Fagsystem.BA
-                    Stønadstype.KONTANTSTØTTE -> Fagsystem.KS
-                },
+                Stønadstype.BARNETRYGD -> Fagsystem.BA
+                Stønadstype.KONTANTSTØTTE -> Fagsystem.KS
+            },
         )
 
     fun klageresultat(


### PR DESCRIPTION
…gjen med tilordnetRessurs satt til null

**Bakgrunn**
[Slack](https://nav-it.slack.com/archives/G012YEK9YQ1/p1739349401792599)
Feilede tasker: [Task 1](https://familie-prosessering.intern.nav.no/service/familie-klage/task/32575), [Task 2](https://familie-prosessering.intern.nav.no/service/familie-klage/task/32579)

Av og til vil en saksbehandler som jobber med sammensatte saker opprette behandlinger og saksbehandle i vårt system. I disse tilfellene ønsker vi allikevel å få tilgang til å opprette behandleSakOppgaver via klage men da må vi sende med "tilordnetRessurs" (saksbehandler) lik null