### PR TITLE
NAV-24658: Ta i bruk nytt endepunkt for oppretting av revurdering klage for KS og BA

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -30,6 +30,10 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     KAN_MELLOMLAGRE_VURDERING("familie-klage.kan-mellomlagre-vurdering", "Release"),
     SKAL_BRUKE_KABAL_API_V4("familie-klage.skal-bruke-kabal-api-v4", "Release"),
     SKAL_BRUKE_NY_LØYPE_FOR_JOURNALFØRING("familie-klage.skal-bruke-ny-loype-for-journalforing", "Release"),
+    SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE(
+        "familie-klage.send-behandlingid-ved-oppretting-av-revurdering-klage",
+        "Release"
+    )
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FagsystemVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FagsystemVedtakService.kt
@@ -66,8 +66,8 @@ class FagsystemVedtakService(
         return try {
             when (fagsak.fagsystem) {
                 Fagsystem.EF -> familieEFSakClient.opprettRevurdering(fagsak.eksternId)
-                Fagsystem.KS -> familieKSSakClient.opprettRevurdering(fagsak.eksternId)
-                Fagsystem.BA -> familieBASakClient.opprettRevurdering(fagsak.eksternId)
+                Fagsystem.KS -> familieKSSakClient.opprettRevurdering(fagsak.eksternId, behandlingId)
+                Fagsystem.BA -> familieBASakClient.opprettRevurdering(fagsak.eksternId, behandlingId)
             }
         } catch (e: Exception) {
             val errorSuffix = "Feilet opprettelse av revurdering for behandling=$behandlingId eksternFagsakId=${fagsak.eksternId}"

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -12,31 +12,43 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
+import java.util.UUID
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 
 @Component
 class FamilieBASakClient(
     @Qualifier("azure") restOperations: RestOperations,
     @Value("\${FAMILIE_BA_SAK_URL}") private val familieBaSakUri: URI,
+    private val featureToggleService: FeatureToggleService
 ) : AbstractRestClient(restOperations, "familie.ba.sak") {
 
-    fun hentVedtak(fagsystemEksternFagsakId: String): List<FagsystemVedtak> {
+    fun hentVedtak(eksternFagsakId: String): List<FagsystemVedtak> {
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieBaSakUri)
-            .pathSegment("api/klage/fagsaker/$fagsystemEksternFagsakId/vedtak")
-            .build().toUri()
+            .pathSegment("api/klage/fagsaker/$eksternFagsakId/vedtak")
+            .build()
+            .toUri()
         return getForEntity<Ressurs<List<FagsystemVedtak>>>(hentVedtakUri).getDataOrThrow()
     }
 
-    fun kanOppretteRevurdering(fagsystemEksternFagsakId: String): KanOppretteRevurderingResponse {
+    fun kanOppretteRevurdering(eksternFagsakId: String): KanOppretteRevurderingResponse {
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieBaSakUri)
-            .pathSegment("api/klage/fagsaker/$fagsystemEksternFagsakId/kan-opprette-revurdering-klage")
-            .build().toUri()
+            .pathSegment("api/klage/fagsaker/$eksternFagsakId/kan-opprette-revurdering-klage")
+            .build()
+            .toUri()
         return getForEntity<Ressurs<KanOppretteRevurderingResponse>>(hentVedtakUri).getDataOrThrow()
     }
 
-    fun opprettRevurdering(fagsystemEksternFagsakId: String): OpprettRevurderingResponse {
+    fun opprettRevurdering(eksternFagsakId: String, klagebehandlingId: UUID): OpprettRevurderingResponse {
+        val url = if (featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE)) {
+            "api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+        } else {
+            "api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
+        }
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieBaSakUri)
-            .pathSegment("api/klage/fagsaker/$fagsystemEksternFagsakId/opprett-revurdering-klage")
-            .build().toUri()
+            .pathSegment(url)
+            .build()
+            .toUri()
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
@@ -12,31 +12,43 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
+import java.util.UUID
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 
 @Component
 class FamilieKSSakClient(
     @Qualifier("azure") restOperations: RestOperations,
     @Value("\${FAMILIE_KS_SAK_URL}") private val familieKsSakUri: URI,
+    private val featureToggleService: FeatureToggleService
 ) : AbstractRestClient(restOperations, "familie.ks.sak") {
 
-    fun hentVedtak(fagsystemEksternFagsakId: String): List<FagsystemVedtak> {
+    fun hentVedtak(eksternFagsakId: String): List<FagsystemVedtak> {
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieKsSakUri)
-            .pathSegment("api/ekstern/fagsaker/$fagsystemEksternFagsakId/vedtak")
-            .build().toUri()
+            .pathSegment("api/ekstern/fagsaker/$eksternFagsakId/vedtak")
+            .build()
+            .toUri()
         return getForEntity<Ressurs<List<FagsystemVedtak>>>(hentVedtakUri).getDataOrThrow()
     }
 
-    fun kanOppretteRevurdering(fagsystemEksternFagsakId: String): KanOppretteRevurderingResponse {
+    fun kanOppretteRevurdering(eksternFagsakId: String): KanOppretteRevurderingResponse {
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieKsSakUri)
-            .pathSegment("api/ekstern/fagsaker/$fagsystemEksternFagsakId/kan-opprette-revurdering-klage")
-            .build().toUri()
+            .pathSegment("api/ekstern/fagsaker/$eksternFagsakId/kan-opprette-revurdering-klage")
+            .build()
+            .toUri()
         return getForEntity<Ressurs<KanOppretteRevurderingResponse>>(hentVedtakUri).getDataOrThrow()
     }
 
-    fun opprettRevurdering(fagsystemEksternFagsakId: String): OpprettRevurderingResponse {
+    fun opprettRevurdering(eksternFagsakId: String, klagebehandlingId: UUID): OpprettRevurderingResponse {
+        val url = if (featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE)) {
+            "api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+        } else {
+            "api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
+        }
         val hentVedtakUri = UriComponentsBuilder.fromUri(familieKsSakUri)
-            .pathSegment("api/ekstern/fagsaker/$fagsystemEksternFagsakId/opprett-revurdering-klage")
-            .build().toUri()
+            .pathSegment(url)
+            .build()
+            .toUri()
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
@@ -73,7 +73,7 @@ class FamilieBASakClientMock {
 
             // mocker annen hver
             var opprettet = true
-            every { mock.opprettRevurdering(any()) } answers {
+            every { mock.opprettRevurdering(any(), any()) } answers {
                 opprettet = !opprettet
                 if (opprettet) {
                     OpprettRevurderingResponse(Opprettet(eksternBehandlingId = UUID.randomUUID().toString()))

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
@@ -73,7 +73,7 @@ class FamilieKSSakClientMock {
 
             // mocker annen hver
             var opprettet = true
-            every { mock.opprettRevurdering(any()) } answers {
+            every { mock.opprettRevurdering(any(), any()) } answers {
                 opprettet = !opprettet
                 if (opprettet) {
                     OpprettRevurderingResponse(Opprettet(eksternBehandlingId = UUID.randomUUID().toString()))

--- a/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClientTest.kt
@@ -1,0 +1,125 @@
+package no.nav.familie.klage.integrasjoner
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.net.URI
+import java.util.UUID
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
+import no.nav.familie.kontrakter.felles.klage.Opprettet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+
+class FamilieBASakClientTest {
+    private val restOperations = mockk<RestOperations>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+
+    private val familieBASakClient = FamilieBASakClient(
+        restOperations = restOperations,
+        familieBaSakUri = URI.create("http://localhost:8080"),
+        featureToggleService = featureToggleService,
+    )
+
+    @Nested
+    inner class OpprettRevurdering {
+        @Test
+        fun `skal opprette revurdering uten å sende behandlingId`() {
+            // Arrange
+            val eksternFagsakId = "1"
+            val klagebehandlingId = UUID.randomUUID()
+
+            val fakeOpprettRevurderingResponse = OpprettRevurderingResponse(
+                opprettet = Opprettet(klagebehandlingId.toString())
+            )
+
+            val uri = URI.create(
+                "http://localhost:8080/api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
+            )
+
+            every {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>()
+                )
+            } returns ResponseEntity.ok(
+                Ressurs.success(
+                    fakeOpprettRevurderingResponse
+                )
+            )
+
+            every { featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE) } returns false
+
+            // Act
+            val opprettRevurderingResponse = familieBASakClient.opprettRevurdering(
+                eksternFagsakId = eksternFagsakId,
+                klagebehandlingId = klagebehandlingId
+            )
+
+            // Assert
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    eq(uri),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<Void>>()
+                )
+            }
+            assertThat(opprettRevurderingResponse).isEqualTo(fakeOpprettRevurderingResponse)
+        }
+
+        @Test
+        fun `skal opprette revurdering`() {
+            // Arrange
+            val eksternFagsakId = "1"
+            val klagebehandlingId = UUID.randomUUID()
+
+            val fakeOpprettRevurderingResponse = OpprettRevurderingResponse(
+                opprettet = Opprettet(klagebehandlingId.toString())
+            )
+
+            val uri = URI.create(
+                "http://localhost:8080/api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+            )
+
+            every {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>()
+                )
+            } returns ResponseEntity.ok(
+                Ressurs.success(
+                    fakeOpprettRevurderingResponse
+                )
+            )
+
+            every { featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE) } returns true
+
+            // Act
+            val opprettRevurderingResponse = familieBASakClient.opprettRevurdering(
+                eksternFagsakId = eksternFagsakId,
+                klagebehandlingId = klagebehandlingId
+            )
+
+            // Assert
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    eq(uri),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<Void>>()
+                )
+            }
+            assertThat(opprettRevurderingResponse).isEqualTo(fakeOpprettRevurderingResponse)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClientTest.kt
@@ -1,0 +1,124 @@
+package no.nav.familie.klage.integrasjoner
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.net.URI
+import java.util.UUID
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
+import no.nav.familie.kontrakter.felles.klage.Opprettet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+
+class FamilieKSSakClientTest {
+    private val restOperations = mockk<RestOperations>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+
+    private val familieKSSakClient = FamilieKSSakClient(
+        restOperations = restOperations,
+        familieKsSakUri = URI.create("http://localhost:8080"),
+        featureToggleService = featureToggleService,
+    )
+
+    @Nested
+    inner class OpprettRevurdering {
+        @Test
+        fun `skal opprette revurdering uten å sende behandlingId`() {
+            // Arrange
+            val eksternFagsakId = "1"
+            val klagebehandlingId = UUID.randomUUID()
+
+            val fakeOpprettRevurderingResponse = OpprettRevurderingResponse(
+                opprettet = Opprettet(klagebehandlingId.toString())
+            )
+
+            val uri = URI.create(
+                "http://localhost:8080/api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
+            )
+
+            every {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>()
+                )
+            } returns ResponseEntity.ok(
+                Ressurs.success(
+                    fakeOpprettRevurderingResponse
+                )
+            )
+
+            every { featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE) } returns false
+
+            // Act
+            val opprettRevurderingResponse = familieKSSakClient.opprettRevurdering(
+                eksternFagsakId = eksternFagsakId,
+                klagebehandlingId = klagebehandlingId
+            )
+
+            // Assert
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    eq(uri),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<Void>>()
+                )
+            }
+            assertThat(opprettRevurderingResponse).isEqualTo(fakeOpprettRevurderingResponse)
+        }
+
+        @Test
+        fun `skal opprette revurdering`() {
+            // Arrange
+            val eksternFagsakId = "1"
+            val klagebehandlingId = UUID.randomUUID()
+
+            val fakeOpprettRevurderingResponse = OpprettRevurderingResponse(
+                opprettet = Opprettet(klagebehandlingId.toString())
+            )
+
+            val uri = URI.create(
+                "http://localhost:8080/api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+            )
+
+            every {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>()
+                )
+            } returns ResponseEntity.ok(
+                Ressurs.success(
+                    fakeOpprettRevurderingResponse
+                )
+            )
+
+            every { featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE) } returns true
+
+            // Act
+            val opprettRevurderingResponse = familieKSSakClient.opprettRevurdering(
+                eksternFagsakId = eksternFagsakId,
+                klagebehandlingId = klagebehandlingId
+            )
+
+            // Assert
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
+                    eq(uri),
+                    eq(HttpMethod.POST),
+                    any<HttpEntity<Void>>()
+                )
+            }
+            assertThat(opprettRevurderingResponse).isEqualTo(fakeOpprettRevurderingResponse)
+        }
+    }
+}


### PR DESCRIPTION
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

**Obs! Obs! familie-ba-sak og familie-ks-sak PRene må merges først, ellers må toggelen være skrudd av.**

Har behov for klagebehandling ID når man rapporterer saksstatistikk til DVH. Vi har lyst til at revurdering klage skal peke til klagebehandlingen som er kilden. Tar i dermed i bruk nytt endepunkt som sender med IDen til klagebehandlingen.

Relatert familie-ba-sak PR: https://github.com/navikt/familie-ba-sak/pull/5211