### PR TITLE
NAV-25020: Korrigerer URL for oppretting av revurdering klage for BA

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -48,9 +48,9 @@ class FamilieBASakClient(
     ): OpprettRevurderingResponse {
         val url =
             if (featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE)) {
-                "api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+                "api/klage/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
             } else {
-                "api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
+                "api/klage/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
             }
         val hentVedtakUri =
             UriComponentsBuilder

--- a/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClientTest.kt
@@ -22,6 +22,7 @@ import java.util.UUID
 class FamilieBASakClientTest {
     private val restOperations = mockk<RestOperations>()
     private val featureToggleService = mockk<FeatureToggleService>()
+    private val baseUrl = "http://localhost:8080/api/klage"
 
     private val familieBASakClient =
         FamilieBASakClient(
@@ -43,10 +44,7 @@ class FamilieBASakClientTest {
                     opprettet = Opprettet(klagebehandlingId.toString()),
                 )
 
-            val uri =
-                URI.create(
-                    "http://localhost:8080/api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage",
-                )
+            val uri = URI.create("$baseUrl/fagsaker/$eksternFagsakId/opprett-revurdering-klage")
 
             every {
                 restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
@@ -92,10 +90,7 @@ class FamilieBASakClientTest {
                     opprettet = Opprettet(klagebehandlingId.toString()),
                 )
 
-            val uri =
-                URI.create(
-                    "http://localhost:8080/api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage",
-                )
+            val uri = URI.create("$baseUrl/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage")
 
             every {
                 restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(


### PR DESCRIPTION
Favro: [NAV-25020](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25020)

Ble litt mye klipp og lim da jeg implementerte toggelen. Korrigerer slik at man går til korrekt (gammel) url når man ikke har toggelen skrudd på. 

Riktig URL prefix i ba:
<img width="431" alt="image" src="https://github.com/user-attachments/assets/30d6c7b4-3990-48f9-a8e8-4d623059aaac" />
