### PR TITLE
Løype for distribuering av brev for brevmottakere uten ident

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/DistribuerBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/DistribuerBrevTask.kt
@@ -3,8 +3,20 @@ package no.nav.familie.klage.distribusjon
 import no.nav.familie.klage.brev.BrevService
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpost
+import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpostMedIdent
+import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpostUtenIdent
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle.SKAL_BRUKE_NY_LØYPE_FOR_JOURNALFØRING
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.dokdist.AdresseType.norskPostadresse
+import no.nav.familie.kontrakter.felles.dokdist.AdresseType.utenlandskPostadresse
+import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -19,6 +31,8 @@ import java.util.UUID
 class DistribuerBrevTask(
     private val brevService: BrevService,
     private val distribusjonService: DistribusjonService,
+    private val fagsakService: FagsakService,
+    private val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
@@ -28,8 +42,15 @@ class DistribuerBrevTask(
         validerHarJournalposter(behandlingId, journalposter)
 
         val distribueringer =
-            journalposter.fold(journalposter) { acc, journalpost ->
-                distribuerOgLagreJournalposter(behandlingId, acc, journalpost)
+            if (featureToggleService.isEnabled(SKAL_BRUKE_NY_LØYPE_FOR_JOURNALFØRING)) {
+                val fagsystem = fagsakService.hentFagsakForBehandling(behandlingId).fagsystem.tilFellesFagsystem()
+                journalposter.fold(journalposter) { acc, journalpost ->
+                    distribuerOgLagreJournalposter(behandlingId, acc, journalpost, brev.mottakere, fagsystem)
+                }
+            } else {
+                journalposter.fold(journalposter) { acc, journalpost ->
+                    distribuerOgLagreJournalposter(behandlingId, acc, journalpost)
+                }
             }
 
         feilHvis(distribueringer.any { it.distribusjonId == null }) {
@@ -58,6 +79,33 @@ class DistribuerBrevTask(
             acc
         }
 
+    private fun distribuerOgLagreJournalposter(
+        behandlingId: UUID,
+        acc: List<BrevmottakerJournalpost>,
+        journalpost: BrevmottakerJournalpost,
+        brevmottakere: Brevmottakere?,
+        fagsystem: Fagsystem,
+    ): List<BrevmottakerJournalpost> =
+        if (journalpost.distribusjonId == null) {
+            val adresse = finnAdresseForJournalpost(journalpost, brevmottakere)
+            val distribusjonId = distribusjonService.distribuerBrev(
+                journalpostId = journalpost.journalpostId,
+                adresse = adresse,
+                fagsystem = fagsystem,
+            )
+            val nyeJournalposter = acc.map {
+                if (it.journalpostId == journalpost.journalpostId) {
+                    it.medDistribusjonsId(distribusjonId = distribusjonId)
+                } else {
+                    it
+                }
+            }
+            brevService.oppdaterMottakerJournalpost(behandlingId, BrevmottakereJournalposter(nyeJournalposter))
+            nyeJournalposter
+        } else {
+            acc
+        }
+
     private fun validerHarJournalposter(
         behandlingId: UUID,
         journalposter: List<BrevmottakerJournalpost>,
@@ -70,6 +118,31 @@ class DistribuerBrevTask(
     private fun mottakereJournalpost(brev: Brev): List<BrevmottakerJournalpost> =
         brev.mottakereJournalposter?.journalposter?.takeIf { it.isNotEmpty() }
             ?: error("Mangler journalposter koblet til brev=${brev.behandlingId}")
+
+    private fun finnAdresseForJournalpost(
+        journalpost: BrevmottakerJournalpost,
+        brevmottakere: Brevmottakere?,
+    ): ManuellAdresse? {
+        return when (journalpost) {
+            is BrevmottakerJournalpostMedIdent -> null
+            is BrevmottakerJournalpostUtenIdent -> {
+                val brevmottaker = brevmottakere?.personer
+                    ?.filterIsInstance<BrevmottakerPersonUtenIdent>()?.find { it.id == journalpost.id }
+                    ?: throw Feil("Mangler brevmottaker for journalpost=${journalpost.journalpostId}")
+
+                with(brevmottaker) {
+                    ManuellAdresse(
+                        adresseType = if (landkode == "NO") norskPostadresse else utenlandskPostadresse,
+                        adresselinje1 = adresselinje1,
+                        adresselinje2 = adresselinje2,
+                        postnummer = postnummer,
+                        poststed = poststed,
+                        land = landkode,
+                    )
+                }
+            }
+        }
+    }
 
     companion object {
         const val TYPE = "distribuerBrevTask"

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/DistribusjonService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/DistribusjonService.kt
@@ -8,12 +8,14 @@ import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.felles.util.StønadstypeVisningsnavn.visningsnavn
 import no.nav.familie.klage.felles.util.TekstUtil.storForbokstav
 import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
 import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstype
+import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -101,6 +103,14 @@ class DistribusjonService(
     }
 
     fun distribuerBrev(journalpostId: String): String = familieIntegrasjonerClient.distribuerBrev(journalpostId, Distribusjonstype.ANNET)
+
+    fun distribuerBrev(journalpostId: String, adresse: ManuellAdresse?, fagsystem: Fagsystem): String =
+        familieIntegrasjonerClient.distribuerBrev(
+            journalpostId = journalpostId,
+            distribusjonstype = Distribusjonstype.ANNET,
+            adresse = adresse,
+            fagsystem = fagsystem,
+        )
 
     private fun lagDokument(
         pdf: ByteArray,

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieIntegrasjonerClient.kt
@@ -5,11 +5,13 @@ import no.nav.familie.http.client.RessursException
 import no.nav.familie.klage.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.klage.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
 import no.nav.familie.kontrakter.felles.dokdist.DistribuerJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstype
+import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
 import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariantformat
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
@@ -78,6 +80,28 @@ class FamilieIntegrasjonerClient(
                 dokumentProdApp = "FAMILIE_KLAGE",
                 distribusjonstype = distribusjonstype,
             )
+
+        return postForEntity<Ressurs<String>>(
+            integrasjonerConfig.distribuerDokumentUri,
+            journalpostRequest,
+            HttpHeaders().medContentTypeJsonUTF8(),
+        ).getDataOrThrow()
+    }
+
+    // sende brev til bruker
+    fun distribuerBrev(
+        journalpostId: String,
+        distribusjonstype: Distribusjonstype,
+        adresse: ManuellAdresse?,
+        fagsystem: Fagsystem,
+    ): String {
+        val journalpostRequest = DistribuerJournalpostRequest(
+            journalpostId = journalpostId,
+            bestillendeFagsystem = fagsystem,
+            dokumentProdApp = "FAMILIE_KLAGE",
+            distribusjonstype = distribusjonstype,
+            adresse = adresse,
+        )
 
         return postForEntity<Ressurs<String>>(
             integrasjonerConfig.distribuerDokumentUri,

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/DistribuerBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/DistribuerBrevTaskTest.kt
@@ -8,77 +8,150 @@ import io.mockk.verifyOrder
 import no.nav.familie.klage.brev.BrevService
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
 import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpost
 import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpostMedIdent
+import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpostUtenIdent
+import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.domain.Fil
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.testutil.DomainUtil.fagsak
+import no.nav.familie.kontrakter.felles.Fagsystem
+import no.nav.familie.kontrakter.felles.dokdist.AdresseType
+import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import java.util.UUID.randomUUID
 
 internal class DistribuerBrevTaskTest {
     private val brevService = mockk<BrevService>()
     private val distribusjonService = mockk<DistribusjonService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
-    val distribuerBrevTask = DistribuerBrevTask(brevService, distribusjonService)
+    private val distribuerBrevTask =
+        DistribuerBrevTask(brevService, distribusjonService, fagsakService, featureToggleService)
 
-    val behandlingId = UUID.randomUUID()
-    val slotJournalposter = mutableListOf<BrevmottakereJournalposter>()
+    private val behandlingId = randomUUID()
+    private val slotJournalposter = mutableListOf<BrevmottakereJournalposter>()
+
+    private val identForPersonMedIdent = "ident"
+    private val idForPersonUtenIdent = randomUUID()
 
     @BeforeEach
     internal fun setUp() {
-        every { distribusjonService.distribuerBrev(any()) } answers { "distId-${firstArg<String>()}" }
+        every { distribusjonService.distribuerBrev(any(), any(), any()) } answers { "distId-${firstArg<String>()}" }
         justRun { brevService.oppdaterMottakerJournalpost(behandlingId, capture(slotJournalposter)) }
+        every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak()
+        every { featureToggleService.isEnabled(any()) } returns true
     }
 
     @Nested
     inner class ManglerJournalposter {
         @Test
-        internal fun `feiler hvis det ikke finnes noen journalpost`() {
-            mockHentBrev(null)
-            assertThatThrownBy {
-                doTask()
-            }.hasMessageContaining("Mangler journalposter")
+        internal fun `feiler hvis journalposter er null`() {
+            // Arrange
+            mockHentBrev(journalposter = null)
 
+            // Act & Assert
+            assertThatThrownBy { doTask() }.hasMessageContaining("Mangler journalposter")
+
+            // Assert
             verifyAntallKall(0)
         }
 
         @Test
-        internal fun `feiler hvis journalpost er empty`() {
-            mockHentBrev(emptyList())
-            assertThatThrownBy {
-                doTask()
-            }.hasMessageContaining("Mangler journalposter")
+        internal fun `feiler hvis journalposter er tom`() {
+            // Arrange
+            mockHentBrev(journalposter = emptyList())
 
+            // Act & Assert
+            assertThatThrownBy { doTask() }.hasMessageContaining("Mangler journalposter")
+
+            // Assert
             verifyAntallKall(0)
+        }
+    }
+
+    @Nested
+    inner class ManglerBrevmottakere {
+
+        @Test
+        internal fun `feiler hvis brevmottakere er null når det finnes journalposter for mottaker uten ident`() {
+            // Arrange
+            val journalposter = listOf(journalpostUtenIdent("1"))
+            mockHentBrev(journalposter = journalposter, brevmottakere = null)
+
+            // Act & Assert
+            assertThatThrownBy { doTask() }.hasMessageContaining("Mangler brevmottaker for journalpost=1")
+
+            // Assert
+            verifyAntallKall(0)
+        }
+
+        @Test
+        internal fun `feiler hvis brevmottakere er tom når det finnes journalposter for mottaker uten ident`() {
+            // Arrange
+            val journalposter = listOf(journalpostUtenIdent("1"))
+            mockHentBrev(journalposter = journalposter, brevmottakere = Brevmottakere())
+
+            // Act & Assert
+            assertThatThrownBy { doTask() }.hasMessageContaining("Mangler brevmottaker for journalpost=1")
+
+            // Assert
+            verifyAntallKall(0)
+        }
+
+        @Test
+        internal fun `feiler ikke hvis brevmottakere er tom når det kun finnes journalposter for mottaker med ident`() {
+            // Arrange
+            val journalposter = listOf(journalpostMedIdent("1"))
+            mockHentBrev(journalposter = journalposter, brevmottakere = Brevmottakere())
+
+            // Act & Assert
+            doTask()
+
+            // Assert
+            verifyAntallKall(1)
         }
     }
 
     @Test
     internal fun `skal distribuere og mellomlagre for hver journalpost`() {
-        mockHentBrev(listOf(journalpost("1"), journalpost("2")))
+        // Arrange
+        val journalposter = listOf(journalpostMedIdent("1"), journalpostUtenIdent("2"))
+        val brevmottakere = Brevmottakere(personer = listOf(personMedIdent, personUtenIdent))
+        mockHentBrev(journalposter = journalposter, brevmottakere = brevmottakere)
+
+        // Act
         doTask()
+
+        // Assert
         verifyAntallKall(2)
         verifyOrder {
-            distribusjonService.distribuerBrev("1")
+            distribusjonService.distribuerBrev("1", null, Fagsystem.EF)
             brevService.oppdaterMottakerJournalpost(
                 behandlingId,
                 BrevmottakereJournalposter(
                     listOf(
-                        journalpost("1", "distId-1"),
-                        journalpost("2"),
+                        journalpostMedIdent("1", "distId-1"),
+                        journalpostUtenIdent("2"),
                     ),
                 ),
             )
-            distribusjonService.distribuerBrev("2")
+            distribusjonService.distribuerBrev("2", manuellAdresse, Fagsystem.EF)
             brevService.oppdaterMottakerJournalpost(
                 behandlingId,
                 BrevmottakereJournalposter(
                     listOf(
-                        journalpost("1", "distId-1"),
-                        journalpost("2", "distId-2"),
+                        journalpostMedIdent("1", "distId-1"),
+                        journalpostUtenIdent("2", "distId-2"),
                     ),
                 ),
             )
@@ -87,18 +160,24 @@ internal class DistribuerBrevTaskTest {
 
     @Test
     internal fun `skal fortsette distribuere de journalposter som mangler distribusjonsId`() {
-        mockHentBrev(listOf(journalpost("1", "distId-1"), journalpost("2")))
-        doTask()
-        verifyAntallKall(1)
+        // Arrange
+        val journalposter = listOf(journalpostMedIdent("1", "distId-1"), journalpostUtenIdent("2"))
+        val brevmottakere = Brevmottakere(personer = listOf(personMedIdent, personUtenIdent))
+        mockHentBrev(journalposter = journalposter, brevmottakere = brevmottakere)
 
+        // Act
+        doTask()
+
+        // Assert
+        verifyAntallKall(1)
         verifyOrder {
-            distribusjonService.distribuerBrev("2")
+            distribusjonService.distribuerBrev("2", manuellAdresse, Fagsystem.EF)
             brevService.oppdaterMottakerJournalpost(
                 behandlingId,
                 BrevmottakereJournalposter(
                     listOf(
-                        journalpost("1", "distId-1"),
-                        journalpost("2", "distId-2"),
+                        journalpostMedIdent("1", "distId-1"),
+                        journalpostUtenIdent("2", "distId-2"),
                     ),
                 ),
             )
@@ -106,25 +185,56 @@ internal class DistribuerBrevTaskTest {
     }
 
     private fun verifyAntallKall(antall: Int) {
-        verify(exactly = antall) { distribusjonService.distribuerBrev(any()) }
+        verify(exactly = antall) { distribusjonService.distribuerBrev(any(), any(), any()) }
         verify(exactly = antall) { brevService.oppdaterMottakerJournalpost(any(), any()) }
     }
 
-    private fun journalpost(
+    private fun journalpostMedIdent(
         journalpostId: String,
         distribusjonId: String? = null,
-    ) = BrevmottakerJournalpostMedIdent("ident", journalpostId, distribusjonId = distribusjonId)
+    ) = BrevmottakerJournalpostMedIdent(identForPersonMedIdent, journalpostId, distribusjonId = distribusjonId)
+
+    private fun journalpostUtenIdent(journalpostId: String, distribusjonId: String? = null) =
+        BrevmottakerJournalpostUtenIdent(idForPersonUtenIdent, journalpostId, distribusjonId = distribusjonId)
+
+    private val personMedIdent =
+        BrevmottakerPersonMedIdent(identForPersonMedIdent, MottakerRolle.BRUKER, "Navn Navnesen")
+
+    private val personUtenIdent =
+        BrevmottakerPersonUtenIdent(
+            id = idForPersonUtenIdent,
+            mottakerRolle = MottakerRolle.BRUKER,
+            navn = "Navn Navnesen",
+            adresselinje1 = "Adresseveien 1",
+            adresselinje2 = null,
+            postnummer = "0123",
+            poststed = "Oslo",
+            landkode = "NO",
+        )
+
+    private val manuellAdresse =
+        ManuellAdresse(
+            adresseType = AdresseType.norskPostadresse,
+            adresselinje1 = "Adresseveien 1",
+            postnummer = "0123",
+            poststed = "Oslo",
+            land = "NO",
+        )
 
     private fun doTask() {
         distribuerBrevTask.doTask(Task(DistribuerBrevTask.TYPE, behandlingId.toString()))
     }
 
-    private fun mockHentBrev(journalposter: List<BrevmottakerJournalpost>? = null) {
+    private fun mockHentBrev(
+        journalposter: List<BrevmottakerJournalpost>? = null,
+        brevmottakere: Brevmottakere? = null,
+    ) {
         every { brevService.hentBrev(behandlingId) } returns
             Brev(
                 behandlingId = behandlingId,
                 saksbehandlerHtml = "",
                 mottakereJournalposter = journalposter?.let { BrevmottakereJournalposter(it) },
+                mottakere = brevmottakere,
                 pdf = Fil(byteArrayOf()),
             )
     }

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/DistribuerBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/DistribuerBrevTaskTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.UUID.randomUUID
 
-internal class DistribuerBrevTaskTest {
+class DistribuerBrevTaskTest {
     private val brevService = mockk<BrevService>()
     private val distribusjonService = mockk<DistribusjonService>()
     private val fagsakService = mockk<FagsakService>()
@@ -45,7 +45,7 @@ internal class DistribuerBrevTaskTest {
     private val idForPersonUtenIdent = randomUUID()
 
     @BeforeEach
-    internal fun setUp() {
+    fun setUp() {
         every { distribusjonService.distribuerBrev(any(), any(), any()) } answers { "distId-${firstArg<String>()}" }
         justRun { brevService.oppdaterMottakerJournalpost(behandlingId, capture(slotJournalposter)) }
         every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak()
@@ -55,7 +55,7 @@ internal class DistribuerBrevTaskTest {
     @Nested
     inner class ManglerJournalposter {
         @Test
-        internal fun `feiler hvis journalposter er null`() {
+        fun `feiler hvis journalposter er null`() {
             // Arrange
             mockHentBrev(journalposter = null)
 
@@ -67,7 +67,7 @@ internal class DistribuerBrevTaskTest {
         }
 
         @Test
-        internal fun `feiler hvis journalposter er tom`() {
+        fun `feiler hvis journalposter er tom`() {
             // Arrange
             mockHentBrev(journalposter = emptyList())
 
@@ -83,7 +83,7 @@ internal class DistribuerBrevTaskTest {
     inner class ManglerBrevmottakere {
 
         @Test
-        internal fun `feiler hvis brevmottakere er null når det finnes journalposter for mottaker uten ident`() {
+        fun `feiler hvis brevmottakere er null når det finnes journalposter for mottaker uten ident`() {
             // Arrange
             val journalposter = listOf(journalpostUtenIdent("1"))
             mockHentBrev(journalposter = journalposter, brevmottakere = null)
@@ -96,7 +96,7 @@ internal class DistribuerBrevTaskTest {
         }
 
         @Test
-        internal fun `feiler hvis brevmottakere er tom når det finnes journalposter for mottaker uten ident`() {
+        fun `feiler hvis brevmottakere er tom når det finnes journalposter for mottaker uten ident`() {
             // Arrange
             val journalposter = listOf(journalpostUtenIdent("1"))
             mockHentBrev(journalposter = journalposter, brevmottakere = Brevmottakere())
@@ -109,7 +109,7 @@ internal class DistribuerBrevTaskTest {
         }
 
         @Test
-        internal fun `feiler ikke hvis brevmottakere er tom når det kun finnes journalposter for mottaker med ident`() {
+        fun `feiler ikke hvis brevmottakere er tom når det kun finnes journalposter for mottaker med ident`() {
             // Arrange
             val journalposter = listOf(journalpostMedIdent("1"))
             mockHentBrev(journalposter = journalposter, brevmottakere = Brevmottakere())
@@ -123,7 +123,7 @@ internal class DistribuerBrevTaskTest {
     }
 
     @Test
-    internal fun `skal distribuere og mellomlagre for hver journalpost`() {
+    fun `skal distribuere og mellomlagre for hver journalpost`() {
         // Arrange
         val journalposter = listOf(journalpostMedIdent("1"), journalpostUtenIdent("2"))
         val brevmottakere = Brevmottakere(personer = listOf(personMedIdent, personUtenIdent))
@@ -159,7 +159,7 @@ internal class DistribuerBrevTaskTest {
     }
 
     @Test
-    internal fun `skal fortsette distribuere de journalposter som mangler distribusjonsId`() {
+    fun `skal fortsette distribuere de journalposter som mangler distribusjonsId`() {
         // Arrange
         val journalposter = listOf(journalpostMedIdent("1", "distId-1"), journalpostUtenIdent("2"))
         val brevmottakere = Brevmottakere(personer = listOf(personMedIdent, personUtenIdent))

--- a/src/test/kotlin/no/nav/familie/klage/distribusjon/DistribusjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/distribusjon/DistribusjonServiceTest.kt
@@ -11,10 +11,13 @@ import no.nav.familie.klage.testutil.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.klage.testutil.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.klage.testutil.DomainUtil.behandling
 import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
+import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
+import no.nav.familie.kontrakter.felles.dokdist.AdresseType
 import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstype
+import no.nav.familie.kontrakter.felles.dokdist.ManuellAdresse
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -85,18 +88,30 @@ internal class DistribusjonServiceTest {
     fun distribuerBrev() {
         val journalpostSlot = slot<String>()
         val distribusjonstypeSlot = slot<Distribusjonstype>()
+        val adresseSlot = slot<ManuellAdresse>()
+        val fagsystemSlot = slot<Fagsystem>()
         val journalpostId = "journalpostId"
+        val manuellAdresse = ManuellAdresse(
+            adresseType = AdresseType.norskPostadresse,
+            adresselinje1 = "Adresseveien 1",
+            postnummer = "0123",
+            poststed = "Oslo",
+        )
 
         every {
             familieIntegrasjonerClient.distribuerBrev(
                 capture(journalpostSlot),
                 capture(distribusjonstypeSlot),
+                capture(adresseSlot),
+                capture(fagsystemSlot),
             )
         } returns "distribusjonsnummer"
 
-        distribusjonService.distribuerBrev(journalpostId)
+        distribusjonService.distribuerBrev(journalpostId, manuellAdresse, Fagsystem.EF)
 
         assertThat(journalpostSlot.captured).isEqualTo(journalpostId)
         assertThat(distribusjonstypeSlot.captured).isEqualTo(Distribusjonstype.ANNET)
+        assertThat(adresseSlot.captured).isEqualTo(manuellAdresse)
+        assertThat(fagsystemSlot.captured).isEqualTo(Fagsystem.EF)
     }
 }


### PR DESCRIPTION
Legger til løype for å distribuere brev, som sender med adresse for brevmottakere uten ident. For brevmottakere med ident (fnr eller orgnr), sendes `adresse = null`, slik det gjøres allerede