### PR TITLE
Utvider innstilling til Nav klageinstans med flere felter

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -56,6 +56,69 @@ class BrevInnholdUtleder(
             ),
         )
 
+    fun lagOpprettholdelseBrev(
+        ident: String,
+        dokumentasjonOgUtredning: String,
+        spørsmåletISaken: String,
+        aktuelleRettskilder: String,
+        klagersAnførsler: String,
+        vurderingAvKlagen: String,
+        navn: String,
+        stønadstype: Stønadstype,
+        påklagetVedtakDetaljer: PåklagetVedtakDetaljer,
+        klageMottatt: LocalDate,
+    ): FritekstBrevRequestDto =
+        FritekstBrevRequestDto(
+            overskrift = "Vi har sendt klagen din til Nav Klageinstans Nord",
+            navn = navn,
+            personIdent = ident,
+            avsnitt =
+                listOf(
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold =
+                            "Vi har ${klageMottatt.norskFormat()} fått klagen din på vedtaket om " +
+                                "${visningsnavn(stønadstype, påklagetVedtakDetaljer)} som ble gjort " +
+                                "${påklagetVedtakDetaljer.vedtakstidspunkt.norskFormat()}, " +
+                                "og kommet frem til at vi ikke endrer vedtaket. Nav Klageinstans skal derfor vurdere saken din på nytt.",
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = "Saksbehandlingstidene finner du på nav.no/saksbehandlingstider.",
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Dette er vurderingen vi har sendt til Nav Klageinstans",
+                        innhold = "",
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Dokumentasjon og utredning",
+                        innhold = dokumentasjonOgUtredning,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Spørsmålet i saken",
+                        innhold = spørsmåletISaken,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Aktuelle rettskilder",
+                        innhold = aktuelleRettskilder,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Klagers anførsler",
+                        innhold = klagersAnførsler,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Vurdering av klagen",
+                        innhold = vurderingAvKlagen,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Har du nye opplysninger?",
+                        innhold =
+                            "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via \n${stønadstype.klageUrl()}.",
+                    ),
+                    harDuSpørsmålAvsnitt(stønadstype),
+                ),
+        )
+
     fun lagFormkravAvvistBrev(
         ident: String,
         navn: String,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -150,9 +150,8 @@ class BrevService(
                         klageMottatt = klageMottatt,
                     )
                 } else {
-                    val getOrThrow = { verdi: String?, felt: String ->
-                        verdi ?: throw Feil("Behandling med resultat $behandlingResultat mangler $felt for generering av brev")
-                    }
+                    fun getOrThrow(verdi: String?, felt: String) = verdi
+                        ?: throw Feil("Behandling med resultat $behandlingResultat mangler $felt for generering av brev")
 
                     val dokumentasjonOgUtredning = getOrThrow(vurdering?.dokumentasjonOgUtredning, "dokumentasjonOgUtredning")
                     val spørsmåletISaken = getOrThrow(vurdering?.spørsmåletISaken, "spørsmåletISaken")
@@ -388,7 +387,9 @@ class BrevService(
         )
 
     private fun validerIkkeSendTrukketKlageBrevPåFeilType(henlagt: HenlagtDto) {
-        feilHvis(henlagt.skalSendeHenleggelsesbrev && henlagt.årsak == HenlagtÅrsak.FEILREGISTRERT) { "Skal ikke sende brev hvis type er ulik trukket tilbake" }
+        feilHvis(henlagt.skalSendeHenleggelsesbrev && henlagt.årsak == HenlagtÅrsak.FEILREGISTRERT) {
+            "Skal ikke sende brev hvis type er ulik trukket tilbake"
+        }
     }
 
     private fun validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -39,6 +39,7 @@ import no.nav.familie.klage.personopplysninger.PersonopplysningerService
 import no.nav.familie.klage.repository.findByIdOrThrow
 import no.nav.familie.klage.vurdering.VurderingService
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -49,8 +50,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.util.Properties
-import java.util.UUID
+import java.util.*
 
 @Service
 class BrevService(
@@ -135,19 +135,44 @@ class BrevService(
 
         return when (behandlingResultat) {
             BehandlingResultat.IKKE_MEDHOLD -> {
-                val instillingKlageinstans = vurdering?.innstillingKlageinstans
-                    ?: throw Feil("Behandling med resultat $behandlingResultat mangler instillingKlageinstans for generering av brev")
                 brukerfeilHvis(påklagetVedtakDetaljer == null) {
                     "Kan ikke opprette brev til klageinstansen når det ikke er valgt et påklaget vedtak"
                 }
-                brevInnholdUtleder.lagOpprettholdelseBrev(
-                    ident = fagsak.hentAktivIdent(),
-                    instillingKlageinstans = instillingKlageinstans,
-                    navn = navn,
-                    stønadstype = fagsak.stønadstype,
-                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
-                    klageMottatt = klageMottatt,
-                )
+                if (fagsak.fagsystem == Fagsystem.EF) {
+                    val instillingKlageinstans = vurdering?.innstillingKlageinstans
+                        ?: throw Feil("Behandling med resultat $behandlingResultat mangler instillingKlageinstans for generering av brev")
+                    brevInnholdUtleder.lagOpprettholdelseBrev(
+                        ident = fagsak.hentAktivIdent(),
+                        instillingKlageinstans = instillingKlageinstans,
+                        navn = navn,
+                        stønadstype = fagsak.stønadstype,
+                        påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                        klageMottatt = klageMottatt,
+                    )
+                } else {
+                    val getOrThrow = { verdi: String?, felt: String ->
+                        verdi ?: throw Feil("Behandling med resultat $behandlingResultat mangler $felt for generering av brev")
+                    }
+
+                    val dokumentasjonOgUtredning = getOrThrow(vurdering?.dokumentasjonOgUtredning, "dokumentasjonOgUtredning")
+                    val spørsmåletISaken = getOrThrow(vurdering?.spørsmåletISaken, "spørsmåletISaken")
+                    val aktuelleRettskilder = getOrThrow(vurdering?.aktuelleRettskilder, "aktuelleRettskilder")
+                    val klagersAnførsler = getOrThrow(vurdering?.klagersAnførsler, "klagersAnførsler")
+                    val vurderingAvKlagen = getOrThrow(vurdering?.vurderingAvKlagen, "vurderingAvKlagen")
+
+                    brevInnholdUtleder.lagOpprettholdelseBrev(
+                        ident = fagsak.hentAktivIdent(),
+                        dokumentasjonOgUtredning = dokumentasjonOgUtredning,
+                        spørsmåletISaken = spørsmåletISaken,
+                        aktuelleRettskilder = aktuelleRettskilder,
+                        klagersAnførsler = klagersAnførsler,
+                        vurderingAvKlagen = vurderingAvKlagen,
+                        navn = navn,
+                        stønadstype = fagsak.stønadstype,
+                        påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                        klageMottatt = klageMottatt,
+                    )
+                }
             }
 
             BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST -> {

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingService.kt
@@ -55,6 +55,11 @@ class VurderingService(
             begrunnelseOmgjøring = vurdering.begrunnelseOmgjøring,
             hjemmel = vurdering.hjemmel,
             innstillingKlageinstans = vurdering.innstillingKlageinstans,
+            dokumentasjonOgUtredning = vurdering.dokumentasjonOgUtredning,
+            spørsmåletISaken = vurdering.spørsmåletISaken,
+            aktuelleRettskilder = vurdering.aktuelleRettskilder,
+            klagersAnførsler = vurdering.klagersAnførsler,
+            vurderingAvKlagen = vurdering.vurderingAvKlagen,
             interntNotat = vurdering.interntNotat,
         ),
     )
@@ -67,6 +72,11 @@ class VurderingService(
                 årsak = vurdering.årsak,
                 begrunnelseOmgjøring = vurdering.begrunnelseOmgjøring,
                 hjemmel = vurdering.hjemmel,
+                dokumentasjonOgUtredning = vurdering.dokumentasjonOgUtredning,
+                spørsmåletISaken = vurdering.spørsmåletISaken,
+                aktuelleRettskilder = vurdering.aktuelleRettskilder,
+                klagersAnførsler = vurdering.klagersAnførsler,
+                vurderingAvKlagen = vurdering.vurderingAvKlagen,
                 interntNotat = vurdering.interntNotat,
             ),
         )

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.klage.vurdering
 import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.vurdering.VurderingValidator.validerVurdering
 import no.nav.familie.klage.vurdering.domain.Vedtak
 import no.nav.familie.klage.vurdering.domain.Vurdering
@@ -18,6 +19,7 @@ class VurderingService(
     private val vurderingRepository: VurderingRepository,
     private val stegService: StegService,
     private val brevRepository: BrevRepository,
+    private val fagsakService: FagsakService,
 ) {
 
     fun hentVurdering(behandlingId: UUID): Vurdering? =
@@ -28,7 +30,8 @@ class VurderingService(
 
     @Transactional
     fun opprettEllerOppdaterVurdering(vurdering: VurderingDto): VurderingDto {
-        validerVurdering(vurdering)
+        val fagsystem = fagsakService.hentFagsakForBehandling(vurdering.behandlingId).fagsystem
+        validerVurdering(vurdering, fagsystem)
         if (vurdering.vedtak === Vedtak.OMGJØR_VEDTAK) {
             brevRepository.deleteById(vurdering.behandlingId)
         }

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingValidator.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingValidator.kt
@@ -66,10 +66,11 @@ object VurderingValidator {
                     feilHvis(felterSomMangler.isNotEmpty()) {
                         val felterSomManglerFormatert =
                             if (felterSomMangler.size > 1) {
-                                "Feltene " + felterSomMangler.dropLast(1)
-                                    .joinToString(", ") + " og " + felterSomMangler.last()
+                                "Feltene ${
+                                    felterSomMangler.dropLast(1).joinToString(", ")
+                                } og ${felterSomMangler.last()}"
                             } else {
-                                "Feltet " + felterSomMangler.first()
+                                "Feltet ${felterSomMangler.first()}"
                             }
                         "$felterSomManglerFormatert må fylles ut ved opprettholdelse av vedtak."
                     }

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingValidator.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingValidator.kt
@@ -3,10 +3,11 @@ package no.nav.familie.klage.vurdering
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 import no.nav.familie.klage.vurdering.domain.Vedtak
 import no.nav.familie.klage.vurdering.dto.VurderingDto
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 
 object VurderingValidator {
 
-    fun validerVurdering(vurdering: VurderingDto) {
+    fun validerVurdering(vurdering: VurderingDto, fagsystem: Fagsystem) {
         when (vurdering.vedtak) {
             Vedtak.OMGJØR_VEDTAK -> {
                 feilHvis(vurdering.årsak == null) {
@@ -18,7 +19,14 @@ object VurderingValidator {
                 feilHvis(vurdering.hjemmel != null) {
                     "Kan ikke lagre hjemmel på omgjør vedtak"
                 }
-                feilHvis(vurdering.innstillingKlageinstans != null) {
+                feilHvis(
+                    vurdering.innstillingKlageinstans != null ||
+                        vurdering.dokumentasjonOgUtredning != null ||
+                        vurdering.spørsmåletISaken != null ||
+                        vurdering.aktuelleRettskilder != null ||
+                        vurdering.klagersAnførsler != null ||
+                        vurdering.vurderingAvKlagen != null,
+                ) {
                     "Skal ikke ha innstilling til klageinstans ved omgjøring av vedtak"
                 }
             }
@@ -32,8 +40,39 @@ object VurderingValidator {
                 feilHvis(vurdering.begrunnelseOmgjøring != null) {
                     "Kan ikke lagre begrunnelse på oppretthold vedtak"
                 }
-                feilHvis(vurdering.innstillingKlageinstans.isNullOrBlank()) {
-                    "Må skrive innstilling til klageinstans ved opprettholdelse av vedtak"
+                if (fagsystem == Fagsystem.EF) {
+                    feilHvis(vurdering.innstillingKlageinstans.isNullOrBlank()) {
+                        "Må skrive innstilling til klageinstans ved opprettholdelse av vedtak"
+                    }
+                }
+                if (fagsystem == Fagsystem.BA || fagsystem == Fagsystem.KS) {
+                    val felterSomMangler = mutableListOf<String>()
+                    if (vurdering.dokumentasjonOgUtredning.isNullOrBlank()) {
+                        felterSomMangler.add("'Dokumentasjon og utredning'")
+                    }
+                    if (vurdering.spørsmåletISaken.isNullOrBlank()) {
+                        felterSomMangler.add("'Spørsmålet i saken'")
+                    }
+                    if (vurdering.aktuelleRettskilder.isNullOrBlank()) {
+                        felterSomMangler.add("'Aktuelle rettskilder'")
+                    }
+                    if (vurdering.klagersAnførsler.isNullOrBlank()) {
+                        felterSomMangler.add("'Klagers anførsler'")
+                    }
+                    if (vurdering.vurderingAvKlagen.isNullOrBlank()) {
+                        felterSomMangler.add("'Vurdering av klagen'")
+                    }
+
+                    feilHvis(felterSomMangler.isNotEmpty()) {
+                        val felterSomManglerFormatert =
+                            if (felterSomMangler.size > 1) {
+                                "Feltene " + felterSomMangler.dropLast(1)
+                                    .joinToString(", ") + " og " + felterSomMangler.last()
+                            } else {
+                                "Feltet " + felterSomMangler.first()
+                            }
+                        "$felterSomManglerFormatert må fylles ut ved opprettholdelse av vedtak."
+                    }
                 }
             }
         }

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/domain/Vurdering.kt
@@ -19,6 +19,13 @@ data class Vurdering(
     val begrunnelseOmgjøring: String? = null,
     val hjemmel: Hjemmel? = null,
     val innstillingKlageinstans: String? = null,
+    val dokumentasjonOgUtredning: String? = null,
+    @Column("sporsmalet_i_saken")
+    val spørsmåletISaken: String? = null,
+    val aktuelleRettskilder: String? = null,
+    @Column("klagers_anforsler")
+    val klagersAnførsler: String? = null,
+    val vurderingAvKlagen: String? = null,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
     val interntNotat: String?,

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/dto/VurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/dto/VurderingDto.kt
@@ -13,6 +13,11 @@ data class VurderingDto(
     val begrunnelseOmgjøring: String? = null,
     val hjemmel: Hjemmel? = null,
     val innstillingKlageinstans: String? = null,
+    val dokumentasjonOgUtredning: String? = null,
+    val spørsmåletISaken: String? = null,
+    val aktuelleRettskilder: String? = null,
+    val klagersAnførsler: String? = null,
+    val vurderingAvKlagen: String? = null,
     val interntNotat: String?,
 )
 
@@ -24,5 +29,10 @@ fun Vurdering.tilDto(): VurderingDto =
         begrunnelseOmgjøring = this.begrunnelseOmgjøring,
         hjemmel = this.hjemmel,
         innstillingKlageinstans = this.innstillingKlageinstans,
+        dokumentasjonOgUtredning = this.dokumentasjonOgUtredning,
+        spørsmåletISaken = this.spørsmåletISaken,
+        aktuelleRettskilder = this.aktuelleRettskilder,
+        klagersAnførsler = this.klagersAnførsler,
+        vurderingAvKlagen = this.vurderingAvKlagen,
         interntNotat = this.interntNotat,
     )

--- a/src/main/resources/db/migration/V24__utvidet_innstilling_klageinstans.sql
+++ b/src/main/resources/db/migration/V24__utvidet_innstilling_klageinstans.sql
@@ -1,0 +1,10 @@
+ALTER TABLE vurdering
+    ADD COLUMN dokumentasjon_og_utredning VARCHAR;
+ALTER TABLE vurdering
+    ADD COLUMN sporsmalet_i_saken VARCHAR;
+ALTER TABLE vurdering
+    ADD COLUMN aktuelle_rettskilder VARCHAR;
+ALTER TABLE vurdering
+    ADD COLUMN klagers_anforsler VARCHAR;
+ALTER TABLE vurdering
+    ADD COLUMN vurdering_av_klagen VARCHAR;

--- a/src/main/resources/db/migration/V24__utvidet_innstilling_klageinstans.sql
+++ b/src/main/resources/db/migration/V24__utvidet_innstilling_klageinstans.sql
@@ -1,10 +1,6 @@
 ALTER TABLE vurdering
-    ADD COLUMN dokumentasjon_og_utredning VARCHAR;
-ALTER TABLE vurdering
-    ADD COLUMN sporsmalet_i_saken VARCHAR;
-ALTER TABLE vurdering
-    ADD COLUMN aktuelle_rettskilder VARCHAR;
-ALTER TABLE vurdering
-    ADD COLUMN klagers_anforsler VARCHAR;
-ALTER TABLE vurdering
-    ADD COLUMN vurdering_av_klagen VARCHAR;
+    ADD COLUMN dokumentasjon_og_utredning VARCHAR,
+    ADD COLUMN sporsmalet_i_saken         VARCHAR,
+    ADD COLUMN aktuelle_rettskilder       VARCHAR,
+    ADD COLUMN klagers_anforsler          VARCHAR,
+    ADD COLUMN vurdering_av_klagen        VARCHAR;

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -124,16 +124,26 @@ object DomainUtil {
         vedtak: Vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
         hjemmel: Hjemmel? = Hjemmel.FT_FEMTEN_FEM,
         innstillingKlageinstans: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        dokumentasjonOgUtredning: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        spørsmåletISaken: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        aktuelleRettskilder: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        klagersAnførsler: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        vurderingAvKlagen: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
         årsak: Årsak? = null,
         begrunnelseOmgjøring: String? = null,
         interntNotat: String? = null,
     ) = Vurdering(
         behandlingId = behandlingId,
         vedtak = vedtak,
-        hjemmel = hjemmel,
-        innstillingKlageinstans = innstillingKlageinstans,
         årsak = årsak,
         begrunnelseOmgjøring = begrunnelseOmgjøring,
+        hjemmel = hjemmel,
+        innstillingKlageinstans = innstillingKlageinstans,
+        dokumentasjonOgUtredning = dokumentasjonOgUtredning,
+        spørsmåletISaken = spørsmåletISaken,
+        aktuelleRettskilder = aktuelleRettskilder,
+        klagersAnførsler = klagersAnførsler,
+        vurderingAvKlagen = vurderingAvKlagen,
         interntNotat = interntNotat,
     )
 
@@ -144,6 +154,11 @@ object DomainUtil {
         begrunnelseOmgjøring: String? = null,
         hjemmel: Hjemmel? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) Hjemmel.BT_FEM else null,
         innstillingKlageinstans: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        dokumentasjonOgUtredning: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        spørsmåletISaken: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        aktuelleRettskilder: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        klagersAnførsler: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
+        vurderingAvKlagen: String? = if (vedtak == Vedtak.OPPRETTHOLD_VEDTAK) "En begrunnelse" else null,
         interntNotat: String? = null,
     ) = VurderingDto(
         behandlingId = behandlingId,
@@ -152,6 +167,11 @@ object DomainUtil {
         begrunnelseOmgjøring = begrunnelseOmgjøring,
         hjemmel = hjemmel,
         innstillingKlageinstans = innstillingKlageinstans,
+        dokumentasjonOgUtredning = dokumentasjonOgUtredning,
+        spørsmåletISaken = spørsmåletISaken,
+        aktuelleRettskilder = aktuelleRettskilder,
+        klagersAnførsler = klagersAnførsler,
+        vurderingAvKlagen = vurderingAvKlagen,
         interntNotat = interntNotat,
     )
 
@@ -190,15 +210,15 @@ object DomainUtil {
             sporbar = sporbar,
             eksternId = "1",
             fagsystem =
-            when (stønadstype) {
-                Stønadstype.OVERGANGSSTØNAD,
-                Stønadstype.BARNETILSYN,
-                Stønadstype.SKOLEPENGER,
-                -> Fagsystem.EF
+                when (stønadstype) {
+                    Stønadstype.OVERGANGSSTØNAD,
+                    Stønadstype.BARNETILSYN,
+                    Stønadstype.SKOLEPENGER,
+                    -> Fagsystem.EF
 
-                Stønadstype.BARNETRYGD -> Fagsystem.BA
-                Stønadstype.KONTANTSTØTTE -> Fagsystem.KS
-            },
+                    Stønadstype.BARNETRYGD -> Fagsystem.BA
+                    Stønadstype.KONTANTSTØTTE -> Fagsystem.KS
+                },
         )
 
     fun klageresultat(

--- a/src/test/kotlin/no/nav/familie/klage/vurdering/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/vurdering/VurderingServiceTest.kt
@@ -7,6 +7,8 @@ import io.mockk.verify
 import no.nav.familie.klage.behandling.StegService
 import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.brev.BrevRepository
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.testutil.DomainUtil.fagsak
 import no.nav.familie.klage.testutil.DomainUtil.vurdering
 import no.nav.familie.klage.vurdering.domain.Hjemmel
 import no.nav.familie.klage.vurdering.domain.Vedtak
@@ -22,7 +24,8 @@ class VurderingServiceTest {
     val vurderingRepository = mockk<VurderingRepository>()
     val stegService = mockk<StegService>()
     val brevRepository = mockk<BrevRepository>()
-    val vurderingService = VurderingService(vurderingRepository, stegService, brevRepository)
+    val fagsakService = mockk<FagsakService>()
+    val vurderingService = VurderingService(vurderingRepository, stegService, brevRepository, fagsakService)
 
     val omgjørVedtakVurdering = vurdering(
         behandlingId = UUID.randomUUID(),
@@ -42,6 +45,7 @@ class VurderingServiceTest {
     fun setup() {
         every { vurderingRepository.findByIdOrNull(any()) } returns omgjørVedtakVurdering
         every { vurderingRepository.update(any()) } answers { firstArg() }
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsak()
         justRun { stegService.oppdaterSteg(any(), any(), any(), any()) }
         justRun { brevRepository.deleteById(any()) }
     }

--- a/src/test/kotlin/no/nav/familie/klage/vurdering/VurderingValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/vurdering/VurderingValidatorTest.kt
@@ -4,53 +4,72 @@ import no.nav.familie.klage.testutil.DomainUtil.vurderingDto
 import no.nav.familie.klage.vurdering.VurderingValidator.validerVurdering
 import no.nav.familie.klage.vurdering.domain.Hjemmel
 import no.nav.familie.klage.vurdering.domain.Vedtak
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.Årsak
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 internal class VurderingValidatorTest {
 
     @Nested
     inner class OmgjørVedtak {
 
-        @Test
-        internal fun `skal validere når man har med årsak, men hjemmel er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal validere når man har med årsak, men hjemmel er null`(fagsystem: Fagsystem) {
             validerVurdering(
-                vurderingDto(
+                vurdering = vurderingDto(
                     vedtak = Vedtak.OMGJØR_VEDTAK,
                     hjemmel = null,
                     årsak = Årsak.FEIL_I_LOVANDVENDELSE,
                     begrunnelseOmgjøring = "begrunnelse",
                 ),
+                fagsystem = fagsystem,
             )
         }
 
-        @Test
-        internal fun `skal feile når årsak er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal feile når årsak er null`(fagsystem: Fagsystem) {
             assertThatThrownBy {
-                validerVurdering(vurderingDto(vedtak = Vedtak.OMGJØR_VEDTAK, hjemmel = null, årsak = null))
+                validerVurdering(
+                    vurdering = vurderingDto(vedtak = Vedtak.OMGJØR_VEDTAK, hjemmel = null, årsak = null),
+                    fagsystem = fagsystem,
+                )
             }.hasMessage("Mangler årsak på omgjør vedtak")
         }
 
-        @Test
-        internal fun `skal feile når hjemmel ikke er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal feile når hjemmel ikke er null`(fagsystem: Fagsystem) {
             assertThatThrownBy {
                 validerVurdering(
-                    vurderingDto(
+                    vurdering = vurderingDto(
                         vedtak = Vedtak.OMGJØR_VEDTAK,
                         hjemmel = Hjemmel.BT_FEM,
                         årsak = Årsak.ANNET,
                         begrunnelseOmgjøring = "begrunnelse",
                     ),
+                    fagsystem = fagsystem,
                 )
             }.hasMessage("Kan ikke lagre hjemmel på omgjør vedtak")
         }
 
-        @Test
-        internal fun `skal feile når begrunnelse for omgjøring er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal feile når begrunnelse for omgjøring er null`(fagsystem: Fagsystem) {
             assertThatThrownBy {
-                validerVurdering(vurderingDto(vedtak = Vedtak.OMGJØR_VEDTAK, årsak = Årsak.ANNET, begrunnelseOmgjøring = null))
+                validerVurdering(
+                    vurdering = vurderingDto(
+                        vedtak = Vedtak.OMGJØR_VEDTAK,
+                        årsak = Årsak.ANNET,
+                        begrunnelseOmgjøring = null,
+                    ),
+                    fagsystem = fagsystem,
+                )
             }.hasMessage("Mangler begrunnelse for omgjøring på omgjør vedtak")
         }
     }
@@ -58,36 +77,113 @@ internal class VurderingValidatorTest {
     @Nested
     inner class OpprettholdVedtak {
 
-        @Test
-        internal fun `skal validere når man har med hjemmel, men årsak er null`() {
-            validerVurdering(vurderingDto(vedtak = Vedtak.OPPRETTHOLD_VEDTAK, hjemmel = Hjemmel.BT_FEM, årsak = null))
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal validere når man har med hjemmel, men årsak er null`(fagsystem: Fagsystem) {
+            validerVurdering(
+                vurdering = vurderingDto(
+                    vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
+                    hjemmel = Hjemmel.BT_FEM,
+                    årsak = null,
+                ),
+                fagsystem = fagsystem,
+            )
         }
 
-        @Test
-        internal fun `skal feile når hjemmel er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal feile når hjemmel er null`(fagsystem: Fagsystem) {
             assertThatThrownBy {
-                validerVurdering(vurderingDto(vedtak = Vedtak.OPPRETTHOLD_VEDTAK, hjemmel = null, årsak = null))
+                validerVurdering(
+                    vurdering = vurderingDto(
+                        vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
+                        hjemmel = null,
+                        årsak = null,
+                    ),
+                    fagsystem = fagsystem,
+                )
             }.hasMessage("Mangler hjemmel på oppretthold vedtak")
         }
 
-        @Test
-        internal fun `skal feile når årsak ikke er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal feile når årsak ikke er null`(fagsystem: Fagsystem) {
             assertThatThrownBy {
-                validerVurdering(vurderingDto(vedtak = Vedtak.OPPRETTHOLD_VEDTAK, hjemmel = Hjemmel.BT_FEM, årsak = Årsak.ANNET))
+                validerVurdering(
+                    vurdering = vurderingDto(
+                        vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
+                        hjemmel = Hjemmel.BT_FEM,
+                        årsak = Årsak.ANNET,
+                    ),
+                    fagsystem = fagsystem,
+                )
             }.hasMessage("Kan ikke lagre årsak på oppretthold vedtak")
         }
 
-        @Test
-        internal fun `skal feile når begrunnelse for omgjøring ikke er null`() {
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class)
+        internal fun `skal feile når begrunnelse for omgjøring ikke er null`(fagsystem: Fagsystem) {
             assertThatThrownBy {
                 validerVurdering(
-                    vurderingDto(
+                    vurdering = vurderingDto(
                         vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
                         hjemmel = Hjemmel.BT_FEM,
                         begrunnelseOmgjøring = "begrunnelse",
                     ),
+                    fagsystem = fagsystem,
                 )
             }.hasMessage("Kan ikke lagre begrunnelse på oppretthold vedtak")
+        }
+
+        @Test
+        internal fun `skal feile når innstillingKlageinstans ikke er satt når fagsystem er EF`() {
+            assertThatThrownBy {
+                validerVurdering(
+                    vurdering = vurderingDto(
+                        vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
+                        hjemmel = Hjemmel.BT_FEM,
+                        innstillingKlageinstans = null,
+                    ),
+                    fagsystem = Fagsystem.EF,
+                )
+            }.hasMessage("Må skrive innstilling til klageinstans ved opprettholdelse av vedtak")
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class, mode = EnumSource.Mode.EXCLUDE, names = ["EF"])
+        internal fun `skal feile når dokumentasjonOgUtredning ikke er satt når fagsystem er BA og KS`(fagsystem: Fagsystem) {
+            assertThatThrownBy {
+                validerVurdering(
+                    vurdering = vurderingDto(
+                        vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
+                        hjemmel = Hjemmel.BT_FEM,
+                        dokumentasjonOgUtredning = null,
+                    ),
+                    fagsystem = fagsystem,
+                )
+            }.hasMessage("Feltet 'Dokumentasjon og utredning' må fylles ut ved opprettholdelse av vedtak.")
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Fagsystem::class, mode = EnumSource.Mode.EXCLUDE, names = ["EF"])
+        internal fun `skal slå sammen felter i feilmelding om innstilling når fagsystem er BA og KS`(fagsystem: Fagsystem) {
+            assertThatThrownBy {
+                validerVurdering(
+                    vurdering = vurderingDto(
+                        vedtak = Vedtak.OPPRETTHOLD_VEDTAK,
+                        hjemmel = Hjemmel.BT_FEM,
+                        dokumentasjonOgUtredning = null,
+                        spørsmåletISaken = null,
+                        aktuelleRettskilder = null,
+                        klagersAnførsler = null,
+                        vurderingAvKlagen = null,
+                    ),
+                    fagsystem = fagsystem,
+                )
+            }.hasMessage(
+                "Feltene 'Dokumentasjon og utredning', 'Spørsmålet i saken', 'Aktuelle rettskilder', " +
+                    "'Klagers anførsler' og 'Vurdering av klagen' må fylles ut ved opprettholdelse av vedtak.",
+            )
         }
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24683)

I klager for barnetrygd og kontantstøtte må saksbehandlerne kunne fylle ut fem felter i innstilling til Nav Klageinstans, i stedet for ett.

- Legger til de fem nye feltene som nullable String på `Vurdering` og `VurderingDto`.
- Endrer validering av `Vurdering` til at de nye feltene må være utfylt dersom fagsystem er BA eller KS, i stedet for `instillingKlageinstans`
- Legger til ny funksjon for generering av opprettholdelsebrev, basert på fagsystem, som lister opp de fem nye feltene som egne avsnitt

Fikser semantikk i overskriftene i brevet i en annen PR

![65f6acaf606969470a6baf3425208590](https://github.com/user-attachments/assets/b9dff3fe-6c74-4fd2-8aca-c431143ceed7)