### PR TITLE
NAV-24445: Setter behandlingstema til null og behandlingstype til klage for KS og BA i klagekontekst

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <felles.version>3.20250122103549_5bcb4dc</felles.version>
         <prosessering.version>2.20250205080941_29def62</prosessering.version>
         <start-class>no.nav.familie.klage.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20250211100920_f88b1ab</kontrakter.version>
+        <kontrakter.version>3.0_20250304135943_b3cfec4</kontrakter.version>
         <saksstatistikk-klage.version>2.0_20230214104704_706e9c0</saksstatistikk-klage.version>
         <nav.security.version>5.0.16</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -27,7 +27,10 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     SETT_PÅ_VENT("familie.klage.sett-pa-vent", "Release"),
     VIS_BREVMOTTAKER_BAKS("familie-klage.vis-brevmottaker-baks", "Release"),
     LEGG_TIL_BREVMOTTAKER_BAKS("familie-klage.legg-til-brevmottaker-baks", "Release"),
-    SETT_BEHANDLINGSTEMA_TIL_KLAGE("familie-klage.nav-24445-sett-behandlingstema-til-klage", "Release"),
+    SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_BAKS(
+        "familie-klage.nav-24445-sett-behandlingstema-til-klage",
+        "Release"
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
Favro: [NAV-24445](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24445)

Vi ønsker å sette `Behandlingstema` til `null` og `Behandlingstype` til `Klage` for BA og KS. 

Tenker å skrive tester senere hvis dette viser seg å fungere. Testfilen burde ryddes litt opp i også så tar det i en egen PR senere. 

Logikken er gjemt bak en toggle. 