### PR TITLE
NAV-24505: Wrapper return type UUID i Ressurs

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -70,8 +70,8 @@ class EksternBehandlingController(
     }
 
     @PostMapping("/v2/opprett")
-    fun opprettBehandlingV2(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest): UUID {
-        return opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto)
+    fun opprettBehandlingV2(@RequestBody opprettKlageBehandlingDto: OpprettKlagebehandlingRequest): Ressurs<UUID> {
+        return Ressurs.success(opprettBehandlingService.opprettBehandling(opprettKlageBehandlingDto))
     }
 
     @PatchMapping("{behandlingId}/gjelder-tilbakekreving")

--- a/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingControllerTest.kt
@@ -178,7 +178,7 @@ internal class EksternBehandlingControllerTest : OppslagSpringRunnerTest() {
             val opprettKlagebehandlingRequest = lagOpprettKlagebehandlingRequest()
 
             // Act
-            val response = restTemplate.exchange<UUID>(
+            val response = restTemplate.exchange<Ressurs<UUID>>(
                 localhost("$baseUrl/v2/opprett"),
                 HttpMethod.POST,
                 HttpEntity<OpprettKlagebehandlingRequest>(
@@ -189,7 +189,8 @@ internal class EksternBehandlingControllerTest : OppslagSpringRunnerTest() {
 
             // Arrange
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-            assertThat(response.body).isNotNull()
+            assertThat(response.body?.status).isEqualTo(Status.SUKSESS)
+            assertThat(response.body?.data).isNotNull()
         }
     }
 }


### PR DESCRIPTION
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Har behvor for å returnere `UUID`en til klagebehandlingen ved opprettelse. Tidligere returnerte vi bare `UUID` rått, men må ha det i en `Ressurs` for at det skal fungere korrekt med kallet som blir gjort i BA/KS-sak. 