### PR TITLE
NAV-24412: Legger til manglende enum som forhindrer proessering av kafka meldinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/kabal/domain/OversendtKlageAnkeV3.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/domain/OversendtKlageAnkeV3.kt
@@ -34,8 +34,9 @@ enum class Type(
 ) {
     KLAGE("1", "Klage", "Klage"),
     ANKE("2", "Anke", "Anke"),
-    ANKE_I_TRYGDERETTEN("3", "Anke i trygderetten", "Anke i trygderetten"),
-    OMGJOERINGSKRAV("4", "Omgjøringskrav", "Omgjøringskrav"),
+    ANKE_I_TRYGDERETTEN("3", "Anke i Trygderetten", "Anke i Trygderetten"),
+    BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET("4", "Behandling etter Trygderetten opphevet", "Behandling etter Trygderetten opphevet"),
+    OMGJOERINGSKRAV("5", "Omgjøringskrav", "Omgjøringskrav"),
 }
 
 data class OversendtKlager(


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24412

Ser at det er innført en enum av typen `BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET` i [klage-kodeverk](https://github.com/navikt/klage-kodeverk/blob/main/src/main/kotlin/no/nav/klage/kodeverk/Type.kt#L11). Denne typen mangler i familie-klage. Når man prøver å prosessere kafka meldinger med denne typen får man en feilmelding og meldingen blir ikke prosessert. Det forhindrer at nye meldinger som kommer på topicet blir prosessert. Se [kibana](https://logs.adeo.no/s/nav-logs-legacy/app/discover#/doc/0d8b7d4e-18f5-4cd1-a02f-f53750611e2f/tjenestekall-team-teamfamilie-000003?id=rhWEI5UBHSyLL8t9V15f) for feilmeldingen.

Det er litt uheldig at endringer i deres enum gjør slik at vi ikke får prosessert meldinger, så man burde egentlig ta en titt på det også etter hvert. 