### PR TITLE
NAV-24774: Fritekst ved opprettholdelse og klagefrist-unntak oppfylt

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -21,7 +21,7 @@ class BrevInnholdUtleder(
 ) {
     fun lagOpprettholdelseBrev(
         ident: String,
-        instillingKlageinstans: String,
+        innstillingKlageinstans: String,
         navn: String,
         stønadstype: Stønadstype,
         påklagetVedtakDetaljer: PåklagetVedtakDetaljer,
@@ -47,7 +47,7 @@ class BrevInnholdUtleder(
                     ),
                     AvsnittDto(
                         deloverskrift = "Dette er vurderingen vi har sendt til Nav Klageinstans",
-                        innhold = instillingKlageinstans,
+                        innhold = innstillingKlageinstans,
                     ),
                     AvsnittDto(
                         deloverskrift = "Har du nye opplysninger?",

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -94,18 +94,27 @@ class BrevInnholdUtleder(
                         deloverskriftHeading = Heading.H2,
                         innhold = "",
                     ),
-                    AvsnittDto(
-                        deloverskrift = "Dokumentasjon og utredning",
-                        deloverskriftHeading = Heading.H3,
-                        innhold = dokumentasjonOgUtredning,
+                    *(
+                        klagefristUnntakBegrunnelse?.let {
+                            listOf(
+                                AvsnittDto(
+                                    deloverskrift = "Dokumentasjon og utredning",
+                                    deloverskriftHeading = Heading.H3,
+                                    innhold = klagefristUnntakBegrunnelse,
+                                ),
+                                AvsnittDto(
+                                    deloverskrift = "",
+                                    innhold = dokumentasjonOgUtredning,
+                                ),
+                            ).toTypedArray()
+                        } ?: listOf(
+                            AvsnittDto(
+                                deloverskrift = "Dokumentasjon og utredning",
+                                deloverskriftHeading = Heading.H3,
+                                innhold = dokumentasjonOgUtredning,
+                            ),
+                        ).toTypedArray()
                     ),
-                    klagefristUnntakBegrunnelse?.let {
-                        AvsnittDto(
-                            deloverskrift = "Unntak for klagefristen er oppfylt",
-                            deloverskriftHeading = Heading.H4,
-                            innhold = klagefristUnntakBegrunnelse,
-                        )
-                    },
                     AvsnittDto(
                         deloverskrift = "Spørsmålet i saken",
                         deloverskriftHeading = Heading.H3,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -30,34 +30,35 @@ class BrevInnholdUtleder(
             navn = navn,
             personIdent = ident,
             avsnitt =
-            listOf(
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold =
-                    "Vi har ${klageMottatt.norskFormat()} fått klagen din på vedtaket om " +
-                        "${visningsnavn(stønadstype, påklagetVedtakDetaljer)} som ble gjort " +
-                        "${påklagetVedtakDetaljer.vedtakstidspunkt.norskFormat()}, " +
-                        "og kommet frem til at vi ikke endrer vedtaket. Nav Klageinstans skal derfor vurdere saken din på nytt.",
+                listOf(
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold =
+                            "Vi har ${klageMottatt.norskFormat()} fått klagen din på vedtaket om " +
+                                "${visningsnavn(stønadstype, påklagetVedtakDetaljer)} som ble gjort " +
+                                "${påklagetVedtakDetaljer.vedtakstidspunkt.norskFormat()}, " +
+                                "og kommet frem til at vi ikke endrer vedtaket. Nav Klageinstans skal derfor vurdere saken din på nytt.",
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = "Saksbehandlingstidene finner du på nav.no/saksbehandlingstider.",
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Dette er vurderingen vi har sendt til Nav Klageinstans",
+                        innhold = instillingKlageinstans,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "Har du nye opplysninger?",
+                        innhold =
+                            "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via \n${stønadstype.klageUrl()}.",
+                    ),
+                    harDuSpørsmålAvsnitt(stønadstype),
                 ),
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = "Saksbehandlingstidene finner du på nav.no/saksbehandlingstider.",
-                ),
-                AvsnittDto(
-                    deloverskrift = "Dette er vurderingen vi har sendt til Nav Klageinstans",
-                    innhold = instillingKlageinstans,
-                ),
-                AvsnittDto(
-                    deloverskrift = "Har du nye opplysninger?",
-                    innhold =
-                    "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via \n${stønadstype.klageUrl()}.",
-                ),
-                harDuSpørsmålAvsnitt(stønadstype),
-            ),
         )
 
     fun lagOpprettholdelseBrev(
         ident: String,
+        saksbehandlerFritekst: String?,
         dokumentasjonOgUtredning: String,
         spørsmåletISaken: String,
         aktuelleRettskilder: String,
@@ -73,7 +74,7 @@ class BrevInnholdUtleder(
             navn = navn,
             personIdent = ident,
             avsnitt =
-                listOf(
+                listOfNotNull(
                     AvsnittDto(
                         deloverskrift = "",
                         innhold =
@@ -82,6 +83,12 @@ class BrevInnholdUtleder(
                                 "${påklagetVedtakDetaljer.vedtakstidspunkt.norskFormat()}, " +
                                 "og kommet frem til at vi ikke endrer vedtaket. Nav Klageinstans skal derfor vurdere saken din på nytt.",
                     ),
+                    saksbehandlerFritekst?.let {
+                        AvsnittDto(
+                            deloverskrift = "",
+                            innhold = saksbehandlerFritekst,
+                        )
+                    },
                     AvsnittDto(
                         deloverskrift = "",
                         innhold = "Saksbehandlingstidene finner du på nav.no/saksbehandlingstider.",
@@ -135,27 +142,27 @@ class BrevInnholdUtleder(
             personIdent = ident,
             navn = navn,
             avsnitt =
-            listOf(
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = avvistBrevInnhold.årsakTilAvvisning,
+                listOf(
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = avvistBrevInnhold.årsakTilAvvisning,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = avvistBrevInnhold.brevtekstFraSaksbehandler,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = avvistBrevInnhold.lovtekst,
+                    ),
+                    duHarRettTilÅKlageAvsnitt(stønadstype),
+                    AvsnittDto(
+                        deloverskrift = "Du har rett til innsyn",
+                        innhold =
+                            "På nav.no/dittnav kan du se dokumentene i saken din.",
+                    ),
+                    harDuSpørsmålAvsnitt(stønadstype),
                 ),
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = avvistBrevInnhold.brevtekstFraSaksbehandler,
-                ),
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = avvistBrevInnhold.lovtekst,
-                ),
-                duHarRettTilÅKlageAvsnitt(stønadstype),
-                AvsnittDto(
-                    deloverskrift = "Du har rett til innsyn",
-                    innhold =
-                    "På nav.no/dittnav kan du se dokumentene i saken din.",
-                ),
-                harDuSpørsmålAvsnitt(stønadstype),
-            ),
         )
     }
 
@@ -173,27 +180,27 @@ class BrevInnholdUtleder(
             personIdent = ident,
             navn = navn,
             avsnitt =
-            listOf(
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = "Vi har avvist klagen din fordi du ikke har klaget på et vedtak.",
+                listOf(
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = "Vi har avvist klagen din fordi du ikke har klaget på et vedtak.",
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = brevtekstFraSaksbehandler,
+                    ),
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold = "Vedtaket er gjort etter forvaltningsloven §§ 28 og 33.",
+                    ),
+                    duHarRettTilÅKlageAvsnitt(stønadstype),
+                    AvsnittDto(
+                        deloverskrift = "Du har rett til innsyn",
+                        innhold =
+                            "På nav.no/dittnav kan du se dokumentene i saken din.",
+                    ),
+                    harDuSpørsmålAvsnitt(stønadstype),
                 ),
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = brevtekstFraSaksbehandler,
-                ),
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = "Vedtaket er gjort etter forvaltningsloven §§ 28 og 33.",
-                ),
-                duHarRettTilÅKlageAvsnitt(stønadstype),
-                AvsnittDto(
-                    deloverskrift = "Du har rett til innsyn",
-                    innhold =
-                    "På nav.no/dittnav kan du se dokumentene i saken din.",
-                ),
-                harDuSpørsmålAvsnitt(stønadstype),
-            ),
         )
     }
 
@@ -201,37 +208,38 @@ class BrevInnholdUtleder(
         ident: String,
         navn: String,
         stønadstype: Stønadstype,
-    ): FritekstBrevRequestDto {
-        return FritekstBrevRequestDto(
+    ): FritekstBrevRequestDto =
+        FritekstBrevRequestDto(
             overskrift = "Saken din er avsluttet",
             personIdent = ident,
             navn = navn,
             avsnitt =
-            listOf(
-                AvsnittDto(
-                    deloverskrift = "",
-                    innhold = "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om ${stønadstype.name.lowercase()}. Vi har derfor avsluttet saken din.",
+                listOf(
+                    AvsnittDto(
+                        deloverskrift = "",
+                        innhold =
+                            "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om ${stønadstype.name.lowercase()}." +
+                                "Vi har derfor avsluttet saken din.",
+                    ),
+                    harDuSpørsmålAvsnitt(stønadstype),
                 ),
-                harDuSpørsmålAvsnitt(stønadstype),
-            ),
         )
-    }
 
     private fun duHarRettTilÅKlageAvsnitt(stønadstype: Stønadstype) =
         AvsnittDto(
             deloverskrift = "Du har rett til å klage",
             innhold =
-            "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
-                "Du finner skjema og informasjon på ${stønadstype.klageUrl()}.",
+                "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
+                    "Du finner skjema og informasjon på ${stønadstype.klageUrl()}.",
         )
 
     private fun harDuSpørsmålAvsnitt(stønadstype: Stønadstype) =
         AvsnittDto(
             deloverskrift = "Har du spørsmål?",
             innhold =
-            "Du finner mer informasjon på ${stønadstype.lesMerUrl()}.\n\n" +
-                "På nav.no/kontakt kan du chatte eller skrive til oss.\n\n" +
-                "Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.",
+                "Du finner mer informasjon på ${stønadstype.lesMerUrl()}.\n\n" +
+                    "På nav.no/kontakt kan du chatte eller skrive til oss.\n\n" +
+                    "Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.",
         )
 
     private fun visningsnavn(

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -60,7 +60,7 @@ class BrevInnholdUtleder(
 
     fun lagOpprettholdelseBrev(
         ident: String,
-        saksbehandlerFritekst: String?,
+        klagefristUnntakBegrunnelse: String?,
         dokumentasjonOgUtredning: String,
         spørsmåletISaken: String,
         aktuelleRettskilder: String,
@@ -99,11 +99,11 @@ class BrevInnholdUtleder(
                         deloverskriftHeading = Heading.H3,
                         innhold = dokumentasjonOgUtredning,
                     ),
-                    saksbehandlerFritekst?.let {
+                    klagefristUnntakBegrunnelse?.let {
                         AvsnittDto(
                             deloverskrift = "Unntak for klagefristen er oppfylt",
                             deloverskriftHeading = Heading.H4,
-                            innhold = saksbehandlerFritekst,
+                            innhold = klagefristUnntakBegrunnelse,
                         )
                     },
                     AvsnittDto(

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -101,7 +101,8 @@ class BrevInnholdUtleder(
                     ),
                     saksbehandlerFritekst?.let {
                         AvsnittDto(
-                            deloverskrift = "",
+                            deloverskrift = "Unntak for klagefristen er oppfylt",
+                            deloverskriftHeading = Heading.H4,
                             innhold = saksbehandlerFritekst,
                         )
                     },

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -30,7 +30,9 @@ import no.nav.familie.klage.felles.util.StønadstypeVisningsnavn.visningsnavn
 import no.nav.familie.klage.felles.util.TaskMetadata.saksbehandlerMetadataKey
 import no.nav.familie.klage.felles.util.isEqualOrAfter
 import no.nav.familie.klage.formkrav.FormService
+import no.nav.familie.klage.formkrav.domain.FormkravFristUnntak
 import no.nav.familie.klage.henlegg.HenlagtDto
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
@@ -46,11 +48,13 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.util.*
+import java.util.Properties
+import java.util.UUID
 
 @Service
 class BrevService(
@@ -66,7 +70,6 @@ class BrevService(
     private val brevInnholdUtleder: BrevInnholdUtleder,
     private val taskService: TaskService,
 ) {
-
     fun hentBrev(behandlingId: UUID): Brev = brevRepository.findByIdOrThrow(behandlingId)
 
     fun hentBrevmottakere(behandlingId: UUID): Brevmottakere {
@@ -74,7 +77,10 @@ class BrevService(
         return brev.mottakere ?: Brevmottakere()
     }
 
-    fun settBrevmottakere(behandlingId: UUID, brevmottakere: BrevmottakereDto) {
+    fun settBrevmottakere(
+        behandlingId: UUID,
+        brevmottakere: BrevmottakereDto,
+    ) {
         val behandling = behandlingService.hentBehandling(behandlingId)
         validerKanLageBrev(behandling)
 
@@ -99,11 +105,12 @@ class BrevService(
 
         val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysninger, fagsak.fagsystem)
 
-        val html = brevClient.genererHtmlFritekstbrev(
-            fritekstBrev = brevRequest,
-            saksbehandlerNavn = signaturMedEnhet.navn,
-            enhet = signaturMedEnhet.enhet,
-        )
+        val html =
+            brevClient.genererHtmlFritekstbrev(
+                fritekstBrev = brevRequest,
+                saksbehandlerNavn = signaturMedEnhet.navn,
+                enhet = signaturMedEnhet.enhet,
+            )
 
         lagreEllerOppdaterBrev(
             behandlingId = behandlingId,
@@ -132,6 +139,7 @@ class BrevService(
     ): FritekstBrevRequestDto {
         val behandlingResultat = utledBehandlingResultat(behandling.id)
         val vurdering = vurderingService.hentVurdering(behandling.id)
+        val formkrav = formService.hentForm(behandling.id)
 
         return when (behandlingResultat) {
             BehandlingResultat.IKKE_MEDHOLD -> {
@@ -139,8 +147,11 @@ class BrevService(
                     "Kan ikke opprette brev til klageinstansen når det ikke er valgt et påklaget vedtak"
                 }
                 if (fagsak.fagsystem == Fagsystem.EF) {
-                    val instillingKlageinstans = vurdering?.innstillingKlageinstans
-                        ?: throw Feil("Behandling med resultat $behandlingResultat mangler instillingKlageinstans for generering av brev")
+                    val instillingKlageinstans =
+                        vurdering?.innstillingKlageinstans
+                            ?: throw Feil(
+                                "Behandling med resultat $behandlingResultat mangler instillingKlageinstans for generering av brev",
+                            )
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         ident = fagsak.hentAktivIdent(),
                         instillingKlageinstans = instillingKlageinstans,
@@ -150,8 +161,24 @@ class BrevService(
                         klageMottatt = klageMottatt,
                     )
                 } else {
-                    fun getOrThrow(verdi: String?, felt: String) = verdi
+                    fun getOrThrow(
+                        verdi: String?,
+                        felt: String,
+                    ) = verdi
                         ?: throw Feil("Behandling med resultat $behandlingResultat mangler $felt for generering av brev")
+
+                    val klagefristUnntakOppfylt =
+                        formkrav.klagefristOverholdtUnntak in
+                            listOf(FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES)
+
+                    if (klagefristUnntakOppfylt &&
+                        formkrav.brevtekst == null
+                    ) {
+                        throw ApiFeil(
+                            "Fritekst må fylles ut.",
+                            httpStatus = HttpStatus.BAD_REQUEST,
+                        )
+                    }
 
                     val dokumentasjonOgUtredning = getOrThrow(vurdering?.dokumentasjonOgUtredning, "dokumentasjonOgUtredning")
                     val spørsmåletISaken = getOrThrow(vurdering?.spørsmåletISaken, "spørsmåletISaken")
@@ -161,6 +188,7 @@ class BrevService(
 
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         ident = fagsak.hentAktivIdent(),
+                        saksbehandlerFritekst = formkrav.brevtekst,
                         dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                         spørsmåletISaken = spørsmåletISaken,
                         aktuelleRettskilder = aktuelleRettskilder,
@@ -177,21 +205,23 @@ class BrevService(
             BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST -> {
                 val formkrav = formService.hentForm(behandling.id)
                 return when (behandling.påklagetVedtak.påklagetVedtakstype) {
-                    PåklagetVedtakstype.UTEN_VEDTAK -> brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
-                        ident = fagsak.hentAktivIdent(),
-                        navn = navn,
-                        formkrav = formkrav,
-                        stønadstype = fagsak.stønadstype,
-                    )
+                    PåklagetVedtakstype.UTEN_VEDTAK ->
+                        brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
+                            ident = fagsak.hentAktivIdent(),
+                            navn = navn,
+                            formkrav = formkrav,
+                            stønadstype = fagsak.stønadstype,
+                        )
 
-                    else -> brevInnholdUtleder.lagFormkravAvvistBrev(
-                        ident = fagsak.hentAktivIdent(),
-                        navn = navn,
-                        form = formkrav,
-                        stønadstype = fagsak.stønadstype,
-                        påklagetVedtakDetaljer = påklagetVedtakDetaljer,
-                        fagsystem = fagsak.fagsystem,
-                    )
+                    else ->
+                        brevInnholdUtleder.lagFormkravAvvistBrev(
+                            ident = fagsak.hentAktivIdent(),
+                            navn = navn,
+                            form = formkrav,
+                            stønadstype = fagsak.stønadstype,
+                            påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                            fagsystem = fagsak.fagsystem,
+                        )
                 }
             }
 
@@ -202,10 +232,9 @@ class BrevService(
         }
     }
 
-    fun hentBrevPdf(behandlingId: UUID): ByteArray {
-        return brevRepository.findByIdOrThrow(behandlingId).pdf?.bytes
+    fun hentBrevPdf(behandlingId: UUID): ByteArray =
+        brevRepository.findByIdOrThrow(behandlingId).pdf?.bytes
             ?: error("Finner ikke brev-pdf for behandling=$behandlingId")
-    }
 
     fun lagreEllerOppdaterBrev(
         behandlingId: UUID,
@@ -230,13 +259,14 @@ class BrevService(
         behandlingId: UUID,
         fagsak: Fagsak,
     ) = Brevmottakere(
-        personer = listOf(
-            BrevmottakerPersonMedIdent(
-                personIdent = fagsak.hentAktivIdent(),
-                navn = personopplysningerService.hentPersonopplysninger(behandlingId).navn,
-                mottakerRolle = MottakerRolle.BRUKER,
+        personer =
+            listOf(
+                BrevmottakerPersonMedIdent(
+                    personIdent = fagsak.hentAktivIdent(),
+                    navn = personopplysningerService.hentPersonopplysninger(behandlingId).navn,
+                    mottakerRolle = MottakerRolle.BRUKER,
+                ),
             ),
-        ),
     )
 
     fun lagBrevPdf(behandlingId: UUID) {
@@ -250,20 +280,25 @@ class BrevService(
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun oppdaterMottakerJournalpost(behandlingId: UUID, brevmottakereJournalposter: BrevmottakereJournalposter) {
+    fun oppdaterMottakerJournalpost(
+        behandlingId: UUID,
+        brevmottakereJournalposter: BrevmottakereJournalposter,
+    ) {
         brevRepository.oppdaterMottakerJournalpost(behandlingId, brevmottakereJournalposter)
     }
 
-    private fun utledBehandlingResultat(behandlingId: UUID): BehandlingResultat {
-        return if (formService.formkravErOppfyltForBehandling(behandlingId)) {
+    private fun utledBehandlingResultat(behandlingId: UUID): BehandlingResultat =
+        if (formService.formkravErOppfyltForBehandling(behandlingId)) {
             vurderingService.hentVurdering(behandlingId)?.vedtak?.tilBehandlingResultat()
                 ?: throw Feil("Burde funnet behandling $behandlingId")
         } else {
             BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST
         }
-    }
 
-    fun opprettJournalførHenleggelsesbrevTask(behandlingId: UUID, henlagt: HenlagtDto) {
+    fun opprettJournalførHenleggelsesbrevTask(
+        behandlingId: UUID,
+        henlagt: HenlagtDto,
+    ) {
         validerIkkeSendTrukketKlageBrevPåFeilType(henlagt)
         validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(behandlingId)
         val html = lagHenleggelsesbrevHtml(behandlingId)
@@ -278,21 +313,21 @@ class BrevService(
 
         lagBrevPdf(behandlingId)
 
-        val journalførBrevTask = Task(
-            type = JournalførBrevTask.TYPE,
-            payload = behandlingId.toString(),
-            properties = Properties().apply {
-                this[saksbehandlerMetadataKey] = SikkerhetContext.hentSaksbehandler(strict = true)
-                this["eksterFagsakId"] = fagsak.eksternId
-                this["fagsystem"] = fagsak.fagsystem.name
-            },
-        )
+        val journalførBrevTask =
+            Task(
+                type = JournalførBrevTask.TYPE,
+                payload = behandlingId.toString(),
+                properties =
+                    Properties().apply {
+                        this[saksbehandlerMetadataKey] = SikkerhetContext.hentSaksbehandler(strict = true)
+                        this["eksterFagsakId"] = fagsak.eksternId
+                        this["fagsystem"] = fagsak.fagsystem.name
+                    },
+            )
         taskService.save(journalførBrevTask)
     }
 
-    fun genererHenleggelsesbrev(
-        behandlingId: UUID,
-    ): ByteArray {
+    fun genererHenleggelsesbrev(behandlingId: UUID): ByteArray {
         val html =
             lagHenleggelsesbrevHtml(behandlingId)
 
@@ -306,16 +341,17 @@ class BrevService(
         val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysninger, fagsak.fagsystem)
         val stønadstype = fagsak.stønadstype
 
-        val html = when (stønadstype) {
-            Stønadstype.BARNETRYGD,
-            Stønadstype.KONTANTSTØTTE,
-            -> lagHenleggelsesbrevHtmlBaks(signaturMedEnhet, personopplysninger.navn, fagsak)
+        val html =
+            when (stønadstype) {
+                Stønadstype.BARNETRYGD,
+                Stønadstype.KONTANTSTØTTE,
+                -> lagHenleggelsesbrevHtmlBaks(signaturMedEnhet, personopplysninger.navn, fagsak)
 
-            Stønadstype.OVERGANGSSTØNAD,
-            Stønadstype.BARNETILSYN,
-            Stønadstype.SKOLEPENGER,
-            -> lagHenleggelsesbrevHtmlEf(behandlingId, signaturMedEnhet, fagsak)
-        }
+                Stønadstype.OVERGANGSSTØNAD,
+                Stønadstype.BARNETILSYN,
+                Stønadstype.SKOLEPENGER,
+                -> lagHenleggelsesbrevHtmlEf(behandlingId, signaturMedEnhet, fagsak)
+            }
 
         return html
     }
@@ -345,11 +381,12 @@ class BrevService(
         navn: String,
         fagsak: Fagsak,
     ): String {
-        val henleggelsesbrevInnhold = brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
-            ident = fagsak.hentAktivIdent(),
-            navn = navn,
-            stønadstype = fagsak.stønadstype,
-        )
+        val henleggelsesbrevInnhold =
+            brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
+                ident = fagsak.hentAktivIdent(),
+                navn = navn,
+                stønadstype = fagsak.stønadstype,
+            )
 
         return brevClient.genererHtmlFritekstbrev(
             fritekstBrev = henleggelsesbrevInnhold,
@@ -368,10 +405,11 @@ class BrevService(
 
     private fun lagNavnOgIdentFlettefelt(behandlingId: UUID): Flettefelter {
         val visningsNavn = personopplysningerService.hentPersonopplysninger(behandlingId).navn
-        val navnOgIdentFlettefelt = Flettefelter(
-            navn = listOf(visningsNavn),
-            fodselsnummer = listOf(personopplysningerService.hentPersonopplysninger(behandlingId).personIdent),
-        )
+        val navnOgIdentFlettefelt =
+            Flettefelter(
+                navn = listOf(visningsNavn),
+                fodselsnummer = listOf(personopplysningerService.hentPersonopplysninger(behandlingId).personIdent),
+            )
         return navnOgIdentFlettefelt
     }
 
@@ -394,9 +432,7 @@ class BrevService(
         }
     }
 
-    private fun validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(
-        ident: UUID,
-    ) {
+    private fun validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(ident: UUID) {
         val personopplysninger = personopplysningerService.hentPersonopplysninger(ident)
         val harVerge = personopplysninger.vergemål.isNotEmpty()
         val harFullmakt: Boolean =
@@ -407,7 +443,7 @@ class BrevService(
                             it.gyldigTilOgMed.isEqualOrAfter(
                                 LocalDate.now(),
                             )
-                            )
+                        )
                 }.isNotEmpty()
         feilHvis(harVerge || harFullmakt) {
             "Skal ikke sende brev hvis person er tilknyttet vergemål eller fullmakt"

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -188,7 +188,7 @@ class BrevService(
 
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         ident = fagsak.hentAktivIdent(),
-                        saksbehandlerFritekst = formkrav.brevtekst,
+                        saksbehandlerFritekst = if (klagefristUnntakOppfylt) formkrav.brevtekst else null,
                         dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                         spørsmåletISaken = spørsmåletISaken,
                         aktuelleRettskilder = aktuelleRettskilder,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -189,7 +189,7 @@ class BrevService(
 
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         ident = fagsak.hentAktivIdent(),
-                        saksbehandlerFritekst = if (klagefristUnntakOppfylt) formkrav.brevtekst else null,
+                        klagefristUnntakBegrunnelse = if (klagefristUnntakOppfylt) formkrav.brevtekst else null,
                         dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                         spørsmåletISaken = spørsmåletISaken,
                         aktuelleRettskilder = aktuelleRettskilder,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -155,7 +155,7 @@ class BrevService(
                             )
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         ident = fagsak.hentAktivIdent(),
-                        instillingKlageinstans = innstillingKlageinstans,
+                        innstillingKlageinstans = innstillingKlageinstans,
                         navn = navn,
                         stønadstype = fagsak.stønadstype,
                         påklagetVedtakDetaljer = påklagetVedtakDetaljer,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -172,13 +172,8 @@ class BrevService(
                         formkrav.klagefristOverholdtUnntak in
                             listOf(FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES)
 
-                    if (klagefristUnntakOppfylt &&
-                        formkrav.brevtekst == null
-                    ) {
-                        throw ApiFeil(
-                            "Fritekst må fylles ut.",
-                            httpStatus = HttpStatus.BAD_REQUEST,
-                        )
+                    brukerfeilHvis(klagefristUnntakOppfylt && formkrav.brevtekst == null) {
+                        "Hvis unntak for klagefrist er oppfylt, må begrunnelse fylles ut i fritekstfelt"
                     }
 
                     val dokumentasjonOgUtredning = getOrThrow(vurdering?.dokumentasjonOgUtredning, "dokumentasjonOgUtredning")

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
@@ -496,8 +496,8 @@ internal class BrevInnholdUtlederTest {
                 assertThat(it.deloverskriftHeading).isEqualTo(Heading.H2)
                 assertThat(it.innhold).isEmpty()
             })
-            assertThat(opprettholdelsesbrev.avsnitt.elementAt(3)).isEqualTo(forventetDokumentasjonOgUtredning)
-            assertThat(opprettholdelsesbrev.avsnitt.elementAt(4)).isEqualTo(forventetKlagefristUnntakBegrunnelse)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(3)).isEqualTo(forventetKlagefristUnntakBegrunnelse)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(4)).isEqualTo(forventetDokumentasjonOgUtredningVedKlagefristUnntak)
             assertThat(opprettholdelsesbrev.avsnitt.elementAt(5)).isEqualTo(forventetSpørsmåletISaken)
             assertThat(opprettholdelsesbrev.avsnitt.elementAt(6)).isEqualTo(forventetAktuelleRettskilder)
             assertThat(opprettholdelsesbrev.avsnitt.elementAt(7)).isEqualTo(forventetKlagersAnførsler)
@@ -1273,9 +1273,15 @@ internal class BrevInnholdUtlederTest {
 
     private val forventetKlagefristUnntakBegrunnelse =
         AvsnittDto(
-            deloverskrift = "Unntak for klagefristen er oppfylt",
-            deloverskriftHeading = Heading.H4,
+            deloverskrift = "Dokumentasjon og utredning",
+            deloverskriftHeading = Heading.H3,
             innhold = klagefristUnntakBegrunnelse,
+        )
+
+    private val forventetDokumentasjonOgUtredningVedKlagefristUnntak =
+        AvsnittDto(
+            deloverskrift = "",
+            innhold = dokumentasjonOgUtredning,
         )
 
     private fun forventetHarDuSpørsmålEf(stønadstype: Stønadstype) =

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
@@ -32,21 +32,23 @@ internal class BrevInnholdUtlederTest {
     private val avvistBrevInnholdUtlederLookup = mockk<AvvistBrevInnholdUtleder.Lookup>()
     private val brevInnholdUtleder = BrevInnholdUtleder(avvistBrevInnholdUtlederLookup)
 
-    private val lesMerUrls = mapOf(
-        Stønadstype.OVERGANGSSTØNAD to "nav.no/alene-med-barn",
-        Stønadstype.BARNETILSYN to "nav.no/alene-med-barn",
-        Stønadstype.SKOLEPENGER to "nav.no/alene-med-barn",
-        Stønadstype.BARNETRYGD to "nav.no/barnetrygd",
-        Stønadstype.KONTANTSTØTTE to "nav.no/kontantstotte",
-    )
+    private val lesMerUrls =
+        mapOf(
+            Stønadstype.OVERGANGSSTØNAD to "nav.no/alene-med-barn",
+            Stønadstype.BARNETILSYN to "nav.no/alene-med-barn",
+            Stønadstype.SKOLEPENGER to "nav.no/alene-med-barn",
+            Stønadstype.BARNETRYGD to "nav.no/barnetrygd",
+            Stønadstype.KONTANTSTØTTE to "nav.no/kontantstotte",
+        )
 
-    private val klageUrls = mapOf(
-        Stønadstype.OVERGANGSSTØNAD to "nav.no/klage#overgangsstonad-til-enslig-mor-eller-far",
-        Stønadstype.BARNETILSYN to "nav.no/klage#stonad-til-barnetilsyn-for-enslig-mor-eller-far",
-        Stønadstype.SKOLEPENGER to "nav.no/klage#stonad-til-skolepenger-for-enslig-mor-eller-far",
-        Stønadstype.BARNETRYGD to "nav.no/klage#barnetrygd",
-        Stønadstype.KONTANTSTØTTE to "nav.no/klage#kontantstotte",
-    )
+    private val klageUrls =
+        mapOf(
+            Stønadstype.OVERGANGSSTØNAD to "nav.no/klage#overgangsstonad-til-enslig-mor-eller-far",
+            Stønadstype.BARNETILSYN to "nav.no/klage#stonad-til-barnetilsyn-for-enslig-mor-eller-far",
+            Stønadstype.SKOLEPENGER to "nav.no/klage#stonad-til-skolepenger-for-enslig-mor-eller-far",
+            Stønadstype.BARNETRYGD to "nav.no/klage#barnetrygd",
+            Stønadstype.KONTANTSTØTTE to "nav.no/klage#kontantstotte",
+        )
 
     private val innstillingKlageinstans = "innhold for innstilling klageinstans"
     private val dokumentasjonOgUtredning = "innhold for dokumentasjon og utredning"
@@ -54,6 +56,7 @@ internal class BrevInnholdUtlederTest {
     private val aktuelleRettskilder = "innhold i aktuelle rettskilder"
     private val klagersAnførsler = "innhold i klagers anførsler"
     private val vurderingAvKlagen = "innhold i vurdering av klagen"
+    private val klagefristUnntakBegrunnelse = "innhold i saksbehandlers begrunnelse for at klagefrist unntak er oppfylt"
 
     @BeforeEach
     fun oppsett() {
@@ -72,14 +75,13 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `brev for opprettholdelse skal inneholde blant annat dato og stønadstype`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `brev for opprettholdelse skal inneholde blant annat dato og stønadstype`(stønadstype: Stønadstype) {
             // Arrange
-            val påklagetVedtakDetaljer = påklagetVedtakDetaljer(
-                eksternFagsystemBehandlingId = "123",
-                vedtakstidspunkt = vedtakstidspunkt,
-            )
+            val påklagetVedtakDetaljer =
+                påklagetVedtakDetaljer(
+                    eksternFagsystemBehandlingId = "123",
+                    vedtakstidspunkt = vedtakstidspunkt,
+                )
 
             // Act
             val opprettholdelsesbrev =
@@ -117,9 +119,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `brev for opprettholdelse skal ha med info om tilbakebetaling`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `brev for opprettholdelse skal ha med info om tilbakebetaling`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -165,9 +165,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `skal utlede brev for opprettholdelse for EF og skal ha med info om sanksjon`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede brev for opprettholdelse for EF og skal ha med info om sanksjon`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -212,9 +210,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede opprettholdselesbrev for BA og KS sanksjon`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede opprettholdselesbrev for BA og KS sanksjon`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -227,6 +223,7 @@ internal class BrevInnholdUtlederTest {
             val opprettholdelsesbrev =
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     ident = ident,
+                    klagefristUnntakBegrunnelse = null,
                     dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                     spørsmåletISaken = spørsmåletISaken,
                     aktuelleRettskilder = aktuelleRettskilder,
@@ -273,9 +270,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede opprettholdselesbrev for BA og KS tilbakekreving`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede opprettholdselesbrev for BA og KS tilbakekreving`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -288,6 +283,7 @@ internal class BrevInnholdUtlederTest {
             val opprettholdelsesbrev =
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     ident = ident,
+                    klagefristUnntakBegrunnelse = null,
                     dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                     spørsmåletISaken = spørsmåletISaken,
                     aktuelleRettskilder = aktuelleRettskilder,
@@ -335,9 +331,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede opprettholdselesbrev for BA og KS utestengelse`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede opprettholdselesbrev for BA og KS utestengelse`(stønadstype: Stønadstype) {
             // Arrange
 
             val påklagetVedtakDetaljer =
@@ -351,6 +345,7 @@ internal class BrevInnholdUtlederTest {
             val opprettholdelsesbrev =
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     ident = ident,
+                    klagefristUnntakBegrunnelse = null,
                     dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                     spørsmåletISaken = spørsmåletISaken,
                     aktuelleRettskilder = aktuelleRettskilder,
@@ -397,9 +392,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede opprettholdselesbrev for BA og KS ordinær`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede opprettholdselesbrev for BA og KS ordinær`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -412,6 +405,7 @@ internal class BrevInnholdUtlederTest {
             val opprettholdelsesbrev =
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     ident = ident,
+                    klagefristUnntakBegrunnelse = null,
                     dokumentasjonOgUtredning = dokumentasjonOgUtredning,
                     spørsmåletISaken = spørsmåletISaken,
                     aktuelleRettskilder = aktuelleRettskilder,
@@ -451,6 +445,67 @@ internal class BrevInnholdUtlederTest {
             assertThat(opprettholdelsesbrev.avsnitt.elementAt(9)).isEqualTo(forventetDuHarRettTilInnsynBaKs)
             assertThat(opprettholdelsesbrev.avsnitt.elementAt(10)).isEqualTo(forventetHarDuSpørsmålBaKs(stønadstype))
         }
+
+        @ParameterizedTest
+        @EnumSource(
+            value = Stønadstype::class,
+            names = ["BARNETRYGD", "KONTANTSTØTTE"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        fun `skal utlede opprettholdselesbrev for BA og KS klagefristunntak oppfylt`(stønadstype: Stønadstype) {
+            // Arrange
+            val påklagetVedtakDetaljer =
+                påklagetVedtakDetaljer(
+                    "123",
+                    vedtakstidspunkt = vedtakstidspunkt,
+                    fagsystemType = FagsystemType.ORDNIÆR,
+                )
+
+            // Act
+            val opprettholdelsesbrev =
+                brevInnholdUtleder.lagOpprettholdelseBrev(
+                    ident = ident,
+                    klagefristUnntakBegrunnelse = klagefristUnntakBegrunnelse,
+                    dokumentasjonOgUtredning = dokumentasjonOgUtredning,
+                    spørsmåletISaken = spørsmåletISaken,
+                    aktuelleRettskilder = aktuelleRettskilder,
+                    klagersAnførsler = klagersAnførsler,
+                    vurderingAvKlagen = vurderingAvKlagen,
+                    navn = navn,
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                    klageMottatt = klageMottatt,
+                )
+
+            // Assert
+            assertThat(opprettholdelsesbrev.overskrift).isEqualTo("Vi har sendt klagen din til Nav Klageinstans Nord")
+            assertThat(opprettholdelsesbrev.personIdent).isEqualTo(ident)
+            assertThat(opprettholdelsesbrev.navn).isEqualTo(navn)
+            assertThat(opprettholdelsesbrev.avsnitt).hasSize(12)
+            assertAvsnittUtenDeloverskrift(
+                opprettholdelsesbrev.avsnitt.elementAt(0),
+                "Vi har 6. november 2021 fått klagen din på vedtaket om ${stønadstype.visningsnavn()} som ble gjort 5. november 2021," +
+                    " og kommet frem til at vi ikke endrer vedtaket. Nav Klageinstans skal derfor vurdere saken din på nytt.",
+            )
+            assertAvsnittUtenDeloverskrift(
+                opprettholdelsesbrev.avsnitt.elementAt(1),
+                "Saksbehandlingstidene finner du på nav.no/saksbehandlingstider.",
+            )
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(2)).satisfies({
+                assertThat(it.deloverskrift).isEqualTo("Dette er vurderingen vi har sendt til Nav Klageinstans")
+                assertThat(it.deloverskriftHeading).isEqualTo(Heading.H2)
+                assertThat(it.innhold).isEmpty()
+            })
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(3)).isEqualTo(forventetDokumentasjonOgUtredning)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(4)).isEqualTo(forventetKlagefristUnntakBegrunnelse)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(5)).isEqualTo(forventetSpørsmåletISaken)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(6)).isEqualTo(forventetAktuelleRettskilder)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(7)).isEqualTo(forventetKlagersAnførsler)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(8)).isEqualTo(forventetVurderingAvKlagen)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(9)).isEqualTo(forventetHarDuNyeOpplysninger(stønadstype))
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(10)).isEqualTo(forventetDuHarRettTilInnsynBaKs)
+            assertThat(opprettholdelsesbrev.avsnitt.elementAt(11)).isEqualTo(forventetHarDuSpørsmålBaKs(stønadstype))
+        }
     }
 
     @Nested
@@ -461,9 +516,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `brev for avvist formkrav skal ha med info om tilbakebetaling for EF`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `brev for avvist formkrav skal ha med info om tilbakebetaling for EF`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -845,14 +898,15 @@ internal class BrevInnholdUtlederTest {
                 )
 
             // Act
-            val formkravAvvistBrev = brevInnholdUtleder.lagFormkravAvvistBrev(
-                ident = ident,
-                navn = navn,
-                form = ikkeOppfyltForm(),
-                stønadstype = stønadstype,
-                påklagetVedtakDetaljer = påklagetVedtakDetaljer,
-                fagsystem = Fagsystem.BA,
-            )
+            val formkravAvvistBrev =
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    ident = ident,
+                    navn = navn,
+                    form = ikkeOppfyltForm(),
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                    fagsystem = Fagsystem.BA,
+                )
 
             // Assert
             assertThat(formkravAvvistBrev.overskrift).isEqualTo("Vi har avvist klagen din på vedtaket om barnetrygd")
@@ -879,14 +933,15 @@ internal class BrevInnholdUtlederTest {
             val stønadstype = Stønadstype.BARNETRYGD
 
             // Act
-            val formkravAvvistBrev = brevInnholdUtleder.lagFormkravAvvistBrev(
-                ident = ident,
-                navn = navn,
-                form = ikkeOppfyltForm(),
-                stønadstype = stønadstype,
-                påklagetVedtakDetaljer = null,
-                fagsystem = Fagsystem.BA,
-            )
+            val formkravAvvistBrev =
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    ident = ident,
+                    navn = navn,
+                    form = ikkeOppfyltForm(),
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = null,
+                    fagsystem = Fagsystem.BA,
+                )
 
             // Assert
             assertThat(formkravAvvistBrev.overskrift).isEqualTo("Vi har avvist klagen din på vedtaket om barnetrygd")
@@ -920,14 +975,15 @@ internal class BrevInnholdUtlederTest {
                 )
 
             // Act
-            val formkravAvvistBrev = brevInnholdUtleder.lagFormkravAvvistBrev(
-                ident = ident,
-                navn = navn,
-                form = ikkeOppfyltForm(),
-                stønadstype = stønadstype,
-                påklagetVedtakDetaljer = påklagetVedtakDetaljer,
-                fagsystem = Fagsystem.KS,
-            )
+            val formkravAvvistBrev =
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    ident = ident,
+                    navn = navn,
+                    form = ikkeOppfyltForm(),
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                    fagsystem = Fagsystem.KS,
+                )
 
             // Assert
             assertThat(formkravAvvistBrev.overskrift).isEqualTo("Vi har avvist klagen din på vedtaket om kontantstøtte")
@@ -954,14 +1010,15 @@ internal class BrevInnholdUtlederTest {
             val stønadstype = Stønadstype.KONTANTSTØTTE
 
             // Act
-            val formkravAvvistBrev = brevInnholdUtleder.lagFormkravAvvistBrev(
-                ident = ident,
-                navn = navn,
-                form = ikkeOppfyltForm(),
-                stønadstype = stønadstype,
-                påklagetVedtakDetaljer = null,
-                fagsystem = Fagsystem.KS,
-            )
+            val formkravAvvistBrev =
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    ident = ident,
+                    navn = navn,
+                    form = ikkeOppfyltForm(),
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = null,
+                    fagsystem = Fagsystem.KS,
+                )
 
             // Assert
             assertThat(formkravAvvistBrev.overskrift).isEqualTo("Vi har avvist klagen din på vedtaket om kontantstøtte")
@@ -988,9 +1045,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `skal utlede avvist brev om vedtak for EF`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede avvist brev om vedtak for EF`(stønadstype: Stønadstype) {
             // Arrange
             val påklagetVedtakDetaljer =
                 påklagetVedtakDetaljer(
@@ -999,14 +1054,15 @@ internal class BrevInnholdUtlederTest {
                 )
 
             // Act
-            val formkravAvvistBrev = brevInnholdUtleder.lagFormkravAvvistBrev(
-                ident = ident,
-                navn = navn,
-                form = ikkeOppfyltForm(),
-                stønadstype = stønadstype,
-                påklagetVedtakDetaljer = påklagetVedtakDetaljer,
-                fagsystem = Fagsystem.EF,
-            )
+            val formkravAvvistBrev =
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    ident = ident,
+                    navn = navn,
+                    form = ikkeOppfyltForm(),
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = påklagetVedtakDetaljer,
+                    fagsystem = Fagsystem.EF,
+                )
 
             // Assert
             assertThat(formkravAvvistBrev.overskrift).isEqualTo("Vi har avvist klagen din på vedtaket om ${stønadstype.visningsnavn()}")
@@ -1034,14 +1090,15 @@ internal class BrevInnholdUtlederTest {
         fun `skal kaste feil om brevtekst mangler i formkrav`() {
             // Arrange
             // Act & assert
-            val exception = assertThrows<IllegalStateException> {
-                brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
-                    ident = ident,
-                    navn = navn,
-                    formkrav = ikkeOppfyltForm().copy(brevtekst = null),
-                    stønadstype = Stønadstype.BARNETRYGD,
-                )
-            }
+            val exception =
+                assertThrows<IllegalStateException> {
+                    brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
+                        ident = ident,
+                        navn = navn,
+                        formkrav = ikkeOppfyltForm().copy(brevtekst = null),
+                        stønadstype = Stønadstype.BARNETRYGD,
+                    )
+                }
             assertThat(exception.message).isEqualTo("Må ha brevtekst fra saksbehandler for å generere brev ved formkrav ikke oppfylt")
         }
 
@@ -1051,9 +1108,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `skal utlede brev for avvist formkrav uten påklaget vedtak for EF`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede brev for avvist formkrav uten påklaget vedtak for EF`(stønadstype: Stønadstype) {
             // Arrange
             // Act
             val brev =
@@ -1081,9 +1136,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede brev for avvist formkrav uten påklaget vedtak for BA og KS`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede brev for avvist formkrav uten påklaget vedtak for BA og KS`(stønadstype: Stønadstype) {
             // Arrange
             // Act
             val brev =
@@ -1114,16 +1167,15 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede brevinnhold for henleggelsesbrev for BA og KS`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede brevinnhold for henleggelsesbrev for BA og KS`(stønadstype: Stønadstype) {
             // Arrange
             // Act
-            val henleggelsesbrevBaksInnhold = brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
-                ident = ident,
-                navn = navn,
-                stønadstype = stønadstype,
-            )
+            val henleggelsesbrevBaksInnhold =
+                brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
+                    ident = ident,
+                    navn = navn,
+                    stønadstype = stønadstype,
+                )
 
             // Assert
             assertThat(henleggelsesbrevBaksInnhold.overskrift).isEqualTo("Saken din er avsluttet")
@@ -1145,16 +1197,15 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.EXCLUDE,
         )
-        fun `skal utlede brevinnhold for henleggelsesbrev for EF`(
-            stønadstype: Stønadstype,
-        ) {
+        fun `skal utlede brevinnhold for henleggelsesbrev for EF`(stønadstype: Stønadstype) {
             // Arrange
             // Act
-            val henleggelsesbrevBaksInnhold = brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
-                ident = ident,
-                navn = navn,
-                stønadstype = stønadstype,
-            )
+            val henleggelsesbrevBaksInnhold =
+                brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
+                    ident = ident,
+                    navn = navn,
+                    stønadstype = stønadstype,
+                )
 
             // Assert
             assertThat(henleggelsesbrevBaksInnhold.overskrift).isEqualTo("Saken din er avsluttet")
@@ -1178,98 +1229,124 @@ internal class BrevInnholdUtlederTest {
             brevtekst = "brevtekst",
         )
 
-    private val forventetInnstillingKlageinstans = AvsnittDto(
-        deloverskrift = "Dette er vurderingen vi har sendt til Nav Klageinstans",
-        deloverskriftHeading = null,
-        innhold = innstillingKlageinstans,
-    )
+    private val forventetInnstillingKlageinstans =
+        AvsnittDto(
+            deloverskrift = "Dette er vurderingen vi har sendt til Nav Klageinstans",
+            deloverskriftHeading = null,
+            innhold = innstillingKlageinstans,
+        )
 
-    private val forventetDokumentasjonOgUtredning = AvsnittDto(
-        deloverskrift = "Dokumentasjon og utredning",
-        deloverskriftHeading = Heading.H3,
-        innhold = dokumentasjonOgUtredning,
-    )
+    private val forventetDokumentasjonOgUtredning =
+        AvsnittDto(
+            deloverskrift = "Dokumentasjon og utredning",
+            deloverskriftHeading = Heading.H3,
+            innhold = dokumentasjonOgUtredning,
+        )
 
-    private val forventetSpørsmåletISaken = AvsnittDto(
-        deloverskrift = "Spørsmålet i saken",
-        deloverskriftHeading = Heading.H3,
-        innhold = spørsmåletISaken,
-    )
+    private val forventetSpørsmåletISaken =
+        AvsnittDto(
+            deloverskrift = "Spørsmålet i saken",
+            deloverskriftHeading = Heading.H3,
+            innhold = spørsmåletISaken,
+        )
 
-    private val forventetAktuelleRettskilder = AvsnittDto(
-        deloverskrift = "Aktuelle rettskilder",
-        deloverskriftHeading = Heading.H3,
-        innhold = aktuelleRettskilder,
-    )
+    private val forventetAktuelleRettskilder =
+        AvsnittDto(
+            deloverskrift = "Aktuelle rettskilder",
+            deloverskriftHeading = Heading.H3,
+            innhold = aktuelleRettskilder,
+        )
 
-    private val forventetKlagersAnførsler = AvsnittDto(
-        deloverskrift = "Klagers anførsler",
-        deloverskriftHeading = Heading.H3,
-        innhold = klagersAnførsler,
-    )
+    private val forventetKlagersAnførsler =
+        AvsnittDto(
+            deloverskrift = "Klagers anførsler",
+            deloverskriftHeading = Heading.H3,
+            innhold = klagersAnførsler,
+        )
 
-    private val forventetVurderingAvKlagen = AvsnittDto(
-        deloverskrift = "Vurdering av klagen",
-        deloverskriftHeading = Heading.H3,
-        innhold = vurderingAvKlagen,
-    )
+    private val forventetVurderingAvKlagen =
+        AvsnittDto(
+            deloverskrift = "Vurdering av klagen",
+            deloverskriftHeading = Heading.H3,
+            innhold = vurderingAvKlagen,
+        )
 
-    private fun forventetHarDuSpørsmålEf(stønadstype: Stønadstype) = AvsnittDto(
-        deloverskrift = "Har du spørsmål?",
-        deloverskriftHeading = null,
-        innhold = "Du finner mer informasjon på ${lesMerUrls[stønadstype]}.\n\n" +
-            "På nav.no/kontakt kan du chatte eller skrive til oss.\n\n" +
-            "Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.",
-    )
+    private val forventetKlagefristUnntakBegrunnelse =
+        AvsnittDto(
+            deloverskrift = "Unntak for klagefristen er oppfylt",
+            deloverskriftHeading = Heading.H4,
+            innhold = klagefristUnntakBegrunnelse,
+        )
 
-    private fun forventetHarDuSpørsmålBaKs(stønadstype: Stønadstype) = AvsnittDto(
-        deloverskrift = "Har du spørsmål?",
-        deloverskriftHeading = Heading.H2,
-        innhold = "Du finner mer informasjon på ${lesMerUrls[stønadstype]}. " +
-            "På nav.no/kontakt kan du chatte eller skrive til oss. " +
-            "Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.",
-    )
+    private fun forventetHarDuSpørsmålEf(stønadstype: Stønadstype) =
+        AvsnittDto(
+            deloverskrift = "Har du spørsmål?",
+            deloverskriftHeading = null,
+            innhold =
+                "Du finner mer informasjon på ${lesMerUrls[stønadstype]}.\n\n" +
+                    "På nav.no/kontakt kan du chatte eller skrive til oss.\n\n" +
+                    "Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.",
+        )
 
-    private fun forventetHarDuNyeOpplysninger(stønadstype: Stønadstype) = AvsnittDto(
-        deloverskrift = "Har du nye opplysninger?",
-        deloverskriftHeading =
-            when (stønadstype) {
-                Stønadstype.BARNETRYGD,
-                Stønadstype.KONTANTSTØTTE,
-                -> Heading.H2
-                else -> null
-            },
-        innhold = "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via \n${klageUrls[stønadstype]}.",
-    )
+    private fun forventetHarDuSpørsmålBaKs(stønadstype: Stønadstype) =
+        AvsnittDto(
+            deloverskrift = "Har du spørsmål?",
+            deloverskriftHeading = Heading.H2,
+            innhold =
+                "Du finner mer informasjon på ${lesMerUrls[stønadstype]}. " +
+                    "På nav.no/kontakt kan du chatte eller skrive til oss. " +
+                    "Hvis du ikke finner svar på nav.no kan du ringe oss på telefon 55 55 33 33, hverdager 09.00-15.00.",
+        )
 
-    private val forventetDuHarRettTilInnsynBaKs = AvsnittDto(
-        deloverskrift = "Du har rett til innsyn i saken din",
-        deloverskriftHeading = Heading.H2,
-        innhold = "Du har rett til å se dokumentene i saken din. Dette følger av forvaltningsloven § 18. " +
-            "Kontakt oss om du vil se dokumentene i saken din. Ta kontakt på nav.no/kontakt eller på " +
-            "telefon 55 55 33 33 <34>. Du kan lese mer om innsynsretten på nav.no/personvernerklaering.",
-    )
+    private fun forventetHarDuNyeOpplysninger(stønadstype: Stønadstype) =
+        AvsnittDto(
+            deloverskrift = "Har du nye opplysninger?",
+            deloverskriftHeading =
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD,
+                    Stønadstype.KONTANTSTØTTE,
+                    -> Heading.H2
+                    else -> null
+                },
+            innhold = "Har du nye opplysninger eller ønsker å uttale deg, kan du sende oss dette via \n${klageUrls[stønadstype]}.",
+        )
 
-    private val forventetDuHarRettTilInnsynEf = AvsnittDto(
-        deloverskrift = "Du har rett til innsyn",
-        deloverskriftHeading = null,
-        innhold = "På nav.no/dittnav kan du se dokumentene i saken din.",
-    )
+    private val forventetDuHarRettTilInnsynBaKs =
+        AvsnittDto(
+            deloverskrift = "Du har rett til innsyn i saken din",
+            deloverskriftHeading = Heading.H2,
+            innhold =
+                "Du har rett til å se dokumentene i saken din. Dette følger av forvaltningsloven § 18. " +
+                    "Kontakt oss om du vil se dokumentene i saken din. Ta kontakt på nav.no/kontakt eller på " +
+                    "telefon 55 55 33 33 <34>. Du kan lese mer om innsynsretten på nav.no/personvernerklaering.",
+        )
 
-    private fun forventetDuHarRettTilÅKlage(stønadstype: Stønadstype) = AvsnittDto(
-        deloverskrift = "Du har rett til å klage",
-        deloverskriftHeading =
-            when (stønadstype) {
-                Stønadstype.BARNETRYGD,
-                Stønadstype.KONTANTSTØTTE,
-                -> Heading.H2
-                else -> null
-            },
-        innhold = "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
-            "Du finner skjema og informasjon på ${klageUrls[stønadstype]}.",
-    )
+    private val forventetDuHarRettTilInnsynEf =
+        AvsnittDto(
+            deloverskrift = "Du har rett til innsyn",
+            deloverskriftHeading = null,
+            innhold = "På nav.no/dittnav kan du se dokumentene i saken din.",
+        )
 
-    private fun assertAvsnittUtenDeloverskrift(avsnittDto: AvsnittDto, forventetTekst: String) {
+    private fun forventetDuHarRettTilÅKlage(stønadstype: Stønadstype) =
+        AvsnittDto(
+            deloverskrift = "Du har rett til å klage",
+            deloverskriftHeading =
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD,
+                    Stønadstype.KONTANTSTØTTE,
+                    -> Heading.H2
+                    else -> null
+                },
+            innhold =
+                "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
+                    "Du finner skjema og informasjon på ${klageUrls[stønadstype]}.",
+        )
+
+    private fun assertAvsnittUtenDeloverskrift(
+        avsnittDto: AvsnittDto,
+        forventetTekst: String,
+    ) {
         assertThat(avsnittDto.deloverskrift).isEmpty()
         assertThat(avsnittDto.deloverskriftHeading).isNull()
         assertThat(avsnittDto.innhold).isEqualTo(forventetTekst)


### PR DESCRIPTION
Legger til saksbehandlers begrunnelse for hvorfor klagefrist-unntak er oppfylt i "opprettholdelse"-brev.

Teksten legges inn først under underoverskriften "Dokumentasjon og utredning".

Beklageligvis ser det ut til at det er flere endringer enn det som er reelt. Veldig mye er bare ktlint.

> Velger her å ikke opprette nye felter for intern begrunnelse og brevtekst, da vi fortsatt forholdsvis enkelt kan utlede om det er en avvisnings-begrunnelse eller en klagefrist-unntak begrunnelse

Screenshots:
![image](https://github.com/user-attachments/assets/f245d889-cf0f-4ba4-a17e-9158d4a6262b)