### PR TITLE
NAV-24879: Tar i bruk endepunkt for å patche enhet på oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetService.kt
@@ -4,7 +4,9 @@ import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.klage.behandlingshistorikk.domain.HistorikkHendelse
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.oppgave.OppgaveService
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -24,6 +26,10 @@ class BehandlendeEnhetService(
     ) {
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsystem = fagsakService.hentFagsak(behandling.fagsakId).fagsystem
+
+        if (fagsystem == Fagsystem.EF) {
+            throw Feil(message = "Fagsystem ${fagsystem.name} er foreløpig ikke støttet.")
+        }
 
         val eksisterendeBehandlendeEnhet =
             Enhet.finnEnhet(
@@ -48,6 +54,7 @@ class BehandlendeEnhetService(
         )
 
         oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
+            fagsystem = fagsystem,
             behandlingId = behandling.id,
             enhet = nyBehandlendeEnhet,
         )

--- a/src/main/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetService.kt
@@ -49,7 +49,7 @@ class BehandlendeEnhetService(
 
         oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
             behandlingId = behandling.id,
-            behandlendeEnhet = nyBehandlendeEnhet,
+            enhet = nyBehandlendeEnhet,
         )
 
         behandlingshistorikkService.opprettBehandlingshistorikk(

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -141,11 +141,13 @@ class OppgaveClient(
         // Lagt til pga. patch-endepunktet i familie-integrasjoner ikke håndterer sletting/tilbakestilling av felt,
         // se https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-10379.
         // Det blir dermed vanskelig å sette f.eks. tilordnet ressurs til "null" gjennom patch-endepunktet.
+        val eksisterendeOppgave = finnOppgaveMedId(oppgaveId)
         val uri =
             UriComponentsBuilder
                 .fromUri(URI.create("$oppgaveUri/$oppgaveId/enhet/${nyEnhet.enhetsnummer}"))
                 .queryParam("fjernMappeFraOppgave", fjernMappeFraOppgave)
                 .queryParam("nullstillTilordnetRessurs", nullstillTilordnetRessurs)
+                .queryParam("versjon", eksisterendeOppgave.versjon)
                 .build()
                 .toUri()
         try {

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.klage.oppgave
 
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
+import no.nav.familie.klage.behandling.enhet.Enhet
 import no.nav.familie.klage.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.klage.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.klage.infrastruktur.exception.ApiFeil
@@ -129,6 +130,30 @@ class OppgaveClient(
 
         val respons = getForEntity<Ressurs<Saksbehandler>>(uri)
         return pakkUtRespons(respons, uri, "hentSaksbehandlerInfo")
+    }
+
+    fun patchEnhetPåOppgave(
+        oppgaveId: Long,
+        nyEnhet: Enhet,
+        fjernMappeFraOppgave: Boolean = true,
+        nullstillTilordnetRessurs: Boolean = true,
+    ): OppgaveResponse {
+        // Lagt til pga. patch-endepunktet i familie-integrasjoner ikke håndterer sletting/tilbakestilling av felt,
+        // se https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-10379.
+        // Det blir dermed vanskelig å sette f.eks. tilordnet ressurs til "null" gjennom patch-endepunktet.
+        val uri =
+            UriComponentsBuilder
+                .fromUri(URI.create("$oppgaveUri/$oppgaveId/enhet/${nyEnhet.enhetsnummer}"))
+                .queryParam("fjernMappeFraOppgave", fjernMappeFraOppgave)
+                .queryParam("nullstillTilordnetRessurs", nullstillTilordnetRessurs)
+                .build()
+                .toUri()
+        try {
+            val response = patchForEntity<Ressurs<OppgaveResponse>>(uri = uri, payload = HttpHeaders().medContentTypeJsonUTF8())
+            return pakkUtRespons(respons = response, uri = uri, metode = "tilordnetEnhet")
+        } catch (exception: Exception) {
+            throw IntegrasjonException(msg = "Oppdatering av enhet på oppgave feilet.", uri = uri, throwable = exception)
+        }
     }
 
     private fun <T> pakkUtRespons(

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveClient.kt
@@ -135,7 +135,7 @@ class OppgaveClient(
     fun patchEnhetPåOppgave(
         oppgaveId: Long,
         nyEnhet: Enhet,
-        fjernMappeFraOppgave: Boolean = true,
+        fjernMappeFraOppgave: Boolean,
         nullstillTilordnetRessurs: Boolean = true,
     ): OppgaveResponse {
         // Lagt til pga. patch-endepunktet i familie-integrasjoner ikke håndterer sletting/tilbakestilling av felt,

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
@@ -87,22 +87,22 @@ class OppgaveService(
 
     fun oppdaterEnhetPåBehandleSakOppgave(
         behandlingId: UUID,
-        behandlendeEnhet: Enhet,
+        enhet: Enhet,
     ) {
         val behandleSakOppgave = behandleSakOppgaveRepository.findByBehandlingId(behandlingId)?.let { hentOppgave(it.oppgaveId) }
-
         if (behandleSakOppgave == null) {
             throw Feil("Finner ingen BehandleSak-Oppgave tilknyttet behandling $behandlingId")
         }
 
+        val oppgaveId = behandleSakOppgave.id
+        if (oppgaveId == null) {
+            throw Feil("Finner ikke id på BehandleSak-Oppgave tilknyttet behandling $behandlingId")
+        }
+
         if (behandleSakOppgave.status !in listOf(StatusEnum.FERDIGSTILT, StatusEnum.FEILREGISTRERT)) {
-            oppdaterOppgave(
-                Oppgave(
-                    id = behandleSakOppgave.id,
-                    tildeltEnhetsnr = behandlendeEnhet.enhetsnummer,
-                    mappeId = null,
-                    tilordnetRessurs = null,
-                ),
+            oppgaveClient.patchEnhetPåOppgave(
+                oppgaveId = oppgaveId,
+                nyEnhet = enhet,
             )
         }
     }

--- a/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/oppgave/OppgaveService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.klage.behandling.enhet.Enhet
 import no.nav.familie.klage.infrastruktur.config.getValue
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.kontrakter.felles.Behandlingstema
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.oppgave.MappeDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
@@ -86,6 +87,7 @@ class OppgaveService(
         }
 
     fun oppdaterEnhetPåBehandleSakOppgave(
+        fagsystem: Fagsystem,
         behandlingId: UUID,
         enhet: Enhet,
     ) {
@@ -103,6 +105,11 @@ class OppgaveService(
             oppgaveClient.patchEnhetPåOppgave(
                 oppgaveId = oppgaveId,
                 nyEnhet = enhet,
+                fjernMappeFraOppgave =
+                    when (fagsystem) {
+                        Fagsystem.BA, Fagsystem.KS -> true
+                        Fagsystem.EF -> false
+                    },
             )
         }
     }

--- a/src/test/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetServiceTest.kt
@@ -73,6 +73,7 @@ class BehandlendeEnhetServiceTest {
 
             every {
                 oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
+                    fagsystem = Fagsystem.BA,
                     behandlingId = behandling.id,
                     enhet = capture(behandlendeEnhetOppgaveSlot),
                 )
@@ -88,7 +89,7 @@ class BehandlendeEnhetServiceTest {
             // Assert
             verify(exactly = 1) { behandlingService.oppdaterBehandlendeEnhet(any(), any(), any()) }
             verify(exactly = 1) { behandlingshistorikkService.opprettBehandlingshistorikk(any(), any(), any(), any()) }
-            verify(exactly = 1) { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(any(), any()) }
+            verify(exactly = 1) { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(any(), any(), any()) }
 
             assertThat(behandlendeEnhetSlot.captured).isEqualTo(nyBehandlendeEnhet)
             assertThat(historikkHendelseSlot.captured).isEqualTo(HistorikkHendelse.BEHANDLENDE_ENHET_ENDRET)
@@ -131,6 +132,7 @@ class BehandlendeEnhetServiceTest {
 
             every {
                 oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
+                    fagsystem = Fagsystem.KS,
                     behandlingId = behandling.id,
                     enhet = capture(behandlendeEnhetOppgaveSlot),
                 )
@@ -146,7 +148,7 @@ class BehandlendeEnhetServiceTest {
             // Assert
             verify(exactly = 1) { behandlingService.oppdaterBehandlendeEnhet(any(), any(), any()) }
             verify(exactly = 1) { behandlingshistorikkService.opprettBehandlingshistorikk(any(), any(), any(), any()) }
-            verify(exactly = 1) { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(any(), any()) }
+            verify(exactly = 1) { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(any(), any(), any()) }
 
             assertThat(behandlendeEnhetSlot.captured).isEqualTo(nyBehandlendeEnhet)
             assertThat(historikkHendelseSlot.captured).isEqualTo(HistorikkHendelse.BEHANDLENDE_ENHET_ENDRET)
@@ -178,7 +180,7 @@ class BehandlendeEnhetServiceTest {
                     )
                 }
 
-            assertThat(feil.message).isEqualTo("Oppslag av enhet for EF er ikke støttet.")
+            assertThat(feil.message).isEqualTo("Fagsystem ${Fagsystem.EF.name} er foreløpig ikke støttet.")
         }
 
         @Test
@@ -201,7 +203,7 @@ class BehandlendeEnhetServiceTest {
             // Assert
             verify(exactly = 0) { behandlingService.oppdaterBehandlendeEnhet(any(), any(), any()) }
             verify(exactly = 0) { behandlingshistorikkService.opprettBehandlingshistorikk(any(), any(), any(), any()) }
-            verify(exactly = 0) { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(any(), any()) }
+            verify(exactly = 0) { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(any(), any(), any()) }
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetServiceTest.kt
@@ -74,7 +74,7 @@ class BehandlendeEnhetServiceTest {
             every {
                 oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
                     behandlingId = behandling.id,
-                    behandlendeEnhet = capture(behandlendeEnhetOppgaveSlot),
+                    enhet = capture(behandlendeEnhetOppgaveSlot),
                 )
             } just Runs
 
@@ -132,7 +132,7 @@ class BehandlendeEnhetServiceTest {
             every {
                 oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
                     behandlingId = behandling.id,
-                    behandlendeEnhet = capture(behandlendeEnhetOppgaveSlot),
+                    enhet = capture(behandlendeEnhetOppgaveSlot),
                 )
             } just Runs
 

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveClientTest.kt
@@ -1,0 +1,131 @@
+package no.nav.familie.klage.oppgave
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.klage.behandling.enhet.BarnetrygdEnhet
+import no.nav.familie.klage.infrastruktur.config.IntegrasjonerConfig
+import no.nav.familie.klage.infrastruktur.exception.IntegrasjonException
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestOperations
+import org.springframework.web.client.exchange
+import java.net.URI
+
+class OppgaveClientTest {
+    private val restOperations: RestOperations = mockk()
+    private val baseUrl = URI("http://localhost:8080")
+    private val oppgaveClient =
+        OppgaveClient(
+            restOperations = restOperations,
+            integrasjonerConfig = IntegrasjonerConfig(baseUrl),
+        )
+
+    @Nested
+    inner class PatchEnhetPåOppgave {
+        @Test
+        fun `skal patche enhet på oppgave og tilbakestille tilordnet ressurs og mappe`() {
+            // Arrange
+            val oppgaveId = 1L
+            val nyEnhet = BarnetrygdEnhet.OSLO
+
+            every {
+                restOperations.exchange<Ressurs<OppgaveResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            } returns ResponseEntity.ok(Ressurs.Companion.success(OppgaveResponse(oppgaveId)))
+
+            // Act
+            val oppgaveResponse =
+                oppgaveClient.patchEnhetPåOppgave(
+                    oppgaveId = oppgaveId,
+                    nyEnhet = nyEnhet,
+                )
+
+            // Assert
+            assertThat(oppgaveResponse.oppgaveId).isEqualTo(oppgaveId)
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OppgaveResponse>>(
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=true&nullstillTilordnetRessurs=true")),
+                    method = eq(HttpMethod.PATCH),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            }
+        }
+
+        @Test
+        fun `skal patche enhet på oppgave uten å tilbakestille tilordnet ressurs eller mappe`() {
+            // Arrange
+            val oppgaveId = 1L
+            val nyEnhet = BarnetrygdEnhet.OSLO
+
+            every {
+                restOperations.exchange<Ressurs<OppgaveResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            } returns ResponseEntity.ok(Ressurs.success(OppgaveResponse(oppgaveId)))
+
+            // Act
+            val oppgaveResponse =
+                oppgaveClient.patchEnhetPåOppgave(
+                    oppgaveId = oppgaveId,
+                    nyEnhet = nyEnhet,
+                    fjernMappeFraOppgave = false,
+                    nullstillTilordnetRessurs = false,
+                )
+
+            // Assert
+            assertThat(oppgaveResponse.oppgaveId).isEqualTo(oppgaveId)
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OppgaveResponse>>(
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=false")),
+                    method = eq(HttpMethod.PATCH),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            }
+        }
+
+        @Test
+        fun `skal håndtere feil ved patching an enhet på oppgave`() {
+            // Arrange
+            val oppgaveId = 1L
+            val nyEnhet = BarnetrygdEnhet.OSLO
+
+            every {
+                restOperations.exchange<Ressurs<OppgaveResponse>>(
+                    url = any<URI>(),
+                    method = any<HttpMethod>(),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            } returns ResponseEntity.badRequest().body(Ressurs.failure())
+
+            // Act & assert
+            val exception =
+                assertThrows<IntegrasjonException> {
+                    oppgaveClient.patchEnhetPåOppgave(
+                        oppgaveId = oppgaveId,
+                        nyEnhet = nyEnhet,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Oppdatering av enhet på oppgave feilet.")
+            verify(exactly = 1) {
+                restOperations.exchange<Ressurs<OppgaveResponse>>(
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=false")),
+                    method = eq(HttpMethod.PATCH),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveClientTest.kt
@@ -49,6 +49,7 @@ class OppgaveClientTest {
                 oppgaveClient.patchEnhetPåOppgave(
                     oppgaveId = oppgaveId,
                     nyEnhet = nyEnhet,
+                    fjernMappeFraOppgave = true,
                 )
 
             // Assert
@@ -116,12 +117,13 @@ class OppgaveClientTest {
                     oppgaveClient.patchEnhetPåOppgave(
                         oppgaveId = oppgaveId,
                         nyEnhet = nyEnhet,
+                        fjernMappeFraOppgave = false,
                     )
                 }
             assertThat(exception.message).isEqualTo("Oppdatering av enhet på oppgave feilet.")
             verify(exactly = 1) {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
-                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=false")),
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=true")),
                     method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveClientTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.klage.behandling.enhet.BarnetrygdEnhet
 import no.nav.familie.klage.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.klage.infrastruktur.exception.IntegrasjonException
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -35,11 +36,20 @@ class OppgaveClientTest {
             // Arrange
             val oppgaveId = 1L
             val nyEnhet = BarnetrygdEnhet.OSLO
+            val eksisterendeOppgave = Oppgave(id = oppgaveId, versjon = 1)
+
+            every {
+                restOperations.exchange<Ressurs<Oppgave>>(
+                    url = any<URI>(),
+                    method = eq(HttpMethod.GET),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            } returns ResponseEntity.ok(Ressurs.Companion.success(eksisterendeOppgave))
 
             every {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
                     url = any<URI>(),
-                    method = any<HttpMethod>(),
+                    method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )
             } returns ResponseEntity.ok(Ressurs.Companion.success(OppgaveResponse(oppgaveId)))
@@ -56,7 +66,7 @@ class OppgaveClientTest {
             assertThat(oppgaveResponse.oppgaveId).isEqualTo(oppgaveId)
             verify(exactly = 1) {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
-                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=true&nullstillTilordnetRessurs=true")),
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=true&nullstillTilordnetRessurs=true&versjon=${eksisterendeOppgave.versjon}")),
                     method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )
@@ -68,11 +78,20 @@ class OppgaveClientTest {
             // Arrange
             val oppgaveId = 1L
             val nyEnhet = BarnetrygdEnhet.OSLO
+            val eksisterendeOppgave = Oppgave(id = oppgaveId, versjon = 1)
+
+            every {
+                restOperations.exchange<Ressurs<Oppgave>>(
+                    url = any<URI>(),
+                    method = eq(HttpMethod.GET),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            } returns ResponseEntity.ok(Ressurs.Companion.success(eksisterendeOppgave))
 
             every {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
                     url = any<URI>(),
-                    method = any<HttpMethod>(),
+                    method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )
             } returns ResponseEntity.ok(Ressurs.success(OppgaveResponse(oppgaveId)))
@@ -90,7 +109,7 @@ class OppgaveClientTest {
             assertThat(oppgaveResponse.oppgaveId).isEqualTo(oppgaveId)
             verify(exactly = 1) {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
-                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=false")),
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=false&versjon=${eksisterendeOppgave.versjon}")),
                     method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )
@@ -102,11 +121,20 @@ class OppgaveClientTest {
             // Arrange
             val oppgaveId = 1L
             val nyEnhet = BarnetrygdEnhet.OSLO
+            val eksisterendeOppgave = Oppgave(id = oppgaveId, versjon = 1)
+
+            every {
+                restOperations.exchange<Ressurs<Oppgave>>(
+                    url = any<URI>(),
+                    method = eq(HttpMethod.GET),
+                    requestEntity = any<HttpEntity<Void>>(),
+                )
+            } returns ResponseEntity.ok(Ressurs.Companion.success(eksisterendeOppgave))
 
             every {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
                     url = any<URI>(),
-                    method = any<HttpMethod>(),
+                    method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )
             } returns ResponseEntity.badRequest().body(Ressurs.failure())
@@ -123,7 +151,7 @@ class OppgaveClientTest {
             assertThat(exception.message).isEqualTo("Oppdatering av enhet på oppgave feilet.")
             verify(exactly = 1) {
                 restOperations.exchange<Ressurs<OppgaveResponse>>(
-                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=true")),
+                    url = eq(URI.create("$baseUrl/api/oppgave/$oppgaveId/enhet/${nyEnhet.enhetsnummer}?fjernMappeFraOppgave=false&nullstillTilordnetRessurs=true&versjon=${eksisterendeOppgave.versjon}")),
                     method = eq(HttpMethod.PATCH),
                     requestEntity = any<HttpEntity<Void>>(),
                 )

--- a/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/oppgave/OppgaveServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.klage.testutil.DomainUtil.behandling
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveResponse
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -21,18 +22,18 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.cache.CacheManager
 import java.util.UUID
 
-internal class OppgaveServiceTest {
-    val behandleSakOppgaveRepository = mockk<BehandleSakOppgaveRepository>()
-    val oppgaveClient = mockk<OppgaveClient>()
-    val behandlingService = mockk<BehandlingService>()
-    val cacheManager = mockk<CacheManager>()
-    val oppgaveService = OppgaveService(behandleSakOppgaveRepository, oppgaveClient, behandlingService, cacheManager)
+class OppgaveServiceTest {
+    private val behandleSakOppgaveRepository = mockk<BehandleSakOppgaveRepository>()
+    private val oppgaveClient = mockk<OppgaveClient>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val cacheManager = mockk<CacheManager>()
+    private val oppgaveService = OppgaveService(behandleSakOppgaveRepository, oppgaveClient, behandlingService, cacheManager)
 
-    val behandlingId = UUID.randomUUID()
-    val oppgaveId = 1L
+    private val behandlingId = UUID.randomUUID()
+    private val oppgaveId = 1L
 
     @Test
-    internal fun `skal oppdatere oppgave med behandlingstemaet for klage-tilbakekreving`() {
+    fun `skal oppdatere oppgave med behandlingstemaet for klage-tilbakekreving`() {
         val oppgaveSlot = slot<Oppgave>()
         val eksisterendeOppgave =
             BehandleSakOppgave(
@@ -81,7 +82,7 @@ internal class OppgaveServiceTest {
     }
 
     @Test
-    internal fun `skal ikke oppdatere oppgave om behandling ikke har status opprettet eller utredes`() {
+    fun `skal ikke oppdatere oppgave om behandling ikke har status opprettet eller utredes`() {
         val behandling = behandling(id = behandlingId, status = BehandlingStatus.FERDIGSTILT)
 
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
@@ -117,20 +118,22 @@ internal class OppgaveServiceTest {
                     status = status,
                 )
 
-            val oppgaveSlot = slot<Oppgave>()
-
             every { behandleSakOppgaveRepository.findByBehandlingId(behandling.id) } returns behandleSakOppgave
             every { oppgaveClient.finnOppgaveMedId(oppgaveId) } returns oppgave
-            every { oppgaveClient.oppdaterOppgave(capture(oppgaveSlot)) } returns oppgaveId
+            every { oppgaveClient.patchEnhetPåOppgave(oppgaveId, nyBehandlendeEnhet) } returns OppgaveResponse(oppgaveId)
 
             // Act
             oppgaveService.oppdaterEnhetPåBehandleSakOppgave(behandlingId = behandling.id, nyBehandlendeEnhet)
 
             // Assert
-            val oppdatertOppgave = oppgaveSlot.captured
-            assertThat(oppdatertOppgave.tildeltEnhetsnr).isEqualTo(nyBehandlendeEnhet.enhetsnummer)
-            assertThat(oppdatertOppgave.mappeId).isNull()
-            assertThat(oppdatertOppgave.tilordnetRessurs).isNull()
+            verify(exactly = 1) {
+                oppgaveClient.patchEnhetPåOppgave(
+                    oppgaveId = oppgaveId,
+                    nyEnhet = nyBehandlendeEnhet,
+                    fjernMappeFraOppgave = true,
+                    nullstillTilordnetRessurs = true,
+                )
+            }
         }
 
         @ParameterizedTest
@@ -175,9 +178,49 @@ internal class OppgaveServiceTest {
             every { behandleSakOppgaveRepository.findByBehandlingId(behandling.id) } returns null
 
             // Act & Assert
-            val feil = assertThrows<Feil> { oppgaveService.oppdaterEnhetPåBehandleSakOppgave(behandlingId = behandling.id, nyBehandlendeEnhet) }
+            val exception =
+                assertThrows<Feil> {
+                    oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
+                        behandlingId = behandling.id,
+                        enhet = nyBehandlendeEnhet,
+                    )
+                }
 
-            assertThat(feil.message).isEqualTo("Finner ingen BehandleSak-Oppgave tilknyttet behandling ${behandling.id}")
+            assertThat(exception.message).isEqualTo("Finner ingen BehandleSak-Oppgave tilknyttet behandling ${behandling.id}")
+        }
+
+        @Test
+        fun `skal kaste feil dersom behandle sak oppgave mangler id for behandling`() {
+            // Arrange
+            val behandling = behandling()
+            val behandlendeEnhet = BarnetrygdEnhet.STORD
+            val nyBehandlendeEnhet = BarnetrygdEnhet.STEINKJER
+            val oppgaveId = 1L
+
+            val behandleSakOppgave = BehandleSakOppgave(behandlingId = behandling.id, oppgaveId = oppgaveId)
+            val oppgave =
+                Oppgave(
+                    id = null,
+                    tildeltEnhetsnr = behandlendeEnhet.enhetsnummer,
+                    tilordnetRessurs = "Saksbehandler",
+                    oppgavetype = "BEH_SAK",
+                    mappeId = 101,
+                    status = StatusEnum.OPPRETTET,
+                )
+
+            every { behandleSakOppgaveRepository.findByBehandlingId(behandling.id) } returns behandleSakOppgave
+            every { oppgaveClient.finnOppgaveMedId(oppgaveId) } returns oppgave
+
+            // Act & Assert
+            val exception =
+                assertThrows<Feil> {
+                    oppgaveService.oppdaterEnhetPåBehandleSakOppgave(
+                        behandlingId = behandling.id,
+                        enhet = nyBehandlendeEnhet,
+                    )
+                }
+
+            assertThat(exception.message).isEqualTo("Finner ikke id på BehandleSak-Oppgave tilknyttet behandling ${behandling.id}")
         }
     }
 }


### PR DESCRIPTION
Favro: [NAV-24879](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24879)

All koden her skal være togglet bak toggelen [familie-klage.skal-kunne-endre-behandlende-enhet-baks](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-klage.skal-kunne-endre-behandlende-enhet-baks)

Patch-endepunktet i familie-integrasjoner fungerer ikke så bra når man skal tilbakestille/slette verdier, se [her](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-10379).

Tar dermed i bruk et annet endepunkt for å oppdatere enhet på oppgave, inspirert av hvordan det er gjort i [ba-sak](https://github.com/navikt/familie-ba-sak/blob/main/src/main/kotlin/no/nav/familie/ba/sak/integrasjoner/familieintegrasjoner/IntegrasjonClient.kt#L337-L360) og [ks-sak](https://github.com/navikt/familie-ks-sak/blob/main/src/main/kotlin/no/nav/familie/ks/sak/integrasjon/familieintegrasjon/IntegrasjonClient.kt#L124-L147). 