### PR TITLE
NAV-24872: Justerer formulering for trukket klage for BA og KS

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -228,7 +228,7 @@ class BrevInnholdUtleder(
             listOfNotNull(
                 AvsnittDto(
                     deloverskrift = "",
-                    innhold = "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om " +
+                    innhold = "Du har trukket klagen din på vedtaket om " +
                         "${stønadstype.name.lowercase()}. Vi har derfor avsluttet saken din.",
                 ),
                 if (stønadstype.erBarnetrygdEllerKontantstøtte()) duHarRettTilInnsynAvsnitt(stønadstype) else null,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -231,7 +231,7 @@ class BrevInnholdUtleder(
                     innhold = "Du har trukket klagen din på vedtaket om " +
                         "${stønadstype.name.lowercase()}. Vi har derfor avsluttet saken din.",
                 ),
-                if (stønadstype.erBarnetrygdEllerKontantstøtte()) duHarRettTilInnsynAvsnitt(stønadstype) else null,
+                duHarRettTilInnsynAvsnitt(stønadstype),
                 harDuSpørsmålAvsnitt(stønadstype),
             ),
         )

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
@@ -1114,10 +1114,7 @@ internal class BrevInnholdUtlederTest {
             names = ["BARNETRYGD", "KONTANTSTØTTE"],
             mode = EnumSource.Mode.INCLUDE,
         )
-        fun `skal utlede brevinnhold for henleggelsesbrev for BA og KS`(
-            stønadstype: Stønadstype,
-        ) {
-            // Arrange
+        fun `skal utlede brevinnhold for henleggelsesbrev for BA og KS`(stønadstype: Stønadstype) {
             // Act
             val henleggelsesbrevBaksInnhold = brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
                 ident = ident,
@@ -1132,41 +1129,11 @@ internal class BrevInnholdUtlederTest {
             assertThat(henleggelsesbrevBaksInnhold.avsnitt).hasSize(3)
             assertAvsnittUtenDeloverskrift(
                 henleggelsesbrevBaksInnhold.avsnitt.elementAt(0),
-                "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om " +
+                "Du har trukket klagen din på vedtaket om " +
                     "${stønadstype.name.lowercase()}. Vi har derfor avsluttet saken din.",
             )
             assertThat(henleggelsesbrevBaksInnhold.avsnitt.elementAt(1)).isEqualTo(forventetDuHarRettTilInnsynBaKs)
             assertThat(henleggelsesbrevBaksInnhold.avsnitt.elementAt(2)).isEqualTo(forventetHarDuSpørsmålBaKs(stønadstype))
-        }
-
-        @ParameterizedTest
-        @EnumSource(
-            value = Stønadstype::class,
-            names = ["BARNETRYGD", "KONTANTSTØTTE"],
-            mode = EnumSource.Mode.EXCLUDE,
-        )
-        fun `skal utlede brevinnhold for henleggelsesbrev for EF`(
-            stønadstype: Stønadstype,
-        ) {
-            // Arrange
-            // Act
-            val henleggelsesbrevBaksInnhold = brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
-                ident = ident,
-                navn = navn,
-                stønadstype = stønadstype,
-            )
-
-            // Assert
-            assertThat(henleggelsesbrevBaksInnhold.overskrift).isEqualTo("Saken din er avsluttet")
-            assertThat(henleggelsesbrevBaksInnhold.personIdent).isEqualTo(ident)
-            assertThat(henleggelsesbrevBaksInnhold.navn).isEqualTo(navn)
-            assertThat(henleggelsesbrevBaksInnhold.avsnitt).hasSize(2)
-            assertAvsnittUtenDeloverskrift(
-                henleggelsesbrevBaksInnhold.avsnitt.elementAt(0),
-                "Du har gitt oss beskjed om at du trekker klagen din på vedtaket om " +
-                    "${stønadstype.name.lowercase()}. Vi har derfor avsluttet saken din.",
-            )
-            assertThat(henleggelsesbrevBaksInnhold.avsnitt.elementAt(1)).isEqualTo(forventetHarDuSpørsmålEf(stønadstype))
         }
     }
 


### PR DESCRIPTION
Favro: [NAV-24872](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24872)

Justerer formulering for trukket klage for BA og KS og oppdaterer tilhørende tester.

Endte opp med å slette en test da den tester noe som aldri skal skje i løsningen.