### PR TITLE
Legg til endepunkt som lagrer vurdering uten validering og oppdatering av steg

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -16,6 +16,7 @@ class FeatureToggleController(
     private val featureTogglesIBruk: Set<Toggle> = setOf(
         Toggle.VIS_BREVMOTTAKER_BAKS,
         Toggle.LEGG_TIL_BREVMOTTAKER_BAKS,
+        Toggle.KAN_MELLOMLAGRE_VURDERING,
     )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -27,6 +27,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
         "Release",
     ),
     BRUK_NYTT_BREV_BA_KS("familie-klage.bruk-nytt-brev-ba-ks", "Release"),
+    KAN_MELLOMLAGRE_VURDERING("familie-klage.kan-mellomlagre-vurdering", "Release"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
@@ -24,16 +24,29 @@ class VurderingController(
 ) {
 
     @GetMapping("{behandlingId}")
-    fun hentVurdering(@PathVariable behandlingId: UUID): Ressurs<VurderingDto?> {
+    fun hentVurdering(
+        @PathVariable behandlingId: UUID,
+    ): Ressurs<VurderingDto?> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(vurderingService.hentVurderingDto(behandlingId))
     }
 
     @PostMapping
-    fun opprettEllerOppdaterVurdering(@RequestBody vurdering: VurderingDto): Ressurs<VurderingDto> {
+    fun lagreVurderingOgOppdaterSteg(
+        @RequestBody vurdering: VurderingDto,
+    ): Ressurs<VurderingDto> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(vurdering.behandlingId)
-        return Ressurs.success(vurderingService.opprettEllerOppdaterVurdering(vurdering))
+        return Ressurs.success(vurderingService.lagreVurderingOgOppdaterSteg(vurdering))
+    }
+
+    @PostMapping(path = ["/lagre"])
+    fun lagreVurdering(
+        @RequestBody vurdering: VurderingDto,
+    ): Ressurs<VurderingDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(vurdering.behandlingId)
+        return Ressurs.success(vurderingService.lagreVurdering(vurdering))
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
@@ -32,11 +32,24 @@ class VurderingController(
         return Ressurs.success(vurderingService.hentVurderingDto(behandlingId))
     }
 
+    @Deprecated(message = "Bruk /lagre-og-oppdater-steg i stedet")
+    @PostMapping
+    fun lagreVurderingOgOppdaterStegDeprekert(
+        @RequestBody vurdering: VurderingDto,
+    ): Ressurs<VurderingDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(vurdering.behandlingId)
+        return Ressurs.success(vurderingService.lagreVurderingOgOppdaterSteg(vurdering))
+    }
+
     @PostMapping(path = ["/lagre-og-oppdater-steg"])
     fun lagreVurderingOgOppdaterSteg(
         @RequestBody vurdering: VurderingDto,
     ): Ressurs<VurderingDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+            vurdering.behandlingId,
+            AuditLoggerEvent.UPDATE,
+        )
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(vurdering.behandlingId)
         return Ressurs.success(vurderingService.lagreVurderingOgOppdaterSteg(vurdering))
     }

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
@@ -32,7 +32,7 @@ class VurderingController(
         return Ressurs.success(vurderingService.hentVurderingDto(behandlingId))
     }
 
-    @PostMapping
+    @PostMapping(path = ["/lagre-og-oppdater-steg"])
     fun lagreVurderingOgOppdaterSteg(
         @RequestBody vurdering: VurderingDto,
     ): Ressurs<VurderingDto> {

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingService.kt
@@ -29,7 +29,7 @@ class VurderingService(
         hentVurdering(behandlingId)?.tilDto()
 
     @Transactional
-    fun opprettEllerOppdaterVurdering(vurdering: VurderingDto): VurderingDto {
+    fun lagreVurderingOgOppdaterSteg(vurdering: VurderingDto): VurderingDto {
         val fagsystem = fagsakService.hentFagsakForBehandling(vurdering.behandlingId).fagsystem
         validerVurdering(vurdering, fagsystem)
         if (vurdering.vedtak === Vedtak.OMGJØR_VEDTAK) {
@@ -38,6 +38,16 @@ class VurderingService(
 
         stegService.oppdaterSteg(vurdering.behandlingId, StegType.VURDERING, StegType.BREV)
 
+        val eksisterendeVurdering = vurderingRepository.findByIdOrNull(vurdering.behandlingId)
+        return if (eksisterendeVurdering != null) {
+            oppdaterVurdering(vurdering, eksisterendeVurdering).tilDto()
+        } else {
+            opprettNyVurdering(vurdering).tilDto()
+        }
+    }
+
+    @Transactional
+    fun lagreVurdering(vurdering: VurderingDto): VurderingDto {
         val eksisterendeVurdering = vurderingRepository.findByIdOrNull(vurdering.behandlingId)
         return if (eksisterendeVurdering != null) {
             oppdaterVurdering(vurdering, eksisterendeVurdering).tilDto()

--- a/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/BehandlingFlytTest.kt
@@ -64,9 +64,9 @@ class BehandlingFlytTest : OppslagSpringRunnerTest() {
             val behandlingId = testWithBrukerContext(groups = listOf(rolleConfig.ef.saksbehandler)) {
                 val behandlingId = opprettBehandlingService.opprettBehandling(opprettKlagebehandlingRequest)
                 formService.oppdaterFormkrav(oppfyltFormDto(behandlingId, påklagetVedtakDto))
-                vurderingService.opprettEllerOppdaterVurdering(vurderingDto(behandlingId, Vedtak.OPPRETTHOLD_VEDTAK))
+                vurderingService.lagreVurderingOgOppdaterSteg(vurderingDto(behandlingId, Vedtak.OPPRETTHOLD_VEDTAK))
                 formService.oppdaterFormkrav(oppfyltFormDto(behandlingId, påklagetVedtakDto))
-                vurderingService.opprettEllerOppdaterVurdering(vurderingDto(behandlingId, Vedtak.OPPRETTHOLD_VEDTAK))
+                vurderingService.lagreVurderingOgOppdaterSteg(vurderingDto(behandlingId, Vedtak.OPPRETTHOLD_VEDTAK))
                 lagEllerOppdaterBrev(behandlingId)
                 ferdigstillBehandlingService.ferdigstillKlagebehandling(behandlingId)
                 behandlingId
@@ -91,12 +91,12 @@ class BehandlingFlytTest : OppslagSpringRunnerTest() {
             val behandlingId = testWithBrukerContext(groups = listOf(rolleConfig.ef.saksbehandler)) {
                 val behandlingId = opprettBehandlingService.opprettBehandling(opprettKlagebehandlingRequest)
                 formService.oppdaterFormkrav(oppfyltFormDto(behandlingId, påklagetVedtakDto))
-                vurderingService.opprettEllerOppdaterVurdering(vurderingDto(behandlingId, Vedtak.OPPRETTHOLD_VEDTAK))
+                vurderingService.lagreVurderingOgOppdaterSteg(vurderingDto(behandlingId, Vedtak.OPPRETTHOLD_VEDTAK))
 
                 lagEllerOppdaterBrev(behandlingId)
 
                 formService.oppdaterFormkrav(oppfyltFormDto(behandlingId, påklagetVedtakDto))
-                vurderingService.opprettEllerOppdaterVurdering(vurderingDto(behandlingId))
+                vurderingService.lagreVurderingOgOppdaterSteg(vurderingDto(behandlingId))
 
                 lagEllerOppdaterBrev(behandlingId)
                 ferdigstillBehandlingService.ferdigstillKlagebehandling(behandlingId)
@@ -126,7 +126,7 @@ class BehandlingFlytTest : OppslagSpringRunnerTest() {
             val behandlingId = testWithBrukerContext(groups = listOf(rolleConfig.ef.saksbehandler)) {
                 val behandlingId = opprettBehandlingService.opprettBehandling(opprettKlagebehandlingRequest)
                 formService.oppdaterFormkrav(oppfyltFormDto(behandlingId))
-                vurderingService.opprettEllerOppdaterVurdering(
+                vurderingService.lagreVurderingOgOppdaterSteg(
                     vurderingDto(
                         behandlingId = behandlingId,
                         vedtak = Vedtak.OMGJØR_VEDTAK,

--- a/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingControllerTest.kt
@@ -69,7 +69,7 @@ internal class FerdigstillBehandlingControllerTest : OppslagSpringRunnerTest() {
 
         formService.opprettInitielleFormkrav(behandling.id)
         formService.oppdaterFormkrav(oppfyltForm(behandling.id).tilDto(PåklagetVedtakDto("123", null, VEDTAK)))
-        vurderingService.opprettEllerOppdaterVurdering(vurdering)
+        vurderingService.lagreVurderingOgOppdaterSteg(vurdering)
 
         brevService.lagBrev(behandling.id)
         behandleSakOppgaveRepository.insert(

--- a/src/test/kotlin/no/nav/familie/klage/vurdering/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/vurdering/VurderingServiceTest.kt
@@ -52,25 +52,25 @@ class VurderingServiceTest {
 
     @Test
     internal fun `skal slette brev ved omgjøring`() {
-        vurderingService.opprettEllerOppdaterVurdering(omgjørVedtakVurdering.tilDto())
+        vurderingService.lagreVurderingOgOppdaterSteg(omgjørVedtakVurdering.tilDto())
         verify(exactly = 1) { brevRepository.deleteById(any()) }
     }
 
     @Test
     internal fun `skal ikke slette brev ved opprettholdelse`() {
-        vurderingService.opprettEllerOppdaterVurdering(opprettholdVedtakVurdering.tilDto())
+        vurderingService.lagreVurderingOgOppdaterSteg(opprettholdVedtakVurdering.tilDto())
         verify(exactly = 0) { brevRepository.deleteById(any()) }
     }
 
     @Test
     fun `skal oppdatere steg ved omgjøring`() {
-        vurderingService.opprettEllerOppdaterVurdering(omgjørVedtakVurdering.tilDto())
+        vurderingService.lagreVurderingOgOppdaterSteg(omgjørVedtakVurdering.tilDto())
         verify(exactly = 1) { stegService.oppdaterSteg(any(), any(), StegType.BREV) }
     }
 
     @Test
     fun `skal oppdatere steg ved opprettholdelse av klage`() {
-        vurderingService.opprettEllerOppdaterVurdering(opprettholdVedtakVurdering.tilDto())
+        vurderingService.lagreVurderingOgOppdaterSteg(opprettholdVedtakVurdering.tilDto())
         verify(exactly = 1) { stegService.oppdaterSteg(any(), any(), StegType.BREV) }
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24788)

For behandlinger for BA og KS ønsker vi å kunne lagre vurdering uten å validere at inneholdet er utfylt og å bytte steg.
Legger til nytt endepunkt, og endrer navn på det gamle, for å bedre beskrive sideeffekten