### PR TITLE
Fikser bedre feilmelding når det ikke er mulig å hente oppgave grunnet tilgangsfeil

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/oppgave/TilordnetRessursService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/TilordnetRessursService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.klage.oppgave
 
 import no.nav.familie.klage.behandling.dto.OppgaveDto
 import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.ManglerTilgang
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
@@ -12,6 +13,7 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import java.util.*
 
 @Service
@@ -23,7 +25,18 @@ class TilordnetRessursService(
 
     fun hentAnsvarligSaksbehandlerForBehandlingsId(behandlingId: UUID): SaksbehandlerDto {
         val behandleSakOppgave = behandleSakOppgaveRepository.findByBehandlingId(behandlingId)
-        val oppgave = behandleSakOppgave?.let { oppgaveClient.finnOppgaveMedId(it.oppgaveId) }
+        val oppgave = try {
+            behandleSakOppgave?.let { oppgaveClient.finnOppgaveMedId(it.oppgaveId) }
+        } catch (exception: HttpClientErrorException) {
+            if (exception.statusCode == HttpStatus.FORBIDDEN) {
+                throw ManglerTilgang(
+                    melding = "Bruker mangler tilgang til etterspurt oppgave",
+                    frontendFeilmelding = "Behandlingen er koblet til en oppgave du ikke har tilgang til. Visning av ansvarlig saksbehandler er derfor ikke mulig",
+                )
+            } else {
+                throw exception
+            }
+        }
 
         val rolle = utledSaksbehandlerRolle(oppgave)
         val saksbehandler = oppgave?.tilordnetRessurs?.let { oppgaveClient.hentSaksbehandlerInfo(it) }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24865

Når man henter ansvarlig saksbehandler for behandlingen så hentes først oppgaven.
Vi har oppdaget tilfeller der dette ikke er mulig fordi bruker ikke har tilgang til oppgaven som behandlingen er koblet til.
Dette fører til en uspesifisert feilmelding i frontend.

Catcher derfor forbidden error ved henting av oppgave når man henter ansvarlig saksbehandler og sender en bedre feilmelding tilbake til frontend. Også lagd tester + noe manglende tester for eksisterende kode.