### PR TITLE
NAV-24505: Oppretting av behandling returnere UUIDen til behandlingen

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -65,8 +65,8 @@ class EksternBehandlingController(
     }
 
     @PostMapping("/opprett")
-    fun opprettBehandling(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest) {
-        opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
+    fun opprettBehandling(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest): UUID {
+        return opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 
     @PatchMapping("{behandlingId}/gjelder-tilbakekreving")

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -65,7 +65,12 @@ class EksternBehandlingController(
     }
 
     @PostMapping("/opprett")
-    fun opprettBehandling(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest): UUID {
+    fun opprettBehandling(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest) {
+        opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
+    }
+
+    @PostMapping("/v2/opprett")
+    fun opprettBehandlingV2(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest): UUID {
         return opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
@@ -179,7 +179,7 @@ internal class EksternBehandlingControllerTest : OppslagSpringRunnerTest() {
 
             // Act
             val response = restTemplate.exchange<UUID>(
-                localhost("$baseUrl/opprett"),
+                localhost("$baseUrl/v2/opprett"),
                 HttpMethod.POST,
                 HttpEntity<OpprettKlagebehandlingRequest>(
                     opprettKlagebehandlingRequest,

--- a/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
@@ -34,7 +34,7 @@ import org.springframework.http.HttpStatus
 
 internal class EksternBehandlingControllerTest : OppslagSpringRunnerTest() {
 
-    private val baseUrl = localhost("/api/ekstern/behandling")
+    private val baseUrl = "/api/ekstern/behandling"
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
@@ -179,7 +179,7 @@ internal class EksternBehandlingControllerTest : OppslagSpringRunnerTest() {
 
             // Act
             val response = restTemplate.exchange<UUID>(
-                baseUrl + "/opprett",
+                localhost("$baseUrl/opprett"),
                 HttpMethod.POST,
                 HttpEntity<OpprettKlagebehandlingRequest>(
                     opprettKlagebehandlingRequest,

--- a/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
@@ -34,7 +34,7 @@ import org.springframework.http.HttpStatus
 
 internal class EksternBehandlingControllerTest : OppslagSpringRunnerTest() {
 
-    private val baseUrl = "/api/ekstern/behandling"
+    private val baseUrl = localhost("/api/ekstern/behandling")
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
@@ -1,11 +1,16 @@
 package no.nav.familie.klage.testutil
 
+import java.time.LocalDate
 import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerOrganisasjonDto
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonMedIdentDto
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonUtenIdentDto
 import no.nav.familie.klage.brevmottaker.dto.SlettbarBrevmottakerPersonUtenIdentDto
 import java.util.UUID
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
+import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
 
 object DtoTestUtil {
     fun lagNyBrevmottakerPersonUtenIdentDto(
@@ -57,6 +62,28 @@ object DtoTestUtil {
     ): SlettbarBrevmottakerPersonUtenIdentDto {
         return SlettbarBrevmottakerPersonUtenIdentDto(
             id,
+        )
+    }
+
+    fun lagOpprettKlagebehandlingRequest(
+        ident: String = "123",
+        stønadstype: Stønadstype = Stønadstype.BARNETRYGD,
+        eksternFagsakId: String = "321",
+        fagsystem: Fagsystem = Fagsystem.BA,
+        klageMottatt: LocalDate = LocalDate.now(),
+        behandlendeEnhet: String = "1000",
+        klageGjelderTilbakekreving: Boolean = false,
+        behandlingsårsak: Klagebehandlingsårsak = Klagebehandlingsårsak.ORDINÆR
+    ): OpprettKlagebehandlingRequest {
+        return OpprettKlagebehandlingRequest(
+            ident = "123",
+            stønadstype = Stønadstype.BARNETRYGD,
+            eksternFagsakId = "321",
+            fagsystem = Fagsystem.BA,
+            klageMottatt = LocalDate.now(),
+            behandlendeEnhet = "1000",
+            klageGjelderTilbakekreving = false,
+            behandlingsårsak = Klagebehandlingsårsak.ORDINÆR
         )
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
@@ -76,14 +76,14 @@ object DtoTestUtil {
         behandlingsårsak: Klagebehandlingsårsak = Klagebehandlingsårsak.ORDINÆR
     ): OpprettKlagebehandlingRequest {
         return OpprettKlagebehandlingRequest(
-            ident = "123",
-            stønadstype = Stønadstype.BARNETRYGD,
-            eksternFagsakId = "321",
-            fagsystem = Fagsystem.BA,
-            klageMottatt = LocalDate.now(),
-            behandlendeEnhet = "1000",
-            klageGjelderTilbakekreving = false,
-            behandlingsårsak = Klagebehandlingsårsak.ORDINÆR
+            ident,
+            stønadstype,
+            eksternFagsakId,
+            fagsystem,
+            klageMottatt,
+            behandlendeEnhet,
+            klageGjelderTilbakekreving,
+            behandlingsårsak,
         )
     }
 }


### PR DESCRIPTION
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Har behov for å vite hvilken UUID behandlingen har når den blir opprettet via BA/KS så returnere derfor den i responsen. 