### PR TITLE
NAV-24896: Rydder opp i valideringskode for brevmottaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretter.kt
@@ -126,38 +126,38 @@ class BrevmottakerOppretter(
         val eksisterendeMottakerRoller = eksisterendeBrevmottakerePersonerUtenIdent.map { it.mottakerRolle }
         when {
             eksisterendeMottakerRoller.any { it == nyBrevmottakerPersonUtenIdent.mottakerRolle } -> {
-                throw Feil("Kan ikke ha duplikate MottakerRolle. ${nyBrevmottakerPersonUtenIdent.mottakerRolle} finnes allerede.")
+                throw Feil("Kan ikke ha duplikate MottakerRolle. ${nyBrevmottakerPersonUtenIdent.mottakerRolle} finnes allerede for $behandlingId.")
             }
 
             nyBrevmottakerPersonUtenIdent.mottakerRolle == MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE &&
                 nyBrevmottakerPersonUtenIdent.navn != brukerensNavn -> {
-                throw Feil("Ved bruker med utenlandsk adresse skal brevmottakerens navn være brukerens navn.")
+                throw Feil("Ved bruker med utenlandsk adresse skal brevmottakerens navn være brukerens navn for $behandlingId.")
             }
 
             nyBrevmottakerPersonUtenIdent.mottakerRolle == MottakerRolle.DØDSBO &&
                 !nyBrevmottakerPersonUtenIdent.navn.contains(brukerensNavn) -> {
-                throw Feil("Ved dødsbo skal brevmottakerens navn inneholde brukerens navn.")
+                throw Feil("Ved dødsbo skal brevmottakerens navn inneholde brukerens navn for $behandlingId.")
             }
 
             nyBrevmottakerPersonUtenIdent.mottakerRolle == MottakerRolle.DØDSBO &&
                 eksisterendeBrevmottakerePersonerUtenIdent.isNotEmpty() -> {
-                throw Feil("Kan ikke legge til dødsbo når det allerede finnes brevmottakere.")
+                throw Feil("Kan ikke legge til dødsbo når det allerede finnes brevmottakere for $behandlingId.")
             }
 
             eksisterendeMottakerRoller.any { it == MottakerRolle.DØDSBO } -> {
-                throw Feil("Kan ikke legge til flere brevmottakere når det allerede finnes et dødsbo.")
+                throw Feil("Kan ikke legge til flere brevmottakere når det allerede finnes et dødsbo for $behandlingId.")
             }
 
             MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE in eksisterendeMottakerRoller &&
                 nyBrevmottakerPersonUtenIdent.mottakerRolle !== MottakerRolle.VERGE &&
                 nyBrevmottakerPersonUtenIdent.mottakerRolle !== MottakerRolle.FULLMAKT -> {
-                throw Feil("Bruker med utenlandsk adresse kan kun kombineres med verge eller fullmektig.")
+                throw Feil("Bruker med utenlandsk adresse kan kun kombineres med verge eller fullmektig for $behandlingId.")
             }
 
             eksisterendeMottakerRoller.isNotEmpty() &&
                 MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE !in eksisterendeMottakerRoller &&
                 nyBrevmottakerPersonUtenIdent.mottakerRolle !== MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE -> {
-                throw Feil("Kan kun legge til bruker med utenlandsk adresse om det finnes en brevmottaker allerede.")
+                throw Feil("Kan kun legge til bruker med utenlandsk adresse om det finnes en brevmottaker allerede for $behandlingId.")
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerSletter.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerSletter.kt
@@ -97,6 +97,8 @@ class BrevmottakerSletter(
             },
         )
 
+        validerMinimumEnMottaker(behandling, nyeBrevmottakere)
+
         brevRepository.update(
             brev.copy(
                 mottakere = nyeBrevmottakere,
@@ -113,6 +115,12 @@ class BrevmottakerSletter(
     private fun validerKorrektBehandlingssteg(behandling: Behandling) {
         if (behandling.steg != StegType.BREV) {
             throw Feil("Behandlingen er i steg ${behandling.steg}, forventet steg ${StegType.BREV}.")
+        }
+    }
+
+    private fun validerMinimumEnMottaker(behandling: Behandling, brevmottakere: Brevmottakere) {
+        if (brevmottakere.personer.isEmpty() && brevmottakere.organisasjoner.isEmpty()) {
+            throw Feil("Må ha minimum en brevmottaker for behandling ${behandling.id}.")
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerErstatterTest.kt
@@ -42,11 +42,34 @@ class BrevmottakerErstatterTest {
     @Nested
     inner class ErstattBrevmottakereTest {
         @Test
+        fun `skal kaste exception om man prøver å lagre ned tom brevmottakere`() {
+            // Arrange
+            val behandling = DomainUtil.behandling(steg = StegType.OPPRETTET)
+
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+
+            every {
+                behandlingService.hentBehandling(behandling.id)
+            } returns behandling
+
+            // Act & assert
+            val exception = assertThrows<Feil> {
+                brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
+            }
+            assertThat(exception.message).isEqualTo("Må ha minimum en brevmottaker for behandling ${behandling.id}.")
+        }
+
+        @Test
         fun `skal kaste exception om behandling er låst for videre redigering`() {
             // Arrange
             val behandling = DomainUtil.behandling(status = BehandlingStatus.FERDIGSTILT)
 
-            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "2"),
+                )
+            )
 
             every {
                 behandlingService.hentBehandling(behandling.id)
@@ -64,7 +87,12 @@ class BrevmottakerErstatterTest {
             // Arrange
             val behandling = DomainUtil.behandling(steg = StegType.OPPRETTET)
 
-            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "2"),
+                )
+            )
 
             every {
                 behandlingService.hentBehandling(behandling.id)
@@ -97,7 +125,7 @@ class BrevmottakerErstatterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
             }
-            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker for behandling ${behandling.id}.")
         }
 
         @Test
@@ -122,7 +150,7 @@ class BrevmottakerErstatterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
             }
-            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker.")
+            assertThat(exception.message).isEqualTo("En person kan bare legges til en gang som brevmottaker for behandling ${behandling.id}.")
         }
 
         @Test
@@ -145,7 +173,7 @@ class BrevmottakerErstatterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerErstatter.erstattBrevmottakere(behandling.id, nyeBrevmottakere)
             }
-            assertThat(exception.message).isEqualTo("En organisasjon kan bare legges til en gang som brevmottaker.")
+            assertThat(exception.message).isEqualTo("En organisasjon kan bare legges til en gang som brevmottaker for behandling ${behandling.id}.")
         }
 
         @Test
@@ -153,7 +181,12 @@ class BrevmottakerErstatterTest {
             // Arrange
             val behandling = DomainUtil.behandling(steg = StegType.BREV)
 
-            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "2"),
+                )
+            )
 
             every {
                 behandlingService.hentBehandling(behandling.id)
@@ -175,7 +208,12 @@ class BrevmottakerErstatterTest {
             // Arrange
             val behandling = DomainUtil.behandling(steg = StegType.BREV)
 
-            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "2"),
+                )
+            )
 
             every {
                 behandlingService.hentBehandling(behandling.id)
@@ -199,11 +237,16 @@ class BrevmottakerErstatterTest {
         }
 
         @Test
-        fun `skal kaste erstatte brevmottakere`() {
+        fun `skal erstatte brevmottakere`() {
             // Arrange
             val behandling = DomainUtil.behandling(steg = StegType.BREV)
 
-            val nyeBrevmottakere = DomainUtil.lagBrevmottakere()
+            val nyeBrevmottakere = DomainUtil.lagBrevmottakere(
+                personer = listOf(
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "1"),
+                    DomainUtil.lagBrevmottakerPersonMedIdent(personIdent = "2"),
+                )
+            )
 
             every {
                 behandlingService.hentBehandling(behandling.id)

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerOppretterTest.kt
@@ -161,7 +161,7 @@ class BrevmottakerOppretterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
-            assertThat(exception.message).isEqualTo("Kan ikke ha duplikate MottakerRolle. FULLMAKT finnes allerede.")
+            assertThat(exception.message).isEqualTo("Kan ikke ha duplikate MottakerRolle. FULLMAKT finnes allerede for ${behandling.id}.")
         }
 
         @Test
@@ -199,7 +199,7 @@ class BrevmottakerOppretterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
-            assertThat(exception.message).isEqualTo("Ved bruker med utenlandsk adresse skal brevmottakerens navn være brukerens navn.")
+            assertThat(exception.message).isEqualTo("Ved bruker med utenlandsk adresse skal brevmottakerens navn være brukerens navn for ${behandling.id}.")
         }
 
         @Test
@@ -237,7 +237,7 @@ class BrevmottakerOppretterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
-            assertThat(exception.message).isEqualTo("Ved dødsbo skal brevmottakerens navn inneholde brukerens navn.")
+            assertThat(exception.message).isEqualTo("Ved dødsbo skal brevmottakerens navn inneholde brukerens navn for ${behandling.id}.")
         }
 
         @Test
@@ -278,7 +278,7 @@ class BrevmottakerOppretterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
-            assertThat(exception.message).isEqualTo("Kan ikke legge til dødsbo når det allerede finnes brevmottakere.")
+            assertThat(exception.message).isEqualTo("Kan ikke legge til dødsbo når det allerede finnes brevmottakere for ${behandling.id}.")
         }
 
         @Test
@@ -321,7 +321,7 @@ class BrevmottakerOppretterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
-            assertThat(exception.message).isEqualTo("Kan ikke legge til flere brevmottakere når det allerede finnes et dødsbo.")
+            assertThat(exception.message).isEqualTo("Kan ikke legge til flere brevmottakere når det allerede finnes et dødsbo for ${behandling.id}.")
         }
 
         @Test
@@ -364,7 +364,7 @@ class BrevmottakerOppretterTest {
             val exception = assertThrows<Feil> {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
-            assertThat(exception.message).isEqualTo("Bruker med utenlandsk adresse kan kun kombineres med verge eller fullmektig.")
+            assertThat(exception.message).isEqualTo("Bruker med utenlandsk adresse kan kun kombineres med verge eller fullmektig for ${behandling.id}.")
         }
 
         @Test
@@ -408,7 +408,7 @@ class BrevmottakerOppretterTest {
                 brevmottakerOppretter.opprettBrevmottaker(behandling.id, nyBrevmottakerPersonUtenIdent)
             }
             assertThat(exception.message).isEqualTo(
-                "Kan kun legge til bruker med utenlandsk adresse om det finnes en brevmottaker allerede.",
+                "Kan kun legge til bruker med utenlandsk adresse om det finnes en brevmottaker allerede for ${behandling.id}.",
             )
         }
 

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
@@ -141,7 +141,7 @@ class BrevmottakerServiceTest {
     @Nested
     inner class SlettBrevmottakerTest {
         @Test
-        fun `skal opprette brevmottaker`() {
+        fun `skal slette brevmottaker`() {
             // Arrange
             val behandlingId = UUID.randomUUID()
             val slettbarBrevmottaker = SlettbarBrevmottakerPersonUtenIdent(UUID.randomUUID())


### PR DESCRIPTION
Favro: [NAV-24896](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24896)

Legger til litt mer validerings, samt forbedrer feilmeldingene som allerede eksiterer. 

Koden her er egentlig togglet bort / ikke i bruk, men tenkte det var greit å bare ta det når jeg først så det. 