### PR TITLE
NAV-24862: Fjerne toggle for å vise brevmottaker BAKS variant

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -14,7 +14,6 @@ class FeatureToggleController(
     private val featureToggleService: FeatureToggleService,
 ) {
     private val featureTogglesIBruk: Set<Toggle> = setOf(
-        Toggle.VIS_BREVMOTTAKER_BAKS,
         Toggle.LEGG_TIL_BREVMOTTAKER_BAKS,
     )
 

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -20,7 +20,6 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     VELG_SIGNATUR_BASERT_PÅ_FAGSAK("familie-klage.velg-signatur-basert-paa-fagsak", "Permission"),
 
     // Release
-    VIS_BREVMOTTAKER_BAKS("familie-klage.vis-brevmottaker-baks", "Release"),
     LEGG_TIL_BREVMOTTAKER_BAKS("familie-klage.legg-til-brevmottaker-baks", "Release"),
     SETT_BEHANDLINGSTEMA_OG_BEHANDLINGSTYPE_FOR_BAKS(
         "familie-klage.nav-24445-sett-behandlingstema-til-klage",

--- a/src/test/kotlin/no/nav/familie/klage/integrasjoner/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/integrasjoner/FeatureToggleMock.kt
@@ -18,7 +18,6 @@ class FeatureToggleMock {
         val mock = mockk<FeatureToggleService>()
         every { mock.isEnabled(any()) } returns true
         every { mock.isEnabled(Toggle.LEGG_TIL_BREVMOTTAKER_BAKS) } returns false
-        every { mock.isEnabled(Toggle.VIS_BREVMOTTAKER_BAKS) } returns true
         return mock
     }
 }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24862

Toggle er skrudd på i prod og trengs ikke lengre. 

Frontend må merges først: https://github.com/navikt/familie-klage-frontend/pull/920