### PR TITLE
NAV-25133: Legger familie-baks-kafka-manager i ACL slik at kafka-manager kan lese topicet.

### DIFF
--- a/kafka/aapen-klage-behandlingsstatistikk/behandlingsstatistikk-topic-dev.yaml
+++ b/kafka/aapen-klage-behandlingsstatistikk/behandlingsstatistikk-topic-dev.yaml
@@ -24,3 +24,6 @@ spec:
     - team: ptsak
       application: pt-sak-famklage-dev
       access: read
+    - team: teamfamilie
+      application: familie-baks-kafka-manager
+      access: read

--- a/kafka/aapen-klage-behandlingsstatistikk/behandlingsstatistikk-topic-prod.yaml
+++ b/kafka/aapen-klage-behandlingsstatistikk/behandlingsstatistikk-topic-prod.yaml
@@ -21,3 +21,6 @@ spec:
     - team: ptsak
       application: pt-sak-famklage
       access: read
+    - team: teamfamilie
+      application: familie-baks-kafka-manager
+      access: read


### PR DESCRIPTION
Favro: [NAV-25133](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25133)

Har lyst til å kunne lese topicene gjennom kafka manager slik at det blir lettere å feilsøke/grave. 