### PR TITLE
NAV-24445: Legger til toggle for å kunne sette behandlingstema til klage

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -27,6 +27,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     SETT_PÅ_VENT("familie.klage.sett-pa-vent", "Release"),
     VIS_BREVMOTTAKER_BAKS("familie-klage.vis-brevmottaker-baks", "Release"),
     LEGG_TIL_BREVMOTTAKER_BAKS("familie-klage.legg-til-brevmottaker-baks", "Release"),
+    SETT_BEHANDLINGSTEMA_TIL_KLAGE("familie-klage.nav-24445-sett-behandlingstema-til-klage", "Release"),
     ;
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.UUID
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 
 internal class BehandlingEventServiceTest {
 
@@ -43,6 +44,7 @@ internal class BehandlingEventServiceTest {
     private val stegService = mockk<StegService>(relaxed = true)
     private val klageresultatRepository = mockk<KlageresultatRepository>(relaxed = true)
     private val integrasjonerClient = mockk<FamilieIntegrasjonerClient>(relaxed = true)
+    private val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
 
     val behandlingEventService = BehandlingEventService(
         behandlingRepository = behandlingRepository,
@@ -51,6 +53,7 @@ internal class BehandlingEventServiceTest {
         taskService = taskService,
         klageresultatRepository = klageresultatRepository,
         integrasjonerClient = integrasjonerClient,
+        featureToggleService = featureToggleService,
     )
 
     val behandlingMedStatusVenter = DomainUtil.behandling(status = BehandlingStatus.VENTER)
@@ -62,6 +65,7 @@ internal class BehandlingEventServiceTest {
         every { klageresultatRepository.insert(any()) } answers { firstArg() }
         every { klageresultatRepository.existsById(any()) } returns false
         every { integrasjonerClient.hentSaksbehandlerInfo(any()) } returns saksbehandler
+        every { featureToggleService.isEnabled(any(), any()) } returns false
     }
 
     @Test


### PR DESCRIPTION
Favro: [NAV-24445 ](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24445)

Vi får foreløpig feil når vi sender inn `Barnetrygd`, se [her](https://github.com/navikt/oppgave/pull/574) for mer informasjon.

Vi ønsker å teste hvordan systemet oppfører seg når vi sender inn `Klage`, legger det derfor bak en toggle for KS og BA. 

Togglen er skrudd på i dev. 