### PR TITLE
NAV-25176: Legger til toggle for ny henlegg behandling dialog

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -18,6 +18,7 @@ class FeatureToggleController(
             Toggle.LEGG_TIL_BREVMOTTAKER_BAKS,
             Toggle.KAN_MELLOMLAGRE_VURDERING,
             Toggle.SKAL_KUNNE_ENDRE_BEHANDLENDE_ENHET_BAKS,
+            Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL,
         )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -31,6 +31,7 @@ enum class Toggle(
         "Release",
     ),
     SKAL_KUNNE_ENDRE_BEHANDLENDE_ENHET_BAKS("familie-klage.skal-kunne-endre-behandlende-enhet-baks", "Release"),
+    BRUK_NY_HENLEGG_BEHANDLING_MODAL("familie-klage.bruk-ny-henlegg-behandling-modal", "Release"),
 
     ;
 


### PR DESCRIPTION
Favro: [NAV-25176](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25176)

Legger til [toggle](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-klage.bruk-ny-henlegg-behandling-modal) for å skru av/på ny henlegg behandling dialog.

Relatert frontend PR: https://github.com/navikt/familie-klage-frontend/pull/944