### PR TITLE
NAV-24873: Setter klagefrist til 3 uker for kontantstøtte

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -242,9 +242,15 @@ class BrevInnholdUtleder(
             deloverskrift = "Du har rett til å klage",
             deloverskriftHeading = utledDeloverskriftHeading(stønadstype),
             innhold =
-            "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
-                "Du finner skjema og informasjon på ${stønadstype.klageUrl()}.",
+                "Hvis du vil klage, må du gjøre dette innen ${utledKlagefrist(stønadstype)} uker fra den datoen du fikk dette brevet. " +
+                    "Du finner skjema og informasjon på ${stønadstype.klageUrl()}.",
         )
+
+    private fun utledKlagefrist(stønadstype: Stønadstype): Int =
+        when (stønadstype) {
+            Stønadstype.KONTANTSTØTTE -> 3
+            else -> 6
+        }
 
     private fun harDuSpørsmålAvsnitt(stønadstype: Stønadstype) =
         AvsnittDto(

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
@@ -954,14 +954,15 @@ internal class BrevInnholdUtlederTest {
             val stønadstype = Stønadstype.KONTANTSTØTTE
 
             // Act
-            val formkravAvvistBrev = brevInnholdUtleder.lagFormkravAvvistBrev(
-                ident = ident,
-                navn = navn,
-                form = ikkeOppfyltForm(),
-                stønadstype = stønadstype,
-                påklagetVedtakDetaljer = null,
-                fagsystem = Fagsystem.KS,
-            )
+            val formkravAvvistBrev =
+                brevInnholdUtleder.lagFormkravAvvistBrev(
+                    ident = ident,
+                    navn = navn,
+                    form = ikkeOppfyltForm(),
+                    stønadstype = stønadstype,
+                    påklagetVedtakDetaljer = null,
+                    fagsystem = Fagsystem.KS,
+                )
 
             // Assert
             assertThat(formkravAvvistBrev.overskrift).isEqualTo("Vi har avvist klagen din på vedtaket om kontantstøtte")
@@ -1256,18 +1257,26 @@ internal class BrevInnholdUtlederTest {
         innhold = "På nav.no/dittnav kan du se dokumentene i saken din.",
     )
 
-    private fun forventetDuHarRettTilÅKlage(stønadstype: Stønadstype) = AvsnittDto(
-        deloverskrift = "Du har rett til å klage",
-        deloverskriftHeading =
-        when (stønadstype) {
-            Stønadstype.BARNETRYGD,
-            Stønadstype.KONTANTSTØTTE,
-            -> Heading.H2
-            else -> null
-        },
-        innhold = "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
-            "Du finner skjema og informasjon på ${klageUrls[stønadstype]}.",
-    )
+    private fun forventetDuHarRettTilÅKlage(stønadstype: Stønadstype) =
+        AvsnittDto(
+            deloverskrift = "Du har rett til å klage",
+            deloverskriftHeading =
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD,
+                    Stønadstype.KONTANTSTØTTE,
+                    -> Heading.H2
+                    else -> null
+                },
+            innhold =
+                when (stønadstype) {
+                    Stønadstype.KONTANTSTØTTE ->
+                        "Hvis du vil klage, må du gjøre dette innen 3 uker fra den datoen du fikk dette brevet. " +
+                            "Du finner skjema og informasjon på ${klageUrls[stønadstype]}."
+                    else ->
+                        "Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette brevet. " +
+                            "Du finner skjema og informasjon på ${klageUrls[stønadstype]}."
+                },
+        )
 
     private fun assertAvsnittUtenDeloverskrift(avsnittDto: AvsnittDto, forventetTekst: String) {
         assertThat(avsnittDto.deloverskrift).isEmpty()


### PR DESCRIPTION
Favro: [NAV-24873](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24873)

Tidligere satt vi alle klagefrister til 6 uker. Nå settes klagefrist til 3 uker for kontantstøtte.