### PR TITLE
Bruk ba ks datasett hvis stønadstypen er ks ba

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
@@ -60,8 +60,8 @@ class BrevClient(
             "HTML-generering av fritekstbrev er ikke implementert"
         }
 
-        val dataset = hentTilhørendeSanityDataset(stønadstype)
-        val url = URI.create("$familieBrevUri/api/$dataset/avansert-dokument/bokmaal/$brevmal/html")
+        val datasetOgType = hentTilhørendeSanityDatasetOgType(stønadstype)
+        val url = URI.create("$familieBrevUri/api/$datasetOgType/bokmaal/$brevmal/html")
 
         return postForEntity(
             url,
@@ -76,7 +76,7 @@ class BrevClient(
         )
     }
 
-    private fun hentTilhørendeSanityDataset(stønadstype: Stønadstype) =
+    private fun hentTilhørendeSanityDatasetOgType(stønadstype: Stønadstype) =
         when (stønadstype) {
             Stønadstype.BARNETRYGD -> BA_SANITY_DATASET
             Stønadstype.KONTANTSTØTTE -> KS_SANITY_DATASET
@@ -86,9 +86,9 @@ class BrevClient(
     companion object {
         const val FRITEKST = "fritekst"
 
-        const val BA_SANITY_DATASET = "ba-brev"
-        const val KS_SANITY_DATASET = "ks-brev"
-        const val EF_SANITTY_DATASET = "ef-brev"
+        const val BA_SANITY_DATASET = "ba-brev/dokument"
+        const val KS_SANITY_DATASET = "ks-brev/dokument"
+        const val EF_SANITTY_DATASET = "ef-brev/avansert-dokument"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
@@ -7,6 +7,7 @@ import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
 import no.nav.familie.klage.felles.util.TekstUtil.norskFormat
 import no.nav.familie.klage.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -53,12 +54,14 @@ class BrevClient(
         saksbehandlersignatur: String,
         enhet: String?,
         skjulBeslutterSignatur: Boolean,
+        stønadstype: Stønadstype,
     ): String {
         feilHvis(brevmal === FRITEKST) {
             "HTML-generering av fritekstbrev er ikke implementert"
         }
 
-        val url = URI.create("$familieBrevUri/api/ef-brev/avansert-dokument/bokmaal/$brevmal/html")
+        val dataset = hentTilhørendeSanityDataset(stønadstype)
+        val url = URI.create("$familieBrevUri/api/$dataset/avansert-dokument/bokmaal/$brevmal/html")
 
         return postForEntity(
             url,
@@ -73,8 +76,19 @@ class BrevClient(
         )
     }
 
+    private fun hentTilhørendeSanityDataset(stønadstype: Stønadstype) =
+        when (stønadstype) {
+            Stønadstype.BARNETRYGD -> BA_SANITY_DATASET
+            Stønadstype.KONTANTSTØTTE -> KS_SANITY_DATASET
+            Stønadstype.OVERGANGSSTØNAD, Stønadstype.BARNETILSYN, Stønadstype.SKOLEPENGER -> EF_SANITTY_DATASET
+        }
+
     companion object {
         const val FRITEKST = "fritekst"
+
+        const val BA_SANITY_DATASET = "ba-brev"
+        const val KS_SANITY_DATASET = "ks-brev"
+        const val EF_SANITTY_DATASET = "ef-brev"
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -147,7 +147,7 @@ class BrevInnholdUtleder(
             listOf(
                 AvsnittDto(
                     deloverskrift = "",
-                    innhold = "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om ${stønadstype.name.lowercase()}",
+                    innhold = "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om ${stønadstype.name.lowercase()}. Vi har derfor avsluttet saken din.",
                 ),
                 harDuSpørsmålAvsnitt(stønadstype),
             ),

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -134,6 +134,26 @@ class BrevInnholdUtleder(
         )
     }
 
+    fun lagHenleggelsesbrevBaksInnhold(
+        ident: String,
+        navn: String,
+        stønadstype: Stønadstype,
+    ): FritekstBrevRequestDto {
+        return FritekstBrevRequestDto(
+            overskrift = "Saken din er avsluttet",
+            personIdent = ident,
+            navn = navn,
+            avsnitt =
+            listOf(
+                AvsnittDto(
+                    deloverskrift = "",
+                    innhold = "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om ${stønadstype.name.lowercase()}",
+                ),
+                harDuSpørsmålAvsnitt(stønadstype),
+            ),
+        )
+    }
+
     private fun duHarRettTilÅKlageAvsnitt(stønadstype: Stønadstype) =
         AvsnittDto(
             deloverskrift = "Du har rett til å klage",

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -284,6 +284,7 @@ class BrevService(
                     saksbehandlersignatur = signaturMedEnhet.navn,
                     enhet = signaturMedEnhet.enhet,
                     skjulBeslutterSignatur = true,
+                    stønadstype = fagsak.stønadstype,
                 )
         return html
     }

--- a/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventService.kt
@@ -7,6 +7,8 @@ import no.nav.familie.klage.behandling.domain.Behandling
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.fagsak.FagsakRepository
 import no.nav.familie.klage.infrastruktur.config.DatabaseConfiguration.StringListWrapper
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.kabal.BehandlingEvent
 import no.nav.familie.klage.kabal.BehandlingFeilregistrertTask
@@ -24,8 +26,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
-import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 
 @Service
 class BehandlingEventService(
@@ -35,7 +35,7 @@ class BehandlingEventService(
     private val klageresultatRepository: KlageresultatRepository,
     private val stegService: StegService,
     private val integrasjonerClient: FamilieIntegrasjonerClient,
-    private val featureToggleService: FeatureToggleService
+    private val featureToggleService: FeatureToggleService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -135,7 +135,7 @@ class BehandlingEventService(
     private fun finnBehandlingstema(stønadstype: Stønadstype): Behandlingstema {
         val skalSetteBehandlingstemaTilKlage = featureToggleService.isEnabled(
             Toggle.SETT_BEHANDLINGSTEMA_TIL_KLAGE,
-            false
+            false,
         )
         return when (stønadstype) {
             Stønadstype.BARNETRYGD -> if (skalSetteBehandlingstemaTilKlage) {

--- a/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.klage.behandling.BehandlingRepository
 import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.fagsak.FagsakRepository
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.kabal.AnkeITrygderettenbehandlingOpprettetDetaljer
 import no.nav.familie.klage.kabal.AnkebehandlingOpprettetDetaljer
@@ -34,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.UUID
-import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 
 internal class BehandlingEventServiceTest {
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24383

Tanken var å gjøre dette samme måte som EF gjør det med henleggelsesbrev.
Men det er veldig skreddersydd EF, og jeg tenker vi må gjøre BAKS løpet opp mot Sanity en annen gang, som ikke er det kortet her (siden vi ikke bruker sanity per i dag uansett).

