### PR TITLE
skal ikke sende brev til kabal ved klagebehandiingsårsak henvendelse …

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTask.kt
@@ -6,6 +6,7 @@ import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.util.TaskMetadata
 import no.nav.familie.klage.kabal.KabalService
 import no.nav.familie.klage.vurdering.VurderingService
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -30,9 +31,18 @@ class SendTilKabalTask(
         val saksbehandlerIdent = task.metadata[TaskMetadata.saksbehandlerMetadataKey].toString()
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
+
         val vurdering =
-            vurderingService.hentVurdering(behandlingId) ?: error("Mangler vurdering på klagen - kan ikke oversendes til kabal")
-        val brevmottakere = brevService.hentBrevmottakere(behandlingId)
+            vurderingService.hentVurdering(behandlingId)
+                ?: error("Mangler vurdering på klagen - kan ikke oversendes til kabal")
+
+        val brevmottakere =
+            if (behandling.årsak != Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL) {
+                brevService.hentBrevmottakere(behandlingId)
+            } else {
+                null
+            }
+
         kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerIdent, brevmottakere)
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -16,7 +16,7 @@ class FeatureToggleController(private val featureToggleService: FeatureToggleSer
     private val funksjonsbrytere: Set<Toggle> = setOf(
         Toggle.SETT_PÅ_VENT,
         Toggle.VIS_BREVMOTTAKER_BAKS,
-        Toggle.LEGG_TIL_BREVMOTTAKER_BAKS
+        Toggle.LEGG_TIL_BREVMOTTAKER_BAKS,
     )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/klage/kabal/KabalService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/KabalService.kt
@@ -33,7 +33,7 @@ class KabalService(
         behandling: Behandling,
         vurdering: Vurdering,
         saksbehandlerIdent: String,
-        brevMottakere: Brevmottakere,
+        brevMottakere: Brevmottakere?,
     ) {
         val saksbehandler = integrasjonerClient.hentSaksbehandlerInfo(saksbehandlerIdent)
         val oversendtKlageAnkeV3 =
@@ -46,7 +46,7 @@ class KabalService(
         behandling: Behandling,
         vurdering: Vurdering,
         saksbehandlersEnhet: String,
-        brevMottakere: Brevmottakere,
+        brevMottakere: Brevmottakere?,
     ): OversendtKlageAnkeV3 =
         OversendtKlageAnkeV3(
             type = Type.KLAGE,
@@ -57,7 +57,7 @@ class KabalService(
                     type = OversendtPartIdType.PERSON,
                     verdi = fagsak.hentAktivIdent(),
                 ),
-                klagersProsessfullmektig = utledFullmektigFraBrevmottakere(brevMottakere),
+                klagersProsessfullmektig = brevMottakere?.let { utledFullmektigFraBrevmottakere(brevMottakere) },
             ),
             fagsak = OversendtSak(fagsakId = fagsak.eksternId, fagsystem = fagsak.fagsystem.tilFellesFagsystem()),
             kildeReferanse = behandling.eksternBehandlingId.toString(),

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingServiceIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingServiceIntegrasjonTest.kt
@@ -4,9 +4,13 @@ import io.mockk.every
 import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.familie.klage.behandling.dto.PåklagetVedtakDto
 import no.nav.familie.klage.behandling.dto.tilPåklagetVedtakDetaljer
+import no.nav.familie.klage.infrastruktur.config.FamilieBASakClientMock
 import no.nav.familie.klage.infrastruktur.config.FamilieEFSakClientMock
+import no.nav.familie.klage.infrastruktur.config.FamilieKSSakClientMock
 import no.nav.familie.klage.infrastruktur.config.OppslagSpringRunnerTest
+import no.nav.familie.klage.integrasjoner.FamilieBASakClient
 import no.nav.familie.klage.integrasjoner.FamilieEFSakClient
+import no.nav.familie.klage.integrasjoner.FamilieKSSakClient
 import no.nav.familie.klage.testutil.BrukerContextUtil
 import no.nav.familie.klage.testutil.DomainUtil.behandling
 import no.nav.familie.klage.testutil.DomainUtil.fagsak
@@ -22,10 +26,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.LocalDateTime.now
-import no.nav.familie.klage.infrastruktur.config.FamilieBASakClientMock
-import no.nav.familie.klage.infrastruktur.config.FamilieKSSakClientMock
-import no.nav.familie.klage.integrasjoner.FamilieBASakClient
-import no.nav.familie.klage.integrasjoner.FamilieKSSakClient
 
 internal class BehandlingServiceIntegrasjonTest : OppslagSpringRunnerTest() {
 

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/SendTilKabalTaskTest.kt
@@ -1,0 +1,91 @@
+package no.nav.familie.klage.distribusjon
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey
+import no.nav.familie.klage.kabal.KabalService
+import no.nav.familie.klage.testutil.DomainUtil.behandling
+import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
+import no.nav.familie.klage.testutil.DomainUtil.lagBrevmottakere
+import no.nav.familie.klage.testutil.DomainUtil.tilFagsak
+import no.nav.familie.klage.testutil.DomainUtil.vurdering
+import no.nav.familie.klage.vurdering.VurderingService
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
+import no.nav.familie.prosessering.domene.Task
+import org.junit.jupiter.api.Test
+import java.util.Properties
+
+internal class SendTilKabalTaskTest {
+
+    private val fagsakService = mockk<FagsakService>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val kabalService = mockk<KabalService>()
+    private val vurderingService = mockk<VurderingService>()
+    private val brevService = mockk<BrevService>()
+
+    private val sendTilKabalTask =
+        SendTilKabalTask(
+            fagsakService = fagsakService,
+            behandlingService = behandlingService,
+            kabalService = kabalService,
+            vurderingService = vurderingService,
+            brevService = brevService,
+        )
+
+    @Test
+    internal fun `skal oversende klage til kabal`() {
+        val fagsak = fagsakDomain().tilFagsak()
+        val behandling = behandling(fagsak = fagsak, årsak = Klagebehandlingsårsak.ORDINÆR)
+        val saksbehandlerIdent = "1"
+        val vurdering = vurdering(behandlingId = behandling.id)
+        val brevmottakere = lagBrevmottakere()
+        val task = Task(
+            type = SendTilKabalTask.TYPE,
+            payload = behandling.id.toString(),
+            properties = Properties().apply {
+                this[saksbehandlerMetadataKey] = saksbehandlerIdent
+            },
+        )
+
+        every { behandlingService.hentBehandling(behandling.id) } returns behandling
+        every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
+        every { vurderingService.hentVurdering(behandling.id) } returns vurdering
+        every { brevService.hentBrevmottakere(behandling.id) } returns brevmottakere
+        every { kabalService.sendTilKabal(any(), any(), any(), any(), any()) } just Runs
+
+        sendTilKabalTask.doTask(task)
+
+        verify(exactly = 1) { kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerIdent, brevmottakere) }
+    }
+
+    @Test
+    internal fun `skal ikke oversende brevmottakere når klagebehandlingsårsak er henvendelse fra kabal`() {
+        val fagsak = fagsakDomain().tilFagsak()
+        val behandling = behandling(fagsak = fagsak, årsak = Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL)
+        val saksbehandlerIdent = "1"
+        val vurdering = vurdering(behandlingId = behandling.id)
+        val task = Task(
+            type = SendTilKabalTask.TYPE,
+            payload = behandling.id.toString(),
+            properties = Properties().apply {
+                this[saksbehandlerMetadataKey] = saksbehandlerIdent
+            },
+        )
+
+        every { behandlingService.hentBehandling(behandling.id) } returns behandling
+        every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
+        every { vurderingService.hentVurdering(behandling.id) } returns vurdering
+        every { kabalService.sendTilKabal(any(), any(), any(), any(), any()) } just Runs
+
+        sendTilKabalTask.doTask(task)
+
+        verify(exactly = 0) { brevService.hentBrevmottakere(any()) }
+        verify(exactly = 1) { kabalService.sendTilKabal(fagsak, behandling, vurdering, saksbehandlerIdent, null) }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
@@ -3,9 +3,6 @@ package no.nav.familie.klage.infrastruktur.config
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
-import java.time.LocalDateTime
-import java.time.Month
-import java.util.UUID
 import no.nav.familie.klage.integrasjoner.FamilieBASakClient
 import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
@@ -20,6 +17,9 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
+import java.time.LocalDateTime
+import java.time.Month
+import java.util.UUID
 
 @Configuration
 @Profile("mock-ba-sak")
@@ -34,7 +34,6 @@ class FamilieBASakClientMock {
     companion object {
 
         fun resetMock(mock: FamilieBASakClient): FamilieBASakClient {
-
             clearMocks(mock)
 
             every { mock.hentVedtak(any()) } returns listOf(
@@ -94,9 +93,6 @@ class FamilieBASakClientMock {
             }
 
             return mock
-
         }
-
     }
-
 }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
@@ -3,9 +3,6 @@ package no.nav.familie.klage.infrastruktur.config
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
-import java.time.LocalDateTime
-import java.time.Month
-import java.util.UUID
 import no.nav.familie.klage.integrasjoner.FamilieKSSakClient
 import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
@@ -20,6 +17,9 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
+import java.time.LocalDateTime
+import java.time.Month
+import java.util.UUID
 
 @Configuration
 @Profile("mock-ks-sak")
@@ -34,7 +34,6 @@ class FamilieKSSakClientMock {
     companion object {
 
         fun resetMock(mock: FamilieKSSakClient): FamilieKSSakClient {
-
             clearMocks(mock)
 
             every { mock.hentVedtak(any()) } returns listOf(
@@ -94,9 +93,6 @@ class FamilieKSSakClientMock {
             }
 
             return mock
-
         }
-
     }
-
 }


### PR DESCRIPTION
…fra kabal

Bugfix: Vi ønsker ikke å prøve å hente ut brevmottakere når vi skal oversende klage til kabal ved behandlingsårsak: Henvendelse fra Kabal. 

Bakgrunn:
[Slack](https://nav-it.slack.com/archives/G012YEK9YQ1/p1740646781624029)