### PR TITLE
Bruk null i stedet for AvsenderMottakerIdType.NULL i AvsenderMottaker uten ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalføringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalføringUtil.kt
@@ -52,7 +52,7 @@ object JournalføringUtil {
             is BrevmottakerPersonUtenIdent -> AvsenderMottaker(
                 id = null,
                 navn = brevmottaker.navn,
-                idType = AvsenderMottakerIdType.NULL,
+                idType = null,
             )
         }
 

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTaskTest.kt
@@ -100,7 +100,7 @@ internal class JournalførBrevTaskTest {
         val avsenderMottaker1 = AvsenderMottaker("1", AvsenderMottakerIdType.FNR, "1navn")
         val avsenderMottaker2 = AvsenderMottaker("2", AvsenderMottakerIdType.FNR, "2navn")
         val avsenderMottakerOrganisasjon = AvsenderMottaker("org1", AvsenderMottakerIdType.ORGNR, "mottaker")
-        val avsenderMottakerUtenIdent = AvsenderMottaker(null, AvsenderMottakerIdType.NULL, "3navn")
+        val avsenderMottakerUtenIdent = AvsenderMottaker(null, null, "3navn")
 
         val brevmottakerUtenIdent =
             BrevmottakerPersonUtenIdent(


### PR DESCRIPTION
Dokarkiv er ikke så fan av enumen AvsenderMottakerIdType.NULL, så endrer idType til null i stedet for