### PR TITLE
NAV-24658: Endrer oversendt id til eksternBehandlingId ved opprettingav revurdering klage for BA og KS

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt
@@ -122,7 +122,7 @@ class FerdigstillBehandlingService(
         if (behandlingsresultat == MEDHOLD &&
             skalOppretteRevurderingAutomatisk(behandling.påklagetVedtak)
         ) {
-            fagsystemVedtakService.opprettRevurdering(behandling.id).tilFagsystemRevurdering()
+            fagsystemVedtakService.opprettRevurdering(behandling).tilFagsystemRevurdering()
         } else {
             null
         }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -44,11 +44,11 @@ class FamilieBASakClient(
 
     fun opprettRevurdering(
         eksternFagsakId: String,
-        klagebehandlingId: UUID,
+        eksternBehandlingId: UUID,
     ): OpprettRevurderingResponse {
         val url =
             if (featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE)) {
-                "api/klage/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+                "api/klage/fagsak/$eksternFagsakId/klagebehandling/$eksternBehandlingId/opprett-revurdering-klage"
             } else {
                 "api/klage/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
             }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
@@ -44,11 +44,11 @@ class FamilieKSSakClient(
 
     fun opprettRevurdering(
         eksternFagsakId: String,
-        klagebehandlingId: UUID,
+        eksternBehandlingId: UUID,
     ): OpprettRevurderingResponse {
         val url =
             if (featureToggleService.isEnabled(Toggle.SEND_BEHANDLING_ID_VED_OPPRETTING_AV_REVURDERING_KLAGE)) {
-                "api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage"
+                "api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$eksternBehandlingId/opprett-revurdering-klage"
             } else {
                 "api/ekstern/fagsaker/$eksternFagsakId/opprett-revurdering-klage"
             }

--- a/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClientTest.kt
@@ -37,11 +37,11 @@ class FamilieBASakClientTest {
         fun `skal opprette revurdering uten å sende behandlingId`() {
             // Arrange
             val eksternFagsakId = "1"
-            val klagebehandlingId = UUID.randomUUID()
+            val eksternBehandlingId = UUID.randomUUID()
 
             val fakeOpprettRevurderingResponse =
                 OpprettRevurderingResponse(
-                    opprettet = Opprettet(klagebehandlingId.toString()),
+                    opprettet = Opprettet(eksternBehandlingId.toString()),
                 )
 
             val uri = URI.create("$baseUrl/fagsaker/$eksternFagsakId/opprett-revurdering-klage")
@@ -65,7 +65,7 @@ class FamilieBASakClientTest {
             val opprettRevurderingResponse =
                 familieBASakClient.opprettRevurdering(
                     eksternFagsakId = eksternFagsakId,
-                    klagebehandlingId = klagebehandlingId,
+                    eksternBehandlingId = eksternBehandlingId,
                 )
 
             // Assert
@@ -83,14 +83,14 @@ class FamilieBASakClientTest {
         fun `skal opprette revurdering`() {
             // Arrange
             val eksternFagsakId = "1"
-            val klagebehandlingId = UUID.randomUUID()
+            val eksternBehandlingId = UUID.randomUUID()
 
             val fakeOpprettRevurderingResponse =
                 OpprettRevurderingResponse(
-                    opprettet = Opprettet(klagebehandlingId.toString()),
+                    opprettet = Opprettet(eksternBehandlingId.toString()),
                 )
 
-            val uri = URI.create("$baseUrl/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage")
+            val uri = URI.create("$baseUrl/fagsak/$eksternFagsakId/klagebehandling/$eksternBehandlingId/opprett-revurdering-klage")
 
             every {
                 restOperations.exchange<Ressurs<OpprettRevurderingResponse>>(
@@ -111,7 +111,7 @@ class FamilieBASakClientTest {
             val opprettRevurderingResponse =
                 familieBASakClient.opprettRevurdering(
                     eksternFagsakId = eksternFagsakId,
-                    klagebehandlingId = klagebehandlingId,
+                    eksternBehandlingId = eksternBehandlingId,
                 )
 
             // Assert

--- a/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClientTest.kt
@@ -36,11 +36,11 @@ class FamilieKSSakClientTest {
         fun `skal opprette revurdering uten å sende behandlingId`() {
             // Arrange
             val eksternFagsakId = "1"
-            val klagebehandlingId = UUID.randomUUID()
+            val eksternBehandlingId = UUID.randomUUID()
 
             val fakeOpprettRevurderingResponse =
                 OpprettRevurderingResponse(
-                    opprettet = Opprettet(klagebehandlingId.toString()),
+                    opprettet = Opprettet(eksternBehandlingId.toString()),
                 )
 
             val uri =
@@ -67,7 +67,7 @@ class FamilieKSSakClientTest {
             val opprettRevurderingResponse =
                 familieKSSakClient.opprettRevurdering(
                     eksternFagsakId = eksternFagsakId,
-                    klagebehandlingId = klagebehandlingId,
+                    eksternBehandlingId = eksternBehandlingId,
                 )
 
             // Assert
@@ -85,16 +85,16 @@ class FamilieKSSakClientTest {
         fun `skal opprette revurdering`() {
             // Arrange
             val eksternFagsakId = "1"
-            val klagebehandlingId = UUID.randomUUID()
+            val eksternBehandlingId = UUID.randomUUID()
 
             val fakeOpprettRevurderingResponse =
                 OpprettRevurderingResponse(
-                    opprettet = Opprettet(klagebehandlingId.toString()),
+                    opprettet = Opprettet(eksternBehandlingId.toString()),
                 )
 
             val uri =
                 URI.create(
-                    "http://localhost:8080/api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$klagebehandlingId/opprett-revurdering-klage",
+                    "http://localhost:8080/api/ekstern/fagsak/$eksternFagsakId/klagebehandling/$eksternBehandlingId/opprett-revurdering-klage",
                 )
 
             every {
@@ -116,7 +116,7 @@ class FamilieKSSakClientTest {
             val opprettRevurderingResponse =
                 familieKSSakClient.opprettRevurdering(
                     eksternFagsakId = eksternFagsakId,
-                    klagebehandlingId = klagebehandlingId,
+                    eksternBehandlingId = eksternBehandlingId,
                 )
 
             // Assert


### PR DESCRIPTION
Favro: [NAV-24658](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24658)

Brukte den intern behandlingId ved en feil. Skal sende over ekstern behandlingId, i likhet med det som er gjort for fagsaken. 