### PR TITLE
NAV-25011: Legger til endepunkt for initielle brevmottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -17,9 +17,8 @@ import no.nav.familie.klage.brev.dto.Henleggelsesbrev
 import no.nav.familie.klage.brev.dto.SignaturDto
 import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
 import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
-import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtleder
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
-import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
 import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
 import no.nav.familie.klage.brevmottaker.dto.tilDomene
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
@@ -67,6 +66,7 @@ class BrevService(
     private val personopplysningerService: PersonopplysningerService,
     private val brevInnholdUtleder: BrevInnholdUtleder,
     private val taskService: TaskService,
+    private val brevmottakerUtleder: BrevmottakerUtleder,
 ) {
     fun hentBrev(behandlingId: UUID): Brev = brevRepository.findByIdOrThrow(behandlingId)
 
@@ -243,25 +243,11 @@ class BrevService(
                 Brev(
                     behandlingId = behandlingId,
                     saksbehandlerHtml = saksbehandlerHtml,
-                    mottakere = initialiserBrevmottakere(behandlingId, fagsak),
+                    mottakere = brevmottakerUtleder.utledInitielleBrevmottakere(behandlingId),
                 ),
             )
         }
     }
-
-    private fun initialiserBrevmottakere(
-        behandlingId: UUID,
-        fagsak: Fagsak,
-    ) = Brevmottakere(
-        personer =
-            listOf(
-                BrevmottakerPersonMedIdent(
-                    personIdent = fagsak.hentAktivIdent(),
-                    navn = personopplysningerService.hentPersonopplysninger(behandlingId).navn,
-                    mottakerRolle = MottakerRolle.BRUKER,
-                ),
-            ),
-    )
 
     fun lagBrevPdf(behandlingId: UUID) {
         val brev = brevRepository.findByIdOrThrow(behandlingId)

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
@@ -74,4 +74,14 @@ class BrevmottakerController(
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
         return Ressurs.success(brevmottakere.tilDto())
     }
+
+    @GetMapping("/initielle/{behandlingId}")
+    fun utledInitielleBrevmottakere(
+        @PathVariable behandlingId: UUID,
+    ): Ressurs<BrevmottakereDto> {
+        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
+        val brevmottakere = brevmottakerService.utledInitielleBrevmottakere(behandlingId)
+        return Ressurs.success(brevmottakere.tilDto())
+    }
 }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerService.kt
@@ -14,6 +14,7 @@ class BrevmottakerService(
     private val brevmottakerErstatter: BrevmottakerErstatter,
     private val brevmottakerOppretter: BrevmottakerOppretter,
     private val brevmottakerSletter: BrevmottakerSletter,
+    private val brevmottakerUtleder: BrevmottakerUtleder,
 ) {
     fun hentBrevmottakere(behandlingId: UUID): Brevmottakere = brevmottakerHenter.hentBrevmottakere(behandlingId)
 
@@ -36,4 +37,6 @@ class BrevmottakerService(
     ) {
         brevmottakerSletter.slettBrevmottaker(behandlingId, slettbarBrevmottaker)
     }
+
+    fun utledInitielleBrevmottakere(behandlingId: UUID): Brevmottakere = brevmottakerUtleder.utledInitielleBrevmottakere(behandlingId)
 }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtleder.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.klage.brevmottaker
+
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class BrevmottakerUtleder(
+    private val fagsakService: FagsakService,
+    private val personopplysningerService: PersonopplysningerService,
+) {
+    fun utledInitielleBrevmottakere(behandlingId: UUID): Brevmottakere {
+        val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
+        val personopplysninger = personopplysningerService.hentPersonopplysninger(behandlingId)
+        return Brevmottakere(
+            personer =
+                listOf(
+                    BrevmottakerPersonMedIdent(
+                        personIdent = fagsak.hentAktivIdent(),
+                        navn = personopplysninger.navn,
+                        mottakerRolle = MottakerRolle.BRUKER,
+                    ),
+                ),
+            organisasjoner = emptyList(),
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.brev.domain.Brev
+import no.nav.familie.klage.brevmottaker.BrevmottakerUtleder
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.formkrav.FormService
@@ -39,6 +40,7 @@ class BrevServiceTest {
     private val personopplysningerService = mockk<PersonopplysningerService>(relaxed = true)
     private val brevInnholdUtleder = mockk<BrevInnholdUtleder>(relaxed = true)
     private val taskService = mockk<TaskService>(relaxed = true)
+    private val brevmottakerUtleder = mockk<BrevmottakerUtleder>(relaxed = true)
 
     private val brevService =
         BrevService(
@@ -53,6 +55,7 @@ class BrevServiceTest {
             personopplysningerService = personopplysningerService,
             brevInnholdUtleder = brevInnholdUtleder,
             taskService = taskService,
+            brevmottakerUtleder = brevmottakerUtleder,
         )
 
     @AfterEach

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
@@ -5,7 +5,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
 import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
 import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottakerPersonUtenIdent
 import no.nav.familie.klage.testutil.DomainUtil
@@ -15,10 +17,11 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class BrevmottakerServiceTest {
-    private val brevmottakerHenter: BrevmottakerHenter = mockk()
-    private val brevmottakerErstatter: BrevmottakerErstatter = mockk()
-    private val brevmottakerOppretter: BrevmottakerOppretter = mockk()
-    private val brevmottakerSletter: BrevmottakerSletter = mockk()
+    private val brevmottakerHenter = mockk<BrevmottakerHenter>()
+    private val brevmottakerErstatter = mockk<BrevmottakerErstatter>()
+    private val brevmottakerOppretter = mockk<BrevmottakerOppretter>()
+    private val brevmottakerSletter = mockk<BrevmottakerSletter>()
+    private val brevmottakerUtleder = mockk<BrevmottakerUtleder>()
 
     private val brevmottakerService: BrevmottakerService =
         BrevmottakerService(
@@ -26,6 +29,7 @@ class BrevmottakerServiceTest {
             brevmottakerErstatter = brevmottakerErstatter,
             brevmottakerOppretter = brevmottakerOppretter,
             brevmottakerSletter = brevmottakerSletter,
+            brevmottakerUtleder = brevmottakerUtleder,
         )
 
     @Nested
@@ -162,6 +166,36 @@ class BrevmottakerServiceTest {
 
             // Assert
             verify(exactly = 1) { brevmottakerSletter.slettBrevmottaker(behandlingId, slettbarBrevmottaker) }
+        }
+    }
+
+    @Nested
+    inner class UtledInitielleBrevmottakere {
+        @Test
+        fun `skal utlede initielle brevmottakere`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brevmottakere =
+                Brevmottakere(
+                    personer =
+                        listOf(
+                            BrevmottakerPersonMedIdent(
+                                personIdent = "123",
+                                mottakerRolle = MottakerRolle.BRUKER,
+                                navn = "Navn Navnesen",
+                            ),
+                        ),
+                    organisasjoner = emptyList(),
+                )
+
+            every { brevmottakerUtleder.utledInitielleBrevmottakere(behandlingId) } returns brevmottakere
+
+            // Act
+            val initielleBrevmottakere = brevmottakerService.utledInitielleBrevmottakere(behandlingId)
+
+            // Assert
+            assertThat(initielleBrevmottakere).isEqualTo(brevmottakere)
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtlederTest.kt
@@ -1,0 +1,51 @@
+package no.nav.familie.klage.brevmottaker
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.fagsak.domain.PersonIdent
+import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import no.nav.familie.klage.testutil.DomainUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BrevmottakerUtlederTest {
+    private val fagsakService = mockk<FagsakService>()
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val brevmottakerUtleder =
+        BrevmottakerUtleder(
+            fagsakService = fagsakService,
+            personopplysningerService = personopplysningerService,
+        )
+
+    @Nested
+    inner class UtledInitielleBrevmottakere {
+        @Test
+        fun `skal utlede initielle brevmottakere`() {
+            // Arrange
+            val personIdent = "123"
+            val behandlingId = UUID.randomUUID()
+            val fagsak = DomainUtil.fagsak(identer = setOf(PersonIdent(personIdent)))
+            val personopplysninger = DomainUtil.personopplysningerDto(navn = "Navn Navnesen")
+
+            every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(behandlingId) } returns personopplysninger
+
+            // Act
+            val brevmottakere = brevmottakerUtleder.utledInitielleBrevmottakere(behandlingId)
+
+            // Assert
+            assertThat(brevmottakere.personer).hasSize(1)
+            assertThat(brevmottakere.personer[0]).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(personIdent)
+                assertThat(it.navn).isEqualTo("Navn Navnesen")
+                assertThat(it.mottakerRolle).isEqualTo(MottakerRolle.BRUKER)
+            }
+            assertThat(brevmottakere.organisasjoner).isEmpty()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -302,9 +302,10 @@ object DomainUtil {
     fun personopplysningerDto(
         personIdent: String = "123",
         adressebeskyttelse: Adressebeskyttelse? = null,
+        navn: String = "navn",
     ) = PersonopplysningerDto(
         personIdent = personIdent,
-        navn = "navn",
+        navn = navn,
         kjønn = Kjønn.MANN,
         adressebeskyttelse = adressebeskyttelse,
         folkeregisterpersonstatus = Folkeregisterpersonstatus.BOSATT,


### PR DESCRIPTION
Favro: [NAV-25011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25011)

Har behov for et eget endepunkt for å hente ut de initielle brevmottakerne slik at de kan vises i "Henlegg behandling" modalen. 