### PR TITLE
NAV-25011: Legger til manuelle brevmottakere i henlegging av behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.klage.brev
 
 import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
-import no.nav.familie.klage.brevmottaker.dto.tilDto
+import no.nav.familie.klage.brevmottaker.dto.tilBrevmottakereDto
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -47,7 +47,7 @@ class BrevController(
     ): Ressurs<BrevmottakereDto> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
-        return Ressurs.success(brevService.hentBrevmottakere(behandlingId).tilDto())
+        return Ressurs.success(brevService.hentBrevmottakere(behandlingId).tilBrevmottakereDto())
     }
 
     @PostMapping("/{behandlingId}/mottakere")

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -22,7 +22,7 @@ import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPerson
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPerson
 import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
-import no.nav.familie.klage.brevmottaker.dto.tilDomene
+import no.nav.familie.klage.brevmottaker.dto.tilBrevmottakere
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.fagsak.domain.Fagsak
@@ -76,18 +76,18 @@ class BrevService(
 
     fun settBrevmottakere(
         behandlingId: UUID,
-        brevmottakere: BrevmottakereDto,
+        brevmottakereDto: BrevmottakereDto,
     ) {
         val behandling = behandlingService.hentBehandling(behandlingId)
         validerKanLageBrev(behandling)
 
-        val mottakere = brevmottakere.tilDomene()
+        val brevmottakere = brevmottakereDto.tilBrevmottakere()
 
-        validerUnikeBrevmottakere(mottakere)
-        validerMinimumEnMottaker(mottakere)
+        validerUnikeBrevmottakere(brevmottakere)
+        validerMinimumEnMottaker(brevmottakere)
 
         val brev = brevRepository.findByIdOrThrow(behandlingId)
-        brevRepository.update(brev.copy(mottakere = mottakere))
+        brevRepository.update(brev.copy(mottakere = brevmottakere))
     }
 
     fun lagBrev(behandlingId: UUID): ByteArray {

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -18,7 +18,9 @@ import no.nav.familie.klage.brev.dto.SignaturDto
 import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerMinimumEnMottaker
 import no.nav.familie.klage.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
 import no.nav.familie.klage.brevmottaker.BrevmottakerUtleder
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPerson
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
+import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPerson
 import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
 import no.nav.familie.klage.brevmottaker.dto.tilDomene
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
@@ -26,31 +28,27 @@ import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.felles.domain.Fil
 import no.nav.familie.klage.felles.util.StønadstypeVisningsnavn.visningsnavn
-import no.nav.familie.klage.felles.util.TaskMetadata.SAKSBEHANDLER_METADATA_KEY
 import no.nav.familie.klage.felles.util.isEqualOrAfter
 import no.nav.familie.klage.formkrav.FormService
 import no.nav.familie.klage.formkrav.domain.FormkravFristUnntak
-import no.nav.familie.klage.henlegg.HenlagtDto
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
-import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.personopplysninger.PersonopplysningerService
 import no.nav.familie.klage.repository.findByIdOrThrow
 import no.nav.familie.klage.vurdering.VurderingService
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
-import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import no.nav.familie.kontrakter.felles.objectMapper
-import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.util.Properties
 import java.util.UUID
 
 @Service
@@ -67,6 +65,7 @@ class BrevService(
     private val brevInnholdUtleder: BrevInnholdUtleder,
     private val taskService: TaskService,
     private val brevmottakerUtleder: BrevmottakerUtleder,
+    private val featureToggleService: FeatureToggleService,
 ) {
     fun hentBrev(behandlingId: UUID): Brev = brevRepository.findByIdOrThrow(behandlingId)
 
@@ -275,36 +274,47 @@ class BrevService(
             BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST
         }
 
-    fun opprettJournalførHenleggelsesbrevTask(
+    fun lagHenleggelsesbrevOgOpprettJournalføringstask(
         behandlingId: UUID,
-        henlagt: HenlagtDto,
+        nyeBrevmottakere: List<NyBrevmottakerPerson>,
     ) {
-        validerIkkeSendTrukketKlageBrevPåFeilType(henlagt)
-        validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(behandlingId)
-        val html = lagHenleggelsesbrevHtml(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsak(behandling.fagsakId)
 
-        lagreEllerOppdaterBrev(
-            behandlingId = behandlingId,
-            saksbehandlerHtml = html,
-            fagsak = fagsak,
-        )
+        if (fagsak.fagsystem == Fagsystem.EF) {
+            validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(behandlingId)
+        }
 
-        lagBrevPdf(behandlingId)
+        val html = lagHenleggelsesbrevHtml(behandlingId)
+        val pdf = familieDokumentClient.genererPdfFraHtml(html)
+        val brevmottakere =
+            if (featureToggleService.isEnabled(Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL)) {
+                Brevmottakere(nyeBrevmottakere.map { BrevmottakerPerson.opprettFra(it) })
+            } else {
+                brevmottakerUtleder.utledInitielleBrevmottakere(behandlingId)
+            }
 
-        val journalførBrevTask =
-            Task(
-                type = JournalførBrevTask.TYPE,
-                payload = behandlingId.toString(),
-                properties =
-                    Properties().apply {
-                        this[SAKSBEHANDLER_METADATA_KEY] = SikkerhetContext.hentSaksbehandler(strict = true)
-                        this["eksterFagsakId"] = fagsak.eksternId
-                        this["fagsystem"] = fagsak.fagsystem.name
-                    },
+        val eksisterendeBrev = brevRepository.findByIdOrNull(behandlingId)
+        if (eksisterendeBrev != null) {
+            brevRepository.update(
+                eksisterendeBrev.copy(
+                    saksbehandlerHtml = html,
+                    pdf = Fil(pdf),
+                    mottakere = brevmottakere,
+                ),
             )
-        taskService.save(journalførBrevTask)
+        } else {
+            brevRepository.insert(
+                Brev(
+                    behandlingId = behandlingId,
+                    saksbehandlerHtml = html,
+                    pdf = Fil(pdf),
+                    mottakere = brevmottakere,
+                ),
+            )
+        }
+
+        taskService.save(JournalførBrevTask.opprettTask(fagsak, behandling))
     }
 
     fun genererHenleggelsesbrev(behandlingId: UUID): ByteArray {
@@ -406,12 +416,6 @@ class BrevService(
                 ),
             ),
         )
-
-    private fun validerIkkeSendTrukketKlageBrevPåFeilType(henlagt: HenlagtDto) {
-        feilHvis(henlagt.skalSendeHenleggelsesbrev && henlagt.årsak == HenlagtÅrsak.FEILREGISTRERT) {
-            "Skal ikke sende brev hvis type er ulik trukket tilbake"
-        }
-    }
 
     private fun validerIkkeSendTrukketKlageBrevHvisVergemålEllerFullmakt(ident: UUID) {
         val personopplysninger = personopplysningerService.hentPersonopplysninger(ident)

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
@@ -3,8 +3,10 @@ package no.nav.familie.klage.brevmottaker
 import no.nav.familie.klage.brevmottaker.dto.BrevmottakereDto
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerDto
 import no.nav.familie.klage.brevmottaker.dto.SlettbarBrevmottakerDto
-import no.nav.familie.klage.brevmottaker.dto.tilDomene
-import no.nav.familie.klage.brevmottaker.dto.tilDto
+import no.nav.familie.klage.brevmottaker.dto.tilBrevmottakere
+import no.nav.familie.klage.brevmottaker.dto.tilBrevmottakereDto
+import no.nav.familie.klage.brevmottaker.dto.tilNyBrevmottaker
+import no.nav.familie.klage.brevmottaker.dto.tilSlettbarBrevmottaker
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -35,7 +37,7 @@ class BrevmottakerController(
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
-        return Ressurs.success(brevmottakere.tilDto())
+        return Ressurs.success(brevmottakere.tilBrevmottakereDto())
     }
 
     @PutMapping("/{behandlingId}")
@@ -46,8 +48,8 @@ class BrevmottakerController(
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         brevmottakereDto.valider()
-        val nyeBrevmottakere = brevmottakerService.erstattBrevmottakere(behandlingId, brevmottakereDto.tilDomene())
-        return Ressurs.success(nyeBrevmottakere.tilDto())
+        val nyeBrevmottakere = brevmottakerService.erstattBrevmottakere(behandlingId, brevmottakereDto.tilBrevmottakere())
+        return Ressurs.success(nyeBrevmottakere.tilBrevmottakereDto())
     }
 
     @PostMapping("/{behandlingId}")
@@ -58,9 +60,9 @@ class BrevmottakerController(
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         nyBrevmottakerDto.valider()
-        brevmottakerService.opprettBrevmottaker(behandlingId, nyBrevmottakerDto.tilDomene())
+        brevmottakerService.opprettBrevmottaker(behandlingId, nyBrevmottakerDto.tilNyBrevmottaker())
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
-        return Ressurs.success(brevmottakere.tilDto())
+        return Ressurs.success(brevmottakere.tilBrevmottakereDto())
     }
 
     @DeleteMapping("/{behandlingId}")
@@ -70,9 +72,9 @@ class BrevmottakerController(
     ): Ressurs<BrevmottakereDto> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.DELETE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
-        brevmottakerService.slettBrevmottaker(behandlingId, slettbarBrevmottakerDto.tilDomene())
+        brevmottakerService.slettBrevmottaker(behandlingId, slettbarBrevmottakerDto.tilSlettbarBrevmottaker())
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
-        return Ressurs.success(brevmottakere.tilDto())
+        return Ressurs.success(brevmottakere.tilBrevmottakereDto())
     }
 
     @GetMapping("/initielle/{behandlingId}")
@@ -82,6 +84,6 @@ class BrevmottakerController(
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         val brevmottakere = brevmottakerService.utledInitielleBrevmottakere(behandlingId)
-        return Ressurs.success(brevmottakere.tilDto())
+        return Ressurs.success(brevmottakere.tilBrevmottakereDto())
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.klage.brevmottaker
 
 import jakarta.transaction.Transactional
 import no.nav.familie.klage.brevmottaker.domain.Brevmottaker
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
 import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.brevmottaker.domain.NyBrevmottaker
 import no.nav.familie.klage.brevmottaker.domain.SlettbarBrevmottaker
@@ -39,4 +40,6 @@ class BrevmottakerService(
     }
 
     fun utledInitielleBrevmottakere(behandlingId: UUID): Brevmottakere = brevmottakerUtleder.utledInitielleBrevmottakere(behandlingId)
+
+    fun utledBrevmottakerBrukerFraBehandling(behandlingId: UUID): BrevmottakerPersonMedIdent = brevmottakerUtleder.utledBrevmottakerBrukerFraBehandling(behandlingId)
 }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtleder.kt
@@ -13,19 +13,19 @@ class BrevmottakerUtleder(
     private val fagsakService: FagsakService,
     private val personopplysningerService: PersonopplysningerService,
 ) {
-    fun utledInitielleBrevmottakere(behandlingId: UUID): Brevmottakere {
+    fun utledInitielleBrevmottakere(behandlingId: UUID): Brevmottakere =
+        Brevmottakere(
+            personer = listOf(utledBrevmottakerBrukerFraBehandling(behandlingId)),
+            organisasjoner = emptyList(),
+        )
+
+    fun utledBrevmottakerBrukerFraBehandling(behandlingId: UUID): BrevmottakerPersonMedIdent {
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         val personopplysninger = personopplysningerService.hentPersonopplysninger(behandlingId)
-        return Brevmottakere(
-            personer =
-                listOf(
-                    BrevmottakerPersonMedIdent(
-                        personIdent = fagsak.hentAktivIdent(),
-                        navn = personopplysninger.navn,
-                        mottakerRolle = MottakerRolle.BRUKER,
-                    ),
-                ),
-            organisasjoner = emptyList(),
+        return BrevmottakerPersonMedIdent(
+            personIdent = fagsak.hentAktivIdent(),
+            navn = personopplysninger.navn,
+            mottakerRolle = MottakerRolle.BRUKER,
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/Brevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/Brevmottaker.kt
@@ -14,6 +14,14 @@ sealed interface Brevmottaker
 sealed interface BrevmottakerPerson : Brevmottaker {
     val navn: String
     val mottakerRolle: MottakerRolle
+
+    companion object {
+        fun opprettFra(nyBrevmottakerPerson: NyBrevmottakerPerson): BrevmottakerPerson =
+            when (nyBrevmottakerPerson) {
+                is NyBrevmottakerPersonMedIdent -> BrevmottakerPersonMedIdent.opprettFra(nyBrevmottakerPerson)
+                is NyBrevmottakerPersonUtenIdent -> BrevmottakerPersonUtenIdent.opprettFra(UUID.randomUUID(), nyBrevmottakerPerson)
+            }
+    }
 }
 
 data class BrevmottakerOrganisasjon(
@@ -27,7 +35,18 @@ data class BrevmottakerPersonMedIdent(
     val personIdent: String,
     override val mottakerRolle: MottakerRolle,
     override val navn: String,
-) : BrevmottakerPerson
+) : BrevmottakerPerson {
+    companion object {
+        fun opprettFra(
+            nyBrevmottakerPersonMedIdent: NyBrevmottakerPersonMedIdent,
+        ): BrevmottakerPersonMedIdent =
+            BrevmottakerPersonMedIdent(
+                personIdent = nyBrevmottakerPersonMedIdent.personIdent,
+                mottakerRolle = nyBrevmottakerPersonMedIdent.mottakerRolle,
+                navn = nyBrevmottakerPersonMedIdent.navn,
+            )
+    }
+}
 
 @JsonDeserialize(`as` = BrevmottakerPersonUtenIdent::class)
 data class BrevmottakerPersonUtenIdent(
@@ -40,7 +59,7 @@ data class BrevmottakerPersonUtenIdent(
     val poststed: String?,
     val landkode: String,
 ) : BrevmottakerPerson {
-    companion object Fabrikk {
+    companion object {
         fun opprettFra(
             id: UUID = UUID.randomUUID(),
             nyBrevmottakerPersonUtenIdent: NyBrevmottakerPersonUtenIdent,

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottaker.kt
@@ -19,35 +19,17 @@ data class NyBrevmottakerPersonUtenIdent(
     val landkode: String,
 ) : NyBrevmottakerPerson {
     init {
-        if (landkode.length != 2) {
-            throw IllegalStateException("Ugyldig landkode: $landkode.")
-        }
-        if (navn.isBlank()) {
-            throw IllegalStateException("Navn kan ikke være tomt.")
-        }
-        if (adresselinje1.isBlank()) {
-            throw IllegalStateException("Adresselinje1 kan ikke være tomt.")
-        }
+        require(landkode.length == 2) { "Ugyldig landkode: $landkode." }
+        require(navn.isNotBlank()) { "Navn kan ikke være tomt." }
+        require(adresselinje1.isNotBlank()) { "Adresselinje1 kan ikke være tomt." }
         if (landkode == LANDKODE_NO) {
-            if (postnummer.isNullOrBlank()) {
-                throw IllegalStateException("Når landkode er $LANDKODE_NO (Norge) må postnummer være satt.")
-            }
-            if (poststed.isNullOrBlank()) {
-                throw IllegalStateException("Når landkode er $LANDKODE_NO (Norge) må poststed være satt.")
-            }
-            if (postnummer.length != 4 || !postnummer.all { it.isDigit() }) {
-                throw IllegalStateException("Postnummer må være 4 siffer.")
-            }
-            if (mottakerRolle == MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE) {
-                throw IllegalStateException("Bruker med utenlandsk adresse kan ikke ha landkode $LANDKODE_NO.")
-            }
+            require(!postnummer.isNullOrBlank()) { "Når landkode er $LANDKODE_NO (Norge) må postnummer være satt." }
+            require(!poststed.isNullOrBlank()) { "Når landkode er $LANDKODE_NO (Norge) må poststed være satt." }
+            require(postnummer.length == 4 && postnummer.all { it.isDigit() }) { "Postnummer må være 4 siffer." }
+            require(mottakerRolle != MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE) { "Bruker med utenlandsk adresse kan ikke ha landkode $LANDKODE_NO." }
         } else {
-            if (!postnummer.isNullOrBlank()) {
-                throw IllegalStateException("Ved utenlandsk landkode må postnummer settes i adresselinje 1.")
-            }
-            if (!poststed.isNullOrBlank()) {
-                throw IllegalStateException("Ved utenlandsk landkode må poststed settes i adresselinje 1.")
-            }
+            require(postnummer.isNullOrBlank()) { "Ved utenlandsk landkode må postnummer settes i adresselinje 1." }
+            require(poststed.isNullOrBlank()) { "Ved utenlandsk landkode må poststed settes i adresselinje 1." }
         }
     }
 }
@@ -58,12 +40,8 @@ data class NyBrevmottakerPersonMedIdent(
     override val navn: String,
 ) : NyBrevmottakerPerson {
     init {
-        if (personIdent.isBlank()) {
-            throw IllegalStateException("Personident kan ikke være blank.")
-        }
-        if (navn.isBlank()) {
-            throw IllegalStateException("Navn kan ikke være blank.")
-        }
+        require(personIdent.isNotBlank()) { "Personident kan ikke være blank." }
+        require(navn.isNotBlank()) { "Navn kan ikke være blank." }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottaker.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottaker.kt
@@ -4,15 +4,20 @@ private const val LANDKODE_NO = "NO"
 
 sealed interface NyBrevmottaker
 
+sealed interface NyBrevmottakerPerson : NyBrevmottaker {
+    val mottakerRolle: MottakerRolle
+    val navn: String
+}
+
 data class NyBrevmottakerPersonUtenIdent(
-    val mottakerRolle: MottakerRolle,
-    val navn: String,
+    override val mottakerRolle: MottakerRolle,
+    override val navn: String,
     val adresselinje1: String,
     val adresselinje2: String? = null,
     val postnummer: String?,
     val poststed: String?,
     val landkode: String,
-) : NyBrevmottaker {
+) : NyBrevmottakerPerson {
     init {
         if (landkode.length != 2) {
             throw IllegalStateException("Ugyldig landkode: $landkode.")
@@ -49,9 +54,18 @@ data class NyBrevmottakerPersonUtenIdent(
 
 data class NyBrevmottakerPersonMedIdent(
     val personIdent: String,
-    val mottakerRolle: MottakerRolle,
-    val navn: String,
-) : NyBrevmottaker
+    override val mottakerRolle: MottakerRolle,
+    override val navn: String,
+) : NyBrevmottakerPerson {
+    init {
+        if (personIdent.isBlank()) {
+            throw IllegalStateException("Personident kan ikke være blank.")
+        }
+        if (navn.isBlank()) {
+            throw IllegalStateException("Navn kan ikke være blank.")
+        }
+    }
+}
 
 data class NyBrevmottakerOrganisasjon(
     val organisasjonsnummer: String,

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/BrevmottakereDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/BrevmottakereDto.kt
@@ -34,13 +34,13 @@ data class BrevmottakereDto(
     }
 }
 
-fun Brevmottakere.tilDto() =
+fun Brevmottakere.tilBrevmottakereDto() =
     BrevmottakereDto(
         personer = this.personer,
         organisasjoner = this.organisasjoner,
     )
 
-fun BrevmottakereDto.tilDomene() =
+fun BrevmottakereDto.tilBrevmottakere() =
     Brevmottakere(
         personer = this.personer,
         organisasjoner = this.organisasjoner,

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDto.kt
@@ -30,48 +30,22 @@ sealed interface NyBrevmottakerDto {
     }
 }
 
+fun NyBrevmottakerDto.tilNyBrevmottaker(): NyBrevmottaker =
+    when (this) {
+        is NyBrevmottakerOrganisasjonDto -> this.tilNyBrevmottakerOrganisasjon()
+        is NyBrevmottakerPersonMedIdentDto -> this.tilNyBrevmottakerPersonMedIdent()
+        is NyBrevmottakerPersonUtenIdentDto -> this.tilNyBrevmottakerPersonUtenIdent()
+    }
+
 sealed interface NyBrevmottakerPersonDto : NyBrevmottakerDto {
     val mottakerRolle: MottakerRolle
     val navn: String
 }
 
-fun NyBrevmottakerPersonDto.tilDomene(): NyBrevmottakerPerson =
+fun NyBrevmottakerPersonDto.tilNyBrevmottakerPerson(): NyBrevmottakerPerson =
     when (this) {
-        is NyBrevmottakerPersonMedIdentDto ->
-            NyBrevmottakerPersonMedIdent(
-                personIdent = personIdent,
-                mottakerRolle = mottakerRolle,
-                navn = navn,
-            )
-
-        is NyBrevmottakerPersonUtenIdentDto -> {
-            NyBrevmottakerPersonUtenIdent(
-                mottakerRolle = mottakerRolle,
-                navn = navn,
-                adresselinje1 = adresselinje1,
-                adresselinje2 = adresselinje2,
-                postnummer = postnummer,
-                poststed = poststed,
-                landkode = landkode,
-            )
-        }
-    }
-
-fun NyBrevmottakerDto.tilDomene(): NyBrevmottaker =
-    when (this) {
-        is NyBrevmottakerOrganisasjonDto -> {
-            NyBrevmottakerOrganisasjon(
-                organisasjonsnummer = organisasjonsnummer,
-                organisasjonsnavn = organisasjonsnavn,
-                navnHosOrganisasjon = navnHosOrganisasjon,
-            )
-        }
-
-        is NyBrevmottakerPersonMedIdentDto,
-        is NyBrevmottakerPersonUtenIdentDto,
-        -> {
-            this.tilDomene()
-        }
+        is NyBrevmottakerPersonMedIdentDto -> this.tilNyBrevmottakerPersonMedIdent()
+        is NyBrevmottakerPersonUtenIdentDto -> this.tilNyBrevmottakerPersonUtenIdent()
     }
 
 @JsonDeserialize(`as` = NyBrevmottakerPersonUtenIdentDto::class)
@@ -124,6 +98,17 @@ data class NyBrevmottakerPersonUtenIdentDto(
     }
 }
 
+fun NyBrevmottakerPersonUtenIdentDto.tilNyBrevmottakerPersonUtenIdent(): NyBrevmottakerPersonUtenIdent =
+    NyBrevmottakerPersonUtenIdent(
+        mottakerRolle = mottakerRolle,
+        navn = navn,
+        adresselinje1 = adresselinje1,
+        adresselinje2 = adresselinje2,
+        postnummer = postnummer,
+        poststed = poststed,
+        landkode = landkode,
+    )
+
 @JsonDeserialize(`as` = NyBrevmottakerPersonMedIdentDto::class)
 data class NyBrevmottakerPersonMedIdentDto(
     val personIdent: String,
@@ -145,6 +130,13 @@ data class NyBrevmottakerPersonMedIdentDto(
             brevmottakerPersonMedIdent.navn == this.navn
 }
 
+fun NyBrevmottakerPersonMedIdentDto.tilNyBrevmottakerPersonMedIdent(): NyBrevmottakerPersonMedIdent =
+    NyBrevmottakerPersonMedIdent(
+        personIdent = personIdent,
+        mottakerRolle = mottakerRolle,
+        navn = navn,
+    )
+
 @JsonDeserialize(`as` = NyBrevmottakerOrganisasjonDto::class)
 data class NyBrevmottakerOrganisasjonDto(
     val organisasjonsnummer: String,
@@ -158,6 +150,13 @@ data class NyBrevmottakerOrganisasjonDto(
         // Do nothing...
     }
 }
+
+fun NyBrevmottakerOrganisasjonDto.tilNyBrevmottakerOrganisasjon(): NyBrevmottakerOrganisasjon =
+    NyBrevmottakerOrganisasjon(
+        organisasjonsnummer = organisasjonsnummer,
+        organisasjonsnavn = organisasjonsnavn,
+        navnHosOrganisasjon = navnHosOrganisasjon,
+    )
 
 class NyBrevmottakerDtoDeserializer : JsonDeserializer<NyBrevmottakerDto>() {
     override fun deserialize(

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDto.kt
@@ -23,7 +23,7 @@ sealed interface SlettbarBrevmottakerDto {
     }
 }
 
-fun SlettbarBrevmottakerDto.tilDomene(): SlettbarBrevmottaker =
+fun SlettbarBrevmottakerDto.tilSlettbarBrevmottaker(): SlettbarBrevmottaker =
     when (this) {
         is SlettbarBrevmottakerOrganisasjonDto -> SlettbarBrevmottakerOrganisasjon(organisasjonsnummer)
         is SlettbarBrevmottakerPersonMedIdentDto -> SlettbarBrevmottakerPersonMedIdent(personIdent)

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
@@ -218,6 +218,7 @@ class JournalførBrevTask(
                 properties =
                     Properties().apply {
                         this[SAKSBEHANDLER_METADATA_KEY] = SikkerhetContext.hentSaksbehandler(strict = true)
+                        // TODO : Endre "eksterFagsakId" til "eksternFagsakId"
                         this["eksterFagsakId"] = fagsak.eksternId
                         this["fagsystem"] = fagsak.fagsystem.name
                     },

--- a/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/klage/distribusjon/JournalførBrevTask.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.klage.distribusjon
 
 import no.nav.familie.klage.behandling.BehandlingService
+import no.nav.familie.klage.behandling.domain.Behandling
 import no.nav.familie.klage.brev.BrevService
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brev.domain.BrevmottakereJournalposter
@@ -15,9 +16,11 @@ import no.nav.familie.klage.distribusjon.JournalføringUtil.mapBrevmottakerJourn
 import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpost
 import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpostMedIdent
 import no.nav.familie.klage.distribusjon.domain.BrevmottakerJournalpostUtenIdent
+import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.felles.util.TaskMetadata.SAKSBEHANDLER_METADATA_KEY
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle.SKAL_BRUKE_NY_LØYPE_FOR_JOURNALFØRING
+import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.klage.personopplysninger.pdl.logger
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -25,6 +28,7 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.stereotype.Service
+import java.util.Properties
 import java.util.UUID
 
 @Service
@@ -203,5 +207,20 @@ class JournalførBrevTask(
 
     companion object {
         const val TYPE = "journalførBrevTask"
+
+        fun opprettTask(
+            fagsak: Fagsak,
+            behandling: Behandling,
+        ): Task =
+            Task(
+                type = TYPE,
+                payload = behandling.id.toString(),
+                properties =
+                    Properties().apply {
+                        this[SAKSBEHANDLER_METADATA_KEY] = SikkerhetContext.hentSaksbehandler(strict = true)
+                        this["eksterFagsakId"] = fagsak.eksternId
+                        this["fagsystem"] = fagsak.fagsystem.name
+                    },
+            )
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenlagtDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenlagtDto.kt
@@ -1,8 +1,0 @@
-package no.nav.familie.klage.henlegg
-
-import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
-
-data class HenlagtDto(
-    val årsak: HenlagtÅrsak,
-    val skalSendeHenleggelsesbrev: Boolean = false,
-)

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingController.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.klage.henlegg
 
 import no.nav.familie.klage.brev.BrevService
-import no.nav.familie.klage.brevmottaker.dto.tilDomene
+import no.nav.familie.klage.brevmottaker.dto.tilNyBrevmottakerPerson
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -39,7 +39,7 @@ class HenleggBehandlingController(
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
         if (henleggBehandlingDto.skalSendeHenleggelsesbrev) {
-            val nyeBrevmottakere = henleggBehandlingDto.nyeBrevmottakere.map { it.tilDomene() }
+            val nyeBrevmottakere = henleggBehandlingDto.nyeBrevmottakere.map { it.tilNyBrevmottakerPerson() }
             brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(behandlingId, nyeBrevmottakere)
         }
         return Ressurs.success(henleggBehandlingService.henleggBehandling(behandlingId, henleggBehandlingDto.årsak))

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingController.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.klage.henlegg
 
 import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.dto.tilDomene
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -21,19 +24,25 @@ import java.util.UUID
 class HenleggBehandlingController(
     private val tilgangService: TilgangService,
     private val henleggBehandlingService: HenleggBehandlingService,
+    private val henleggBehandlingValidator: HenleggBehandlingValidator,
     private val brevService: BrevService,
 ) {
+    private val logger: Logger = LoggerFactory.getLogger(HenleggBehandlingController::class.java)
+
     @PostMapping("{behandlingId}/henlegg")
     fun henleggBehandling(
         @PathVariable behandlingId: UUID,
-        @RequestBody henlegg: HenlagtDto,
+        @RequestBody henleggBehandlingDto: HenleggBehandlingDto,
     ): Ressurs<Unit> {
+        logger.info("Henlegger behandling=$behandlingId")
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
-        if (henlegg.skalSendeHenleggelsesbrev) {
-            brevService.opprettJournalførHenleggelsesbrevTask(behandlingId, henlegg)
+        henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
+        if (henleggBehandlingDto.skalSendeHenleggelsesbrev) {
+            val nyeBrevmottakere = henleggBehandlingDto.nyeBrevmottakere.map { it.tilDomene() }
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(behandlingId, nyeBrevmottakere)
         }
-        return Ressurs.success(henleggBehandlingService.henleggBehandling(behandlingId, henlegg))
+        return Ressurs.success(henleggBehandlingService.henleggBehandling(behandlingId, henleggBehandlingDto.årsak))
     }
 
     @GetMapping("/{behandlingId}/henlegg/brev/forhandsvisning")
@@ -42,8 +51,6 @@ class HenleggBehandlingController(
     ): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
-        return henleggBrevRessurs(behandlingId)
+        return Ressurs.success(brevService.genererHenleggelsesbrev(behandlingId))
     }
-
-    private fun henleggBrevRessurs(behandlingId: UUID) = Ressurs.success(brevService.genererHenleggelsesbrev(behandlingId))
 }

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingDto.kt
@@ -1,0 +1,55 @@
+package no.nav.familie.klage.henlegg
+
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerDto
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonDto
+import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonMedIdentDto
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+
+data class HenleggBehandlingDto(
+    val årsak: HenlagtÅrsak,
+    val skalSendeHenleggelsesbrev: Boolean = false,
+    val nyeBrevmottakere: List<NyBrevmottakerPersonDto> = emptyList(),
+) {
+    fun valider() {
+        if (årsak == HenlagtÅrsak.FEILREGISTRERT && skalSendeHenleggelsesbrev) {
+            throw ApiFeil.badRequest("Kan ikke sende henleggelsesbrev når årsak er ${HenlagtÅrsak.FEILREGISTRERT}.")
+        }
+
+        if (skalSendeHenleggelsesbrev && nyeBrevmottakere.isEmpty()) {
+            throw ApiFeil.badRequest("Forventer minst en brevmottaker.")
+        }
+
+        if (nyeBrevmottakere.size > 2) {
+            throw ApiFeil.badRequest("Forventer ikke mer enn 2 brevmottakere.")
+        }
+
+        if (nyeBrevmottakere.distinct().size != nyeBrevmottakere.size) {
+            throw ApiFeil.badRequest("Forventer ingen duplikate mottaker roller.")
+        }
+
+        val mottakerRoller = nyeBrevmottakere.map { it.mottakerRolle }
+        if (mottakerRoller.containsAll(setOf(MottakerRolle.BRUKER, MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE))) {
+            throw ApiFeil.badRequest("${MottakerRolle.BRUKER} kan ikke kombineres med ${MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE}.")
+        }
+
+        if (mottakerRoller.contains(MottakerRolle.DØDSBO) && mottakerRoller.size > 1) {
+            throw ApiFeil.badRequest("${MottakerRolle.DØDSBO} kan ikke kombineres med flere mottaker roller.")
+        }
+
+        nyeBrevmottakere.forEach(NyBrevmottakerDto::valider)
+    }
+
+    fun finnNyBrevmottakerBruker(): NyBrevmottakerPersonMedIdentDto? {
+        val brevmottakerBruker =
+            nyeBrevmottakere
+                .filterIsInstance<NyBrevmottakerPersonMedIdentDto>()
+                .filter { it.mottakerRolle == MottakerRolle.BRUKER }
+        if (brevmottakerBruker.size > 1) {
+            throw Feil("Forventer ikke mer enn 1 brevmottaker med mottaker rolle ${MottakerRolle.BRUKER}.")
+        }
+        return brevmottakerBruker.singleOrNull()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.klage.oppgave.OppgaveTaskService
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.BehandlingStatus.FERDIGSTILT
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -34,7 +35,7 @@ class HenleggBehandlingService(
     @Transactional
     fun henleggBehandling(
         behandlingId: UUID,
-        henlagt: HenlagtDto,
+        henlagtÅrsak: HenlagtÅrsak,
     ) {
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
@@ -43,7 +44,7 @@ class HenleggBehandlingService(
 
         val henlagtBehandling =
             behandling.copy(
-                henlagtÅrsak = henlagt.årsak,
+                henlagtÅrsak = henlagtÅrsak,
                 resultat = BehandlingResultat.HENLAGT,
                 steg = BEHANDLING_FERDIGSTILT,
                 status = FERDIGSTILT,

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidator.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidator.kt
@@ -32,7 +32,7 @@ class HenleggBehandlingValidator(
         val erBrevmottakerBrukerLik = brevmottakerBrukerFraDto != null && brevmottakerBrukerFraDto.erLik(brevmottakerBrukerFraBehandling)
 
         if (brevmottakerBrukerFraDto != null && !erBrevmottakerBrukerLik) {
-            throw ApiFeil.badRequest("Bruker fra dto er ulik bruker utledet fra behandlingen.")
+            throw ApiFeil.badRequest("Innsendt bruker samsvarer ikke med bruker utledet fra behandlingen.")
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidator.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidator.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.klage.henlegg
+
+import no.nav.familie.klage.brevmottaker.BrevmottakerService
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.feilHvis
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class HenleggBehandlingValidator(
+    private val brevmottakerService: BrevmottakerService,
+    private val featureToggleService: FeatureToggleService,
+) {
+    fun validerHenleggBehandlingDto(
+        behandlingId: UUID,
+        henleggBehandlingDto: HenleggBehandlingDto,
+    ) {
+        if (!featureToggleService.isEnabled(Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL)) {
+            feilHvis(henleggBehandlingDto.skalSendeHenleggelsesbrev && henleggBehandlingDto.årsak == HenlagtÅrsak.FEILREGISTRERT) {
+                "Skal ikke sende brev hvis type er ulik trukket tilbake"
+            }
+            return
+        }
+
+        henleggBehandlingDto.valider()
+
+        val brevmottakerBrukerFraDto = henleggBehandlingDto.finnNyBrevmottakerBruker()
+        val brevmottakerBrukerFraBehandling = brevmottakerService.utledBrevmottakerBrukerFraBehandling(behandlingId)
+        val erBrevmottakerBrukerLik = brevmottakerBrukerFraDto != null && brevmottakerBrukerFraDto.erLik(brevmottakerBrukerFraBehandling)
+
+        if (brevmottakerBrukerFraDto != null && !erBrevmottakerBrukerLik) {
+            throw ApiFeil.badRequest("Bruker fra dto er ulik bruker utledet fra behandlingen.")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevServiceTest.kt
@@ -6,41 +6,47 @@ import io.mockk.slot
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.brev.domain.Brev
 import no.nav.familie.klage.brevmottaker.BrevmottakerUtleder
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonMedIdent
+import no.nav.familie.klage.brevmottaker.domain.BrevmottakerPersonUtenIdent
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.felles.domain.Fil
 import no.nav.familie.klage.formkrav.FormService
-import no.nav.familie.klage.henlegg.HenlagtDto
 import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.personopplysninger.PersonopplysningerService
-import no.nav.familie.klage.personopplysninger.dto.FullmaktDto
-import no.nav.familie.klage.personopplysninger.dto.Kjønn
-import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
-import no.nav.familie.klage.personopplysninger.dto.VergemålDto
 import no.nav.familie.klage.testutil.BrukerContextUtil
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.klage.testutil.DtoTestUtil
 import no.nav.familie.klage.vurdering.VurderingService
-import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
-import java.util.UUID.randomUUID
 
 class BrevServiceTest {
-    private val brevClient = mockk<BrevClient>(relaxed = true)
+    private val brevClient = mockk<BrevClient>()
     private val brevRepository = mockk<BrevRepository>()
-    private val behandlingService = mockk<BehandlingService>(relaxed = true)
-    private val familieDokumentClient = mockk<FamilieDokumentClient>(relaxed = true)
-    private val brevsignaturService = mockk<BrevsignaturService>(relaxed = true)
-    private val fagsakService = mockk<FagsakService>(relaxed = true)
-    private val formService = mockk<FormService>(relaxed = true)
-    private val vurderingService = mockk<VurderingService>(relaxed = true)
-    private val personopplysningerService = mockk<PersonopplysningerService>(relaxed = true)
-    private val brevInnholdUtleder = mockk<BrevInnholdUtleder>(relaxed = true)
-    private val taskService = mockk<TaskService>(relaxed = true)
-    private val brevmottakerUtleder = mockk<BrevmottakerUtleder>(relaxed = true)
+    private val behandlingService = mockk<BehandlingService>()
+    private val familieDokumentClient = mockk<FamilieDokumentClient>()
+    private val brevsignaturService = mockk<BrevsignaturService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val formService = mockk<FormService>()
+    private val vurderingService = mockk<VurderingService>()
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val brevInnholdUtleder = mockk<BrevInnholdUtleder>()
+    private val taskService = mockk<TaskService>()
+    private val brevmottakerUtleder = mockk<BrevmottakerUtleder>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val brevService =
         BrevService(
@@ -56,139 +62,594 @@ class BrevServiceTest {
             brevInnholdUtleder = brevInnholdUtleder,
             taskService = taskService,
             brevmottakerUtleder = brevmottakerUtleder,
+            featureToggleService = featureToggleService,
         )
 
+    @BeforeEach
+    fun setup() {
+        BrukerContextUtil.mockBrukerContext()
+        every { featureToggleService.isEnabled(any()) } returns true
+    }
+
     @AfterEach
-    internal fun tearDown() {
+    fun tearDown() {
         BrukerContextUtil.clearBrukerContext()
     }
 
-    @Test
-    internal fun `Skal kaste feil hvis feilregistrert og send brev er true`() {
-        val exception =
-            assertThrows<Feil> {
-                brevService.opprettJournalførHenleggelsesbrevTask(
-                    randomUUID(),
-                    HenlagtDto(HenlagtÅrsak.FEILREGISTRERT, true),
-                )
-            }
-        assertThat(exception.message).isEqualTo("Skal ikke sende brev hvis type er ulik trukket tilbake")
-    }
+    @Nested
+    inner class LagHenleggelsesbrevOgOpprettJournalføringstask {
+        @Test
+        fun `skal kaste feil hvis verge for fagsystem EF`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.SKOLEPENGER)
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
 
-    @Test
-    internal fun `Skal kaste feil hvis bruker har fullmakt`() {
-        mocckHentPersonopplysningerMedFullmakt()
-        val exception =
-            assertThrows<Feil> {
-                brevService.opprettJournalførHenleggelsesbrevTask(
-                    randomUUID(),
-                    HenlagtDto(HenlagtÅrsak.TRUKKET_TILBAKE, true),
-                )
-            }
-        assertThat(exception.message).isEqualTo("Skal ikke sende brev hvis person er tilknyttet vergemål eller fullmakt")
-    }
-
-    @Test
-    internal fun `Skal ikke kaste feil hvis bruker har fullmakt som har utgått`() {
-        BrukerContextUtil.mockBrukerContext()
-        mocckHentPersonopplysningerMedFullmaktEnDagSiden()
-
-        val taskSlot = slot<no.nav.familie.prosessering.domene.Task>()
-        val behandlingId = randomUUID()
-
-        every { brevRepository.findByIdOrNull(any()) } returns
-            Brev(
-                behandlingId = behandlingId,
-                saksbehandlerHtml = "someHtml",
-                mottakere = null,
-            )
-        every { brevRepository.insert(any()) } answers { firstArg() }
-        every { brevRepository.update(any()) } answers { firstArg() }
-        every { taskService.save(capture(taskSlot)) } answers { firstArg() }
-
-        brevService.opprettJournalførHenleggelsesbrevTask(
-            behandlingId,
-            HenlagtDto(årsak = HenlagtÅrsak.TRUKKET_TILBAKE, skalSendeHenleggelsesbrev = true),
-        )
-
-        assertThat(taskSlot.isCaptured).isTrue()
-        assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
-        assertThat(taskSlot.captured.payload).isEqualTo(behandlingId.toString())
-    }
-
-    @Test
-    internal fun `Skal kaste feil hvis bruker har Verge`() {
-        mockkHentPersonopplysningerMedVergemål()
-        val exception =
-            assertThrows<Feil> {
-                brevService.opprettJournalførHenleggelsesbrevTask(
-                    randomUUID(),
-                    HenlagtDto(årsak = HenlagtÅrsak.TRUKKET_TILBAKE, skalSendeHenleggelsesbrev = true),
-                )
-            }
-        assertThat(exception.message).isEqualTo("Skal ikke sende brev hvis person er tilknyttet vergemål eller fullmakt")
-    }
-
-    private fun mocckHentPersonopplysningerMedFullmaktEnDagSiden() {
-        every { personopplysningerService.hentPersonopplysninger(any()) } returns
-            dto(
-                fullmakt =
-                    listOf(
-                        FullmaktDto(
-                            gyldigFraOgMed = LocalDate.now().minusDays(2),
-                            gyldigTilOgMed = LocalDate.now().minusDays(1),
-                            navn = "123",
-                            motpartsPersonident = "123",
-                            områder = emptyList(),
+            val personopplysningerDtoMedVergemål =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    vergemål =
+                        listOf(
+                            DtoTestUtil.lagVergemålDto(
+                                navn = "Vergenavn",
+                            ),
                         ),
-                    ),
-            )
-    }
+                )
 
-    private fun mocckHentPersonopplysningerMedFullmakt() {
-        every { personopplysningerService.hentPersonopplysninger(any()) } returns
-            dto(
-                fullmakt =
-                    listOf(
-                        FullmaktDto(
-                            gyldigFraOgMed = LocalDate.now(),
-                            gyldigTilOgMed = null,
-                            navn = "123",
-                            motpartsPersonident = "123",
-                            områder = emptyList(),
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDtoMedVergemål
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                        behandlingId = behandling.id,
+                        nyeBrevmottakere = emptyList(),
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Skal ikke sende brev hvis person er tilknyttet vergemål eller fullmakt")
+        }
+
+        @Test
+        fun `skal kaste feil hvis fullmakt for fagsystem EF`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.SKOLEPENGER)
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val fullmaktDtoSomFortsattLøper =
+                DtoTestUtil.lagFullmaktDto(
+                    gyldigFraOgMed = LocalDate.now().minusDays(1),
+                    gyldigTilOgMed = null,
+                )
+            val personopplysningerDto = DtoTestUtil.lagPersonopplysningerDto(fullmakt = listOf(fullmaktDtoSomFortsattLøper))
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                        behandlingId = behandling.id,
+                        nyeBrevmottakere = emptyList(),
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Skal ikke sende brev hvis person er tilknyttet vergemål eller fullmakt")
+        }
+
+        @Test
+        fun `skal opprette henleggelsesbrev og opprette journalføringstask når toggle er skrudd av for fagsystem EF`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.SKOLEPENGER)
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val personopplysningerDto =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    fullmakt =
+                        listOf(
+                            DtoTestUtil.lagFullmaktDto(
+                                navn = "Navn Navnesen",
+                                gyldigFraOgMed = LocalDate.now().minusDays(2),
+                                gyldigTilOgMed = LocalDate.now().minusDays(1),
+                            ),
                         ),
-                    ),
-            )
-    }
+                )
 
-    private fun mockkHentPersonopplysningerMedVergemål() {
-        every { personopplysningerService.hentPersonopplysninger(any()) } returns
-            dto(
-                vergemål =
-                    listOf(
-                        VergemålDto(
-                            embete = null,
-                            type = null,
-                            motpartsPersonident = null,
-                            navn = null,
-                            omfang = null,
+            val bruker = DomainUtil.lagNyBrevmottakerPersonMedIdent(mottakerRolle = MottakerRolle.BRUKER)
+            val nyeBrevmottakere = listOf(bruker)
+
+            val initielleBrevmottakere =
+                DomainUtil.lagBrevmottakere(
+                    personer =
+                        listOf(
+                            DomainUtil.lagBrevmottakerPersonMedIdent(
+                                personIdent = bruker.personIdent,
+                                mottakerRolle = bruker.mottakerRolle,
+                                navn = bruker.navn,
+                            ),
                         ),
-                    ),
-            )
-    }
+                    organisasjoner = emptyList(),
+                )
 
-    private fun dto(
-        fullmakt: List<FullmaktDto> = emptyList(),
-        vergemål: List<VergemålDto> = emptyList(),
-    ) = PersonopplysningerDto(
-        personIdent = "",
-        navn = "",
-        kjønn = Kjønn.MANN,
-        adressebeskyttelse = null,
-        folkeregisterpersonstatus = null,
-        dødsdato = null,
-        fullmakt = fullmakt,
-        egenAnsatt = false,
-        vergemål = vergemål,
-    )
+            val pdf = ByteArray(0)
+
+            val taskSlot = slot<Task>()
+            val brevSlot = slot<Brev>()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { behandlingService.hentBehandlingDto(behandling.id) } returns DtoTestUtil.lagBehandlingDto(fagsak = fagsak, behandling = behandling)
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+            every { brevsignaturService.lagSignatur(personopplysningerDto, fagsak.fagsystem) } returns DtoTestUtil.lagSignaturDto()
+            every { brevClient.genererHtml(any(), any(), any(), any(), any(), any()) } returns "<html />"
+            every { familieDokumentClient.genererPdfFraHtml(any()) } returns pdf
+            every { brevmottakerUtleder.utledInitielleBrevmottakere(behandling.id) } returns initielleBrevmottakere
+            every { brevRepository.findByIdOrNull(any()) } returns null
+            every { brevRepository.insert(capture(brevSlot)) } answers { firstArg() }
+            every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+            every { featureToggleService.isEnabled(Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL) } returns false
+
+            // Act
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                behandlingId = behandling.id,
+                nyeBrevmottakere = nyeBrevmottakere,
+            )
+
+            // Assert
+            assertThat(brevSlot.isCaptured).isTrue()
+            assertThat(brevSlot.captured.behandlingId).isEqualTo(behandling.id)
+            assertThat(brevSlot.captured.saksbehandlerHtml).isEqualTo("<html />")
+            assertThat(brevSlot.captured.pdf).isEqualTo(Fil(pdf))
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(0),
+            ).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(bruker.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(bruker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(bruker.navn)
+            }
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakereJournalposter).isNull()
+            assertThat(brevSlot.captured.sporbar).isNotNull()
+            assertThat(taskSlot.isCaptured).isTrue()
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(behandling.id.toString())
+        }
+
+        @Test
+        fun `skal oppdatere eksisterende brev til henleggelsesbrev og opprette journalføringstask når toggle er skrudd av for fagsystem EF`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val personopplysningerDto =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    fullmakt =
+                        listOf(
+                            DtoTestUtil.lagFullmaktDto(
+                                navn = "Navn Navnesen",
+                                gyldigFraOgMed = LocalDate.now().minusDays(2),
+                                gyldigTilOgMed = LocalDate.now().minusDays(1),
+                            ),
+                        ),
+                )
+
+            val bruker = DomainUtil.lagNyBrevmottakerPersonMedIdent(mottakerRolle = MottakerRolle.BRUKER)
+            val nyeBrevmottakere = listOf(bruker)
+
+            val initielleBrevmottakere =
+                DomainUtil.lagBrevmottakere(
+                    personer =
+                        listOf(
+                            DomainUtil.lagBrevmottakerPersonMedIdent(
+                                personIdent = bruker.personIdent,
+                                mottakerRolle = bruker.mottakerRolle,
+                                navn = bruker.navn,
+                            ),
+                        ),
+                    organisasjoner = emptyList(),
+                )
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = initielleBrevmottakere)
+
+            val pdf = ByteArray(0)
+
+            val taskSlot = slot<Task>()
+            val brevSlot = slot<Brev>()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { behandlingService.hentBehandlingDto(behandling.id) } returns DtoTestUtil.lagBehandlingDto(fagsak = fagsak, behandling = behandling)
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+            every { brevsignaturService.lagSignatur(personopplysningerDto, fagsak.fagsystem) } returns DtoTestUtil.lagSignaturDto()
+            every { brevClient.genererHtml(any(), any(), any(), any(), any(), any()) } returns "<html />"
+            every { familieDokumentClient.genererPdfFraHtml(any()) } returns pdf
+            every { brevmottakerUtleder.utledInitielleBrevmottakere(behandling.id) } returns initielleBrevmottakere
+            every { brevRepository.findByIdOrNull(any()) } returns brev
+            every { brevRepository.update(capture(brevSlot)) } answers { firstArg() }
+            every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+            every { featureToggleService.isEnabled(Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL) } returns false
+
+            // Act
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                behandlingId = behandling.id,
+                nyeBrevmottakere = nyeBrevmottakere,
+            )
+
+            // Assert
+            assertThat(brevSlot.isCaptured).isTrue()
+            assertThat(brevSlot.captured.behandlingId).isEqualTo(behandling.id)
+            assertThat(brevSlot.captured.saksbehandlerHtml).isEqualTo("<html />")
+            assertThat(brevSlot.captured.pdf).isEqualTo(Fil(pdf))
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(0),
+            ).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(bruker.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(bruker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(bruker.navn)
+            }
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakereJournalposter).isNull()
+            assertThat(brevSlot.captured.sporbar).isNotNull()
+            assertThat(taskSlot.isCaptured).isTrue()
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(behandling.id.toString())
+        }
+
+        @Test
+        fun `skal opprette henleggelsesbrev og opprette journalføringstask for fagsystem BA`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD)
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val personopplysningerDto =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    fullmakt =
+                        listOf(
+                            DtoTestUtil.lagFullmaktDto(
+                                navn = "Navn Navnesen",
+                                gyldigFraOgMed = LocalDate.now().minusDays(2),
+                                gyldigTilOgMed = LocalDate.now().minusDays(1),
+                            ),
+                        ),
+                )
+
+            val bruker = DomainUtil.lagNyBrevmottakerPersonMedIdent(mottakerRolle = MottakerRolle.BRUKER)
+            val verge = DomainUtil.lagNyBrevmottakerPersonUtenIdent(mottakerRolle = MottakerRolle.VERGE)
+            val nyeBrevmottakere = listOf(bruker, verge)
+
+            val initielleBrevmottakere =
+                DomainUtil.lagBrevmottakere(
+                    personer =
+                        listOf(
+                            DomainUtil.lagBrevmottakerPersonMedIdent(
+                                personIdent = bruker.personIdent,
+                                mottakerRolle = bruker.mottakerRolle,
+                                navn = bruker.navn,
+                            ),
+                        ),
+                    organisasjoner = emptyList(),
+                )
+
+            val lagFritekstBrevRequestDto =
+                DtoTestUtil.lagFritekstBrevRequestDto(
+                    personIdent = bruker.personIdent,
+                    navn = bruker.navn,
+                )
+
+            val pdf = ByteArray(0)
+
+            val taskSlot = slot<Task>()
+            val brevSlot = slot<Brev>()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { behandlingService.hentBehandlingDto(behandling.id) } returns DtoTestUtil.lagBehandlingDto(fagsak = fagsak, behandling = behandling)
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+            every { brevsignaturService.lagSignatur(personopplysningerDto, fagsak.fagsystem) } returns DtoTestUtil.lagSignaturDto()
+            every { brevClient.genererHtmlFritekstbrev(any(), any(), any(), any()) } returns "<html />"
+            every { familieDokumentClient.genererPdfFraHtml(any()) } returns pdf
+            every { brevmottakerUtleder.utledInitielleBrevmottakere(behandling.id) } returns initielleBrevmottakere
+            every { brevRepository.findByIdOrNull(any()) } returns null
+            every { brevRepository.insert(capture(brevSlot)) } answers { firstArg() }
+            every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+            every { brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(any(), any(), any()) } returns lagFritekstBrevRequestDto
+
+            // Act
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                behandlingId = behandling.id,
+                nyeBrevmottakere = nyeBrevmottakere,
+            )
+
+            // Assert
+            assertThat(brevSlot.isCaptured).isTrue()
+            assertThat(brevSlot.captured.behandlingId).isEqualTo(behandling.id)
+            assertThat(brevSlot.captured.saksbehandlerHtml).isEqualTo("<html />")
+            assertThat(brevSlot.captured.pdf).isEqualTo(Fil(pdf))
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(2)
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(0),
+            ).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(bruker.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(bruker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(bruker.navn)
+            }
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(1),
+            ).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(verge.mottakerRolle)
+                assertThat(it.navn).isEqualTo(verge.navn)
+                assertThat(it.adresselinje1).isEqualTo(verge.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(verge.adresselinje2)
+                assertThat(it.poststed).isEqualTo(verge.poststed)
+                assertThat(it.postnummer).isEqualTo(verge.postnummer)
+                assertThat(it.landkode).isEqualTo(verge.landkode)
+            }
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakereJournalposter).isNull()
+            assertThat(brevSlot.captured.sporbar).isNotNull()
+            assertThat(taskSlot.isCaptured).isTrue()
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(behandling.id.toString())
+        }
+
+        @Test
+        fun `skal oppdatere eksisterende brev til henleggelsesbrev og opprette journalføringstask for fagsystem BA`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.BARNETRYGD)
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val personopplysningerDto =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    fullmakt =
+                        listOf(
+                            DtoTestUtil.lagFullmaktDto(
+                                navn = "Navn Navnesen",
+                                gyldigFraOgMed = LocalDate.now().minusDays(2),
+                                gyldigTilOgMed = LocalDate.now().minusDays(1),
+                            ),
+                        ),
+                )
+
+            val bruker = DomainUtil.lagNyBrevmottakerPersonMedIdent(mottakerRolle = MottakerRolle.BRUKER)
+            val verge = DomainUtil.lagNyBrevmottakerPersonUtenIdent(mottakerRolle = MottakerRolle.VERGE)
+            val nyeBrevmottakere = listOf(bruker, verge)
+
+            val initielleBrevmottakere =
+                DomainUtil.lagBrevmottakere(
+                    personer =
+                        listOf(
+                            DomainUtil.lagBrevmottakerPersonMedIdent(
+                                personIdent = bruker.personIdent,
+                                mottakerRolle = bruker.mottakerRolle,
+                                navn = bruker.navn,
+                            ),
+                        ),
+                    organisasjoner = emptyList(),
+                )
+
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = initielleBrevmottakere)
+
+            val lagFritekstBrevRequestDto =
+                DtoTestUtil.lagFritekstBrevRequestDto(
+                    personIdent = bruker.personIdent,
+                    navn = bruker.navn,
+                )
+
+            val pdf = ByteArray(0)
+
+            val taskSlot = slot<Task>()
+            val brevSlot = slot<Brev>()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { behandlingService.hentBehandlingDto(behandling.id) } returns DtoTestUtil.lagBehandlingDto(fagsak = fagsak, behandling = behandling)
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+            every { brevsignaturService.lagSignatur(personopplysningerDto, fagsak.fagsystem) } returns DtoTestUtil.lagSignaturDto()
+            every { brevClient.genererHtmlFritekstbrev(any(), any(), any(), any()) } returns "<html />"
+            every { familieDokumentClient.genererPdfFraHtml(any()) } returns pdf
+            every { brevmottakerUtleder.utledInitielleBrevmottakere(behandling.id) } returns initielleBrevmottakere
+            every { brevRepository.findByIdOrNull(any()) } returns brev
+            every { brevRepository.update(capture(brevSlot)) } answers { firstArg() }
+            every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+            every { brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(any(), any(), any()) } returns lagFritekstBrevRequestDto
+
+            // Act
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                behandlingId = behandling.id,
+                nyeBrevmottakere = nyeBrevmottakere,
+            )
+
+            // Assert
+            assertThat(brevSlot.isCaptured).isTrue()
+            assertThat(brevSlot.captured.behandlingId).isEqualTo(behandling.id)
+            assertThat(brevSlot.captured.saksbehandlerHtml).isEqualTo("<html />")
+            assertThat(brevSlot.captured.pdf).isEqualTo(Fil(pdf))
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(2)
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(0),
+            ).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(bruker.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(bruker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(bruker.navn)
+            }
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(1),
+            ).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(verge.mottakerRolle)
+                assertThat(it.navn).isEqualTo(verge.navn)
+                assertThat(it.adresselinje1).isEqualTo(verge.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(verge.adresselinje2)
+                assertThat(it.poststed).isEqualTo(verge.poststed)
+                assertThat(it.postnummer).isEqualTo(verge.postnummer)
+                assertThat(it.landkode).isEqualTo(verge.landkode)
+            }
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakereJournalposter).isNull()
+            assertThat(brevSlot.captured.sporbar).isNotNull()
+            assertThat(taskSlot.isCaptured).isTrue()
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(behandling.id.toString())
+        }
+
+        @Test
+        fun `skal opprette henleggelsesbrev og opprette journalføringstask for fagsystem EF`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak(stønadstype = Stønadstype.SKOLEPENGER)
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val personopplysningerDto =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    fullmakt =
+                        listOf(
+                            DtoTestUtil.lagFullmaktDto(
+                                navn = "Navn Navnesen",
+                                gyldigFraOgMed = LocalDate.now().minusDays(2),
+                                gyldigTilOgMed = LocalDate.now().minusDays(1),
+                            ),
+                        ),
+                )
+
+            val bruker = DomainUtil.lagNyBrevmottakerPersonMedIdent(mottakerRolle = MottakerRolle.BRUKER)
+            val nyeBrevmottakere = listOf(bruker)
+
+            val pdf = ByteArray(0)
+
+            val taskSlot = slot<Task>()
+            val brevSlot = slot<Brev>()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { behandlingService.hentBehandlingDto(behandling.id) } returns DtoTestUtil.lagBehandlingDto(fagsak = fagsak, behandling = behandling)
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+            every { brevsignaturService.lagSignatur(personopplysningerDto, fagsak.fagsystem) } returns DtoTestUtil.lagSignaturDto()
+            every { brevClient.genererHtml(any(), any(), any(), any(), any(), any()) } returns "<html />"
+            every { familieDokumentClient.genererPdfFraHtml(any()) } returns pdf
+            every { brevRepository.findByIdOrNull(any()) } returns null
+            every { brevRepository.insert(capture(brevSlot)) } answers { firstArg() }
+            every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+
+            // Act
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                behandlingId = behandling.id,
+                nyeBrevmottakere = nyeBrevmottakere,
+            )
+
+            // Assert
+            assertThat(brevSlot.isCaptured).isTrue()
+            assertThat(brevSlot.captured.behandlingId).isEqualTo(behandling.id)
+            assertThat(brevSlot.captured.saksbehandlerHtml).isEqualTo("<html />")
+            assertThat(brevSlot.captured.pdf).isEqualTo(Fil(pdf))
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(0),
+            ).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(bruker.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(bruker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(bruker.navn)
+            }
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakereJournalposter).isNull()
+            assertThat(brevSlot.captured.sporbar).isNotNull()
+            assertThat(taskSlot.isCaptured).isTrue()
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(behandling.id.toString())
+        }
+
+        @Test
+        fun `skal oppdatere eksisterende brev til henleggelsesbrev og opprette journalføringstask for fagsystem EF`() {
+            // Arrange
+            val fagsak = DomainUtil.fagsak()
+            val behandling = DomainUtil.behandling(fagsak = fagsak)
+
+            val personopplysningerDto =
+                DtoTestUtil.lagPersonopplysningerDto(
+                    fullmakt =
+                        listOf(
+                            DtoTestUtil.lagFullmaktDto(
+                                navn = "Navn Navnesen",
+                                gyldigFraOgMed = LocalDate.now().minusDays(2),
+                                gyldigTilOgMed = LocalDate.now().minusDays(1),
+                            ),
+                        ),
+                )
+
+            val bruker = DomainUtil.lagNyBrevmottakerPersonMedIdent(mottakerRolle = MottakerRolle.BRUKER)
+            val nyeBrevmottakere = listOf(bruker)
+
+            val initielleBrevmottakere =
+                DomainUtil.lagBrevmottakere(
+                    personer =
+                        listOf(
+                            DomainUtil.lagBrevmottakerPersonMedIdent(
+                                personIdent = bruker.personIdent,
+                                mottakerRolle = bruker.mottakerRolle,
+                                navn = bruker.navn,
+                            ),
+                        ),
+                    organisasjoner = emptyList(),
+                )
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = initielleBrevmottakere)
+
+            val pdf = ByteArray(0)
+
+            val taskSlot = slot<Task>()
+            val brevSlot = slot<Brev>()
+
+            every { behandlingService.hentBehandling(behandling.id) } returns behandling
+            every { behandlingService.hentBehandlingDto(behandling.id) } returns DtoTestUtil.lagBehandlingDto(fagsak = fagsak, behandling = behandling)
+            every { fagsakService.hentFagsak(behandling.fagsakId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(any()) } returns personopplysningerDto
+            every { brevsignaturService.lagSignatur(personopplysningerDto, fagsak.fagsystem) } returns DtoTestUtil.lagSignaturDto()
+            every { brevClient.genererHtml(any(), any(), any(), any(), any(), any()) } returns "<html />"
+            every { familieDokumentClient.genererPdfFraHtml(any()) } returns pdf
+            every { brevRepository.findByIdOrNull(any()) } returns brev
+            every { brevRepository.update(capture(brevSlot)) } answers { firstArg() }
+            every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+
+            // Act
+            brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(
+                behandlingId = behandling.id,
+                nyeBrevmottakere = nyeBrevmottakere,
+            )
+
+            // Assert
+            assertThat(brevSlot.isCaptured).isTrue()
+            assertThat(brevSlot.captured.behandlingId).isEqualTo(behandling.id)
+            assertThat(brevSlot.captured.saksbehandlerHtml).isEqualTo("<html />")
+            assertThat(brevSlot.captured.pdf).isEqualTo(Fil(pdf))
+            assertThat(brevSlot.captured.mottakere?.personer).hasSize(1)
+            assertThat(
+                brevSlot.captured.mottakere
+                    ?.personer
+                    ?.get(0),
+            ).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(bruker.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(bruker.mottakerRolle)
+                assertThat(it.navn).isEqualTo(bruker.navn)
+            }
+            assertThat(brevSlot.captured.mottakere?.organisasjoner).isEmpty()
+            assertThat(brevSlot.captured.mottakereJournalposter).isNull()
+            assertThat(brevSlot.captured.sporbar).isNotNull()
+            assertThat(taskSlot.isCaptured).isTrue()
+            assertThat(taskSlot.captured.type).isEqualTo(JournalførBrevTask.TYPE)
+            assertThat(taskSlot.captured.payload).isEqualTo(behandling.id.toString())
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerServiceTest.kt
@@ -198,4 +198,28 @@ class BrevmottakerServiceTest {
             assertThat(initielleBrevmottakere).isEqualTo(brevmottakere)
         }
     }
+
+    @Nested
+    inner class UtledBrevmottakerBrukerFraBehandling {
+        @Test
+        fun `skal utlede brevmottaker bruker fra behandling`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brevmottakerBruker =
+                BrevmottakerPersonMedIdent(
+                    personIdent = "123",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "Navn Navnesen",
+                )
+
+            every { brevmottakerUtleder.utledBrevmottakerBrukerFraBehandling(behandlingId) } returns brevmottakerBruker
+
+            // Act
+            val brevmottakerFraBehandling = brevmottakerService.utledBrevmottakerBrukerFraBehandling(behandlingId)
+
+            // Assert
+            assertThat(brevmottakerFraBehandling).isEqualTo(brevmottakerBruker)
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerUtlederTest.kt
@@ -48,4 +48,27 @@ class BrevmottakerUtlederTest {
             assertThat(brevmottakere.organisasjoner).isEmpty()
         }
     }
+
+    @Nested
+    inner class UtledBrevmottakerBrukerFraBehandling {
+        @Test
+        fun `skal utlede brevmottaker bruker fra behandling`() {
+            // Arrange
+            val personIdent = "123"
+            val behandlingId = UUID.randomUUID()
+            val fagsak = DomainUtil.fagsak(identer = setOf(PersonIdent(personIdent)))
+            val personopplysninger = DomainUtil.personopplysningerDto(navn = "Navn Navnesen")
+
+            every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak
+            every { personopplysningerService.hentPersonopplysninger(behandlingId) } returns personopplysninger
+
+            // Act
+            val brevmottakerBruker = brevmottakerUtleder.utledBrevmottakerBrukerFraBehandling(behandlingId)
+
+            // Assert
+            assertThat(brevmottakerBruker.personIdent).isEqualTo(personIdent)
+            assertThat(brevmottakerBruker.navn).isEqualTo("Navn Navnesen")
+            assertThat(brevmottakerBruker.mottakerRolle).isEqualTo(MottakerRolle.BRUKER)
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/BrevmottakerKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/BrevmottakerKtTest.kt
@@ -9,6 +9,63 @@ import java.util.UUID
 
 class BrevmottakerKtTest {
     @Nested
+    inner class BrevmottakerPersonTest {
+        @Test
+        fun `skal opprette BrevmottakerPerson fra NyBrevmottakerPersonMedIdent`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdent = DomainUtil.lagNyBrevmottakerPersonMedIdent()
+
+            // Act
+            val brevmottakerPerson = BrevmottakerPerson.opprettFra(nyBrevmottakerPersonMedIdent)
+
+            // Assert
+            assertThat(brevmottakerPerson).isInstanceOfSatisfying(BrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(nyBrevmottakerPersonMedIdent.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonMedIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonMedIdent.navn)
+            }
+        }
+
+        @Test
+        fun `skal opprette BrevmottakerPerson fra NyBrevmottakerPersonUtenIdent`() {
+            // Arrange
+            val nyBrevmottakerPersonUtenIdent = DomainUtil.lagNyBrevmottakerPersonUtenIdent()
+
+            // Act
+            val brevmottakerPerson = BrevmottakerPerson.opprettFra(nyBrevmottakerPersonUtenIdent)
+
+            // Assert
+            assertThat(brevmottakerPerson).isInstanceOfSatisfying(BrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.id).isNotNull()
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdent.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdent.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdent.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdent.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdent.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdent.landkode)
+            }
+        }
+    }
+
+    @Nested
+    inner class BrevmottakerPersonMedIdentTest {
+        @Test
+        fun `skal opprette BrevmottakerPersonMedIdent fra NyBrevmottakerPersonMedIdent`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdent = DomainUtil.lagNyBrevmottakerPersonMedIdent()
+
+            // Act
+            val brevmottakerPersonMedIdent = BrevmottakerPersonMedIdent.opprettFra(nyBrevmottakerPersonMedIdent)
+
+            // Assert
+            assertThat(brevmottakerPersonMedIdent.personIdent).isEqualTo(nyBrevmottakerPersonMedIdent.personIdent)
+            assertThat(brevmottakerPersonMedIdent.navn).isEqualTo(nyBrevmottakerPersonMedIdent.navn)
+            assertThat(brevmottakerPersonMedIdent.mottakerRolle).isEqualTo(nyBrevmottakerPersonMedIdent.mottakerRolle)
+        }
+    }
+
+    @Nested
     inner class BrevmottakerPersonUtenIdentTest {
         @Test
         fun `skal opprette BrevmottakerPersonUtenIdent fra NyBrevmottakerPersonUtenIdent med oppgitt ID`() {

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottakerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottakerTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.klage.testutil.DomainUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
 class NyBrevmottakerTest {
@@ -198,6 +199,49 @@ class NyBrevmottakerTest {
             assertThat(nyBrevmottaker.postnummer).isEqualTo("0010")
             assertThat(nyBrevmottaker.poststed).isEqualTo("Oslo")
             assertThat(nyBrevmottaker.landkode).isEqualTo("NO")
+        }
+    }
+
+    @Nested
+    inner class NyBrevmottakerPersonMedIdentTest {
+        @Test
+        fun `skal kaste exception om person ident er blank`() {
+            // Act & assert
+            val exception =
+                assertThrows<IllegalStateException> {
+                    NyBrevmottakerPersonMedIdent(
+                        personIdent = "",
+                        mottakerRolle = MottakerRolle.BRUKER,
+                        navn = "Navn Navnesen",
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Personident kan ikke være blank.")
+        }
+
+        @Test
+        fun `skal kaste exception om nav er blank`() {
+            // Act & assert
+            val exception =
+                assertThrows<IllegalStateException> {
+                    NyBrevmottakerPersonMedIdent(
+                        personIdent = "12345678903",
+                        mottakerRolle = MottakerRolle.BRUKER,
+                        navn = "",
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Navn kan ikke være blank.")
+        }
+
+        @Test
+        fun `skal ikke kaste exception ved oppretting`() {
+            // Act & assert
+            assertDoesNotThrow {
+                NyBrevmottakerPersonMedIdent(
+                    personIdent = "12345678903",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "Navn Navnesen",
+                )
+            }
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottakerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/domain/NyBrevmottakerTest.kt
@@ -14,7 +14,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om landkode er mindre enn 2 tegn`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "N")
                 }
             assertThat(exception.message).isEqualTo("Ugyldig landkode: N.")
@@ -24,7 +24,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om landkode er mer enn 2 tegn`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NOR")
                 }
             assertThat(exception.message).isEqualTo("Ugyldig landkode: NOR.")
@@ -34,7 +34,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om navn er en tom string`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(navn = "")
                 }
             assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
@@ -44,7 +44,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om navn er en string med kun mellomrom`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(navn = " ")
                 }
             assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
@@ -54,7 +54,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om adresselinje1 er en tom string`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(adresselinje1 = "")
                 }
             assertThat(exception.message).isEqualTo("Adresselinje1 kan ikke være tomt.")
@@ -64,7 +64,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om adresselinje1 er en string med kun mellomrom`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(adresselinje1 = " ")
                 }
             assertThat(exception.message).isEqualTo("Adresselinje1 kan ikke være tomt.")
@@ -74,7 +74,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om postnummer er null og landkode er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = null)
                 }
             assertThat(exception.message).isEqualTo("Når landkode er NO (Norge) må postnummer være satt.")
@@ -84,7 +84,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om poststed er null og landkode er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", poststed = null)
                 }
             assertThat(exception.message).isEqualTo("Når landkode er NO (Norge) må poststed være satt.")
@@ -94,7 +94,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om postnummer ikke inneholder kun tall og landkode er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = "123T")
                 }
             assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
@@ -104,7 +104,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om postnummer er mindre enn 4 tegn og landkode er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = "123")
                 }
             assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
@@ -114,7 +114,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om postnummer er mer enn 4 tegn og landkode er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "NO", postnummer = "12345")
                 }
             assertThat(exception.message).isEqualTo("Postnummer må være 4 siffer.")
@@ -124,7 +124,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om mottakertype er bruker med utenlandsk adresse og landkode er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(
                         landkode = "NO",
                         mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
@@ -137,7 +137,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om postnummer ikke er null og landkode ikke er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "BR", postnummer = "1234", poststed = null)
                 }
             assertThat(exception.message).isEqualTo("Ved utenlandsk landkode må postnummer settes i adresselinje 1.")
@@ -147,7 +147,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om poststed ikke er null og landkode ikke er NO`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     DomainUtil.lagNyBrevmottakerPersonUtenIdent(landkode = "BR", postnummer = null, poststed = "Harstad")
                 }
             assertThat(exception.message).isEqualTo("Ved utenlandsk landkode må poststed settes i adresselinje 1.")
@@ -208,7 +208,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om person ident er blank`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     NyBrevmottakerPersonMedIdent(
                         personIdent = "",
                         mottakerRolle = MottakerRolle.BRUKER,
@@ -222,7 +222,7 @@ class NyBrevmottakerTest {
         fun `skal kaste exception om nav er blank`() {
             // Act & assert
             val exception =
-                assertThrows<IllegalStateException> {
+                assertThrows<IllegalArgumentException> {
                     NyBrevmottakerPersonMedIdent(
                         personIdent = "12345678903",
                         mottakerRolle = MottakerRolle.BRUKER,

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDtoKtTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonMedIdent
 import no.nav.familie.klage.brevmottaker.domain.NyBrevmottakerPersonUtenIdent
 import no.nav.familie.klage.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.klage.testutil.DtoTestUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -14,6 +15,45 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
 
 class NyBrevmottakerDtoKtTest {
+    @Nested
+    inner class NyBrevmottakerPersonDtoTest {
+        @Test
+        fun `skal mappe NyBrevmottakerPersonMedIdentDto til domene`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdentDto = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto()
+
+            // Act
+            val domene = (nyBrevmottakerPersonMedIdentDto as NyBrevmottakerPersonDto).tilDomene()
+
+            // Assert
+            assertThat(domene).isInstanceOfSatisfying(NyBrevmottakerPersonMedIdent::class.java) {
+                assertThat(it.personIdent).isEqualTo(nyBrevmottakerPersonMedIdentDto.personIdent)
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonMedIdentDto.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonMedIdentDto.navn)
+            }
+        }
+
+        @Test
+        fun `skal mappe NyBrevmottakerPersonUtenIdentDto til domene`() {
+            // Arrange
+            val nyBrevmottakerPersonUtenIdentDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto()
+
+            // Act
+            val domene = (nyBrevmottakerPersonUtenIdentDto as NyBrevmottakerPersonDto).tilDomene()
+
+            // Assert
+            assertThat(domene).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdent::class.java) {
+                assertThat(it.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdentDto.mottakerRolle)
+                assertThat(it.navn).isEqualTo(nyBrevmottakerPersonUtenIdentDto.navn)
+                assertThat(it.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdentDto.adresselinje1)
+                assertThat(it.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdentDto.adresselinje2)
+                assertThat(it.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdentDto.postnummer)
+                assertThat(it.poststed).isEqualTo(nyBrevmottakerPersonUtenIdentDto.poststed)
+                assertThat(it.landkode).isEqualTo(nyBrevmottakerPersonUtenIdentDto.landkode)
+            }
+        }
+    }
+
     @Nested
     inner class NyBrevmottakerDtoTest {
         @Test
@@ -31,7 +71,7 @@ class NyBrevmottakerDtoKtTest {
                 )
 
             // Act
-            val nyBrevmottaker = nyBrevmottakerDto.tilDomene()
+            val nyBrevmottaker = (nyBrevmottakerDto as NyBrevmottakerDto).tilDomene()
 
             // Assert
             assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdent::class.java) {
@@ -56,7 +96,7 @@ class NyBrevmottakerDtoKtTest {
                 )
 
             // Act
-            val nyBrevmottaker = nyBrevmottakerDto.tilDomene()
+            val nyBrevmottaker = (nyBrevmottakerDto as NyBrevmottakerDto).tilDomene()
 
             // Assert
             assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerPersonMedIdent::class.java) {
@@ -77,7 +117,7 @@ class NyBrevmottakerDtoKtTest {
                 )
 
             // Act
-            val nyBrevmottaker = nyBrevmottakerDto.tilDomene()
+            val nyBrevmottaker = (nyBrevmottakerDto as NyBrevmottakerDto).tilDomene()
 
             // Assert
             assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerOrganisasjon::class.java) {
@@ -132,6 +172,102 @@ class NyBrevmottakerDtoKtTest {
                 }
             assertThat(exception.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
             assertThat(exception.message).isEqualTo("Person med ident kan ikke være ${MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE}")
+        }
+
+        @Test
+        fun `skal returnere false om person ident er ulik`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdentDto =
+                DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val brevmottakerPersonMedIdent =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "3",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            // Act
+            val erLik = nyBrevmottakerPersonMedIdentDto.erLik(brevmottakerPersonMedIdent)
+
+            // Assert
+            assertThat(erLik).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om navn er ulik`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdentDto =
+                DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "foo",
+                )
+
+            val brevmottakerPersonMedIdent =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "bar",
+                )
+
+            // Act
+            val erLik = nyBrevmottakerPersonMedIdentDto.erLik(brevmottakerPersonMedIdent)
+
+            // Assert
+            assertThat(erLik).isFalse()
+        }
+
+        @Test
+        fun `skal returnere false om mottaker rolle er ulik`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdentDto =
+                DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val brevmottakerPersonMedIdent =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.VERGE,
+                    navn = "navn",
+                )
+
+            // Act
+            val erLik = nyBrevmottakerPersonMedIdentDto.erLik(brevmottakerPersonMedIdent)
+
+            // Assert
+            assertThat(erLik).isFalse()
+        }
+
+        @Test
+        fun `skal returnere true om er like`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdentDto =
+                DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val brevmottakerPersonMedIdent =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            // Act
+            val erLik = nyBrevmottakerPersonMedIdentDto.erLik(brevmottakerPersonMedIdent)
+
+            // Assert
+            assertThat(erLik).isTrue()
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/NyBrevmottakerDtoKtTest.kt
@@ -23,7 +23,7 @@ class NyBrevmottakerDtoKtTest {
             val nyBrevmottakerPersonMedIdentDto = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto()
 
             // Act
-            val domene = (nyBrevmottakerPersonMedIdentDto as NyBrevmottakerPersonDto).tilDomene()
+            val domene = nyBrevmottakerPersonMedIdentDto.tilNyBrevmottakerPerson()
 
             // Assert
             assertThat(domene).isInstanceOfSatisfying(NyBrevmottakerPersonMedIdent::class.java) {
@@ -39,7 +39,7 @@ class NyBrevmottakerDtoKtTest {
             val nyBrevmottakerPersonUtenIdentDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto()
 
             // Act
-            val domene = (nyBrevmottakerPersonUtenIdentDto as NyBrevmottakerPersonDto).tilDomene()
+            val domene = nyBrevmottakerPersonUtenIdentDto.tilNyBrevmottakerPerson()
 
             // Assert
             assertThat(domene).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdent::class.java) {
@@ -71,7 +71,7 @@ class NyBrevmottakerDtoKtTest {
                 )
 
             // Act
-            val nyBrevmottaker = (nyBrevmottakerDto as NyBrevmottakerDto).tilDomene()
+            val nyBrevmottaker = nyBrevmottakerDto.tilNyBrevmottaker()
 
             // Assert
             assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerPersonUtenIdent::class.java) {
@@ -96,7 +96,7 @@ class NyBrevmottakerDtoKtTest {
                 )
 
             // Act
-            val nyBrevmottaker = (nyBrevmottakerDto as NyBrevmottakerDto).tilDomene()
+            val nyBrevmottaker = nyBrevmottakerDto.tilNyBrevmottaker()
 
             // Assert
             assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerPersonMedIdent::class.java) {
@@ -117,7 +117,7 @@ class NyBrevmottakerDtoKtTest {
                 )
 
             // Act
-            val nyBrevmottaker = (nyBrevmottakerDto as NyBrevmottakerDto).tilDomene()
+            val nyBrevmottaker = nyBrevmottakerDto.tilNyBrevmottaker()
 
             // Assert
             assertThat(nyBrevmottaker).isInstanceOfSatisfying(NyBrevmottakerOrganisasjon::class.java) {
@@ -140,6 +140,26 @@ class NyBrevmottakerDtoKtTest {
 
             // Assert
             assertThat(type).isEqualTo(NyBrevmottakerDto.Type.ORGANISASJON)
+        }
+
+        @Test
+        fun `skal mappe dto til domene`() {
+            // Arrange
+            val nyBrevmottakerOrganisasjonDto =
+                DtoTestUtil.lagNyBrevmottakerOrganisasjonDto(
+                    organisasjonsnummer = "123",
+                    organisasjonsnavn = "orgnavn",
+                    navnHosOrganisasjon = "navn hos org",
+                )
+
+            // Act
+            val nyBrevmottakerOrganisasjon =
+                nyBrevmottakerOrganisasjonDto.tilNyBrevmottakerOrganisasjon()
+
+            // Assert
+            assertThat(nyBrevmottakerOrganisasjon.organisasjonsnummer).isEqualTo(nyBrevmottakerOrganisasjonDto.organisasjonsnummer)
+            assertThat(nyBrevmottakerOrganisasjon.organisasjonsnavn).isEqualTo(nyBrevmottakerOrganisasjonDto.organisasjonsnavn)
+            assertThat(nyBrevmottakerOrganisasjon.navnHosOrganisasjon).isEqualTo(nyBrevmottakerOrganisasjonDto.navnHosOrganisasjon)
         }
     }
 
@@ -268,6 +288,20 @@ class NyBrevmottakerDtoKtTest {
 
             // Assert
             assertThat(erLik).isTrue()
+        }
+
+        @Test
+        fun `skal mappe fra dto til domene`() {
+            // Arrange
+            val nyBrevmottakerPersonMedIdentDto = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto()
+
+            // Act
+            val nyBrevmottakerPersonMedIdent = nyBrevmottakerPersonMedIdentDto.tilNyBrevmottakerPersonMedIdent()
+
+            // Assert
+            assertThat(nyBrevmottakerPersonMedIdent.personIdent).isEqualTo(nyBrevmottakerPersonMedIdentDto.personIdent)
+            assertThat(nyBrevmottakerPersonMedIdent.mottakerRolle).isEqualTo(nyBrevmottakerPersonMedIdentDto.mottakerRolle)
+            assertThat(nyBrevmottakerPersonMedIdent.navn).isEqualTo(nyBrevmottakerPersonMedIdentDto.navn)
         }
     }
 
@@ -561,6 +595,24 @@ class NyBrevmottakerDtoKtTest {
             assertThat(nyBrevmottakerDto.postnummer).isEqualTo("0010")
             assertThat(nyBrevmottakerDto.poststed).isEqualTo("Oslo")
             assertThat(nyBrevmottakerDto.landkode).isEqualTo("NO")
+        }
+
+        @Test
+        fun `skal mappe fra dto til domene`() {
+            // Arrange
+            val nyBrevmottakerPersonUtenIdentDto = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto()
+
+            // Act
+            val nyBrevmottakerPersonUtenIdent = nyBrevmottakerPersonUtenIdentDto.tilNyBrevmottakerPersonUtenIdent()
+
+            // Assert
+            assertThat(nyBrevmottakerPersonUtenIdent.mottakerRolle).isEqualTo(nyBrevmottakerPersonUtenIdentDto.mottakerRolle)
+            assertThat(nyBrevmottakerPersonUtenIdent.navn).isEqualTo(nyBrevmottakerPersonUtenIdentDto.navn)
+            assertThat(nyBrevmottakerPersonUtenIdent.adresselinje1).isEqualTo(nyBrevmottakerPersonUtenIdentDto.adresselinje1)
+            assertThat(nyBrevmottakerPersonUtenIdent.adresselinje2).isEqualTo(nyBrevmottakerPersonUtenIdentDto.adresselinje2)
+            assertThat(nyBrevmottakerPersonUtenIdent.postnummer).isEqualTo(nyBrevmottakerPersonUtenIdentDto.postnummer)
+            assertThat(nyBrevmottakerPersonUtenIdent.poststed).isEqualTo(nyBrevmottakerPersonUtenIdentDto.poststed)
+            assertThat(nyBrevmottakerPersonUtenIdent.landkode).isEqualTo(nyBrevmottakerPersonUtenIdentDto.landkode)
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/dto/SlettbarBrevmottakerDtoKtTest.kt
@@ -18,7 +18,7 @@ class SlettbarBrevmottakerDtoKtTest {
             val dto = SlettbarBrevmottakerOrganisasjonDto("123")
 
             // Act
-            val domene = dto.tilDomene()
+            val domene = dto.tilSlettbarBrevmottaker()
 
             // Assert
             assertThat(domene).isInstanceOfSatisfying(SlettbarBrevmottakerOrganisasjon::class.java) {
@@ -32,7 +32,7 @@ class SlettbarBrevmottakerDtoKtTest {
             val dto = SlettbarBrevmottakerPersonMedIdentDto("123")
 
             // Act
-            val domene = dto.tilDomene()
+            val domene = dto.tilSlettbarBrevmottaker()
 
             // Assert
             assertThat(domene).isInstanceOfSatisfying(SlettbarBrevmottakerPersonMedIdent::class.java) {
@@ -47,7 +47,7 @@ class SlettbarBrevmottakerDtoKtTest {
             val dto = SlettbarBrevmottakerPersonUtenIdentDto(id)
 
             // Act
-            val domene = dto.tilDomene()
+            val domene = dto.tilSlettbarBrevmottaker()
 
             // Assert
             assertThat(domene).isInstanceOfSatisfying(SlettbarBrevmottakerPersonUtenIdent::class.java) {

--- a/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingControllerTest.kt
@@ -1,39 +1,170 @@
 package no.nav.familie.klage.henlegg
 
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.klage.testutil.DtoTestUtil
 import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
-import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class HenleggBehandlingControllerTest {
-    val taskService = mockk<TaskService>(relaxed = true)
-    val tilgangService = mockk<TilgangService>(relaxed = true)
-    val henleggBehandlingService = mockk<HenleggBehandlingService>(relaxed = true)
-    val brevService = mockk<BrevService>(relaxed = true)
+    private val tilgangService = mockk<TilgangService>()
+    private val henleggBehandlingService = mockk<HenleggBehandlingService>()
+    private val henleggBehandlingValidator = mockk<HenleggBehandlingValidator>()
+    private val brevService = mockk<BrevService>()
 
-    val henleggBehandlingController =
+    private val henleggBehandlingController =
         HenleggBehandlingController(
             tilgangService = tilgangService,
             henleggBehandlingService = henleggBehandlingService,
+            henleggBehandlingValidator = henleggBehandlingValidator,
             brevService = brevService,
         )
 
-    @Test
-    internal fun `Skal lage send brev task hvis send brev er true og henlagårsak er trukket`() {
-        brevService.opprettJournalførHenleggelsesbrevTask(UUID.randomUUID(), HenlagtDto(HenlagtÅrsak.TRUKKET_TILBAKE, true))
-        verify(exactly = 1) { brevService.opprettJournalførHenleggelsesbrevTask(any(), any()) }
+    @BeforeEach
+    fun setup() {
+        every { tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(any(), any()) } just runs
+        every { tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(any()) } just runs
+        every { henleggBehandlingValidator.validerHenleggBehandlingDto(any(), any()) } just runs
     }
 
-    @Test
-    internal fun `Skal ikke lage send brev task hvis skalSendeHenleggelsesBrev er false`() {
-        henleggBehandlingController.henleggBehandling(
-            UUID.randomUUID(),
-            HenlagtDto(HenlagtÅrsak.TRUKKET_TILBAKE, false),
-        )
-        verify(exactly = 0) { brevService.opprettJournalførHenleggelsesbrevTask(any(), any()) }
+    @Nested
+    inner class HenleggBehandling {
+        @Test
+        fun `skal kaste feil hvis tilgangservice valider tilgang til person med relasjon for behandling feiler`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = false,
+                )
+
+            every { tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(any(), any()) } throws RuntimeException("Ops!")
+
+            // Act & assert
+            val exception =
+                assertThrows<RuntimeException> {
+                    henleggBehandlingController.henleggBehandling(
+                        behandlingId = behandlingId,
+                        henleggBehandlingDto = henleggBehandlingDto,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Ops!")
+        }
+
+        @Test
+        fun `skal kaste feil hvis tilgangservice valider saksbehandlerrole til stønad for behandling feiler`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = false,
+                )
+
+            every { tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(any()) } throws RuntimeException("Ops!")
+
+            // Act & assert
+            val exception =
+                assertThrows<RuntimeException> {
+                    henleggBehandlingController.henleggBehandling(
+                        behandlingId = behandlingId,
+                        henleggBehandlingDto = henleggBehandlingDto,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Ops!")
+        }
+
+        @Test
+        fun `skal henlegge behandling men ikke lage brev hvis skalSendeHenleggelsesBrev er false`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = false,
+                )
+
+            every { henleggBehandlingService.henleggBehandling(behandlingId, henleggBehandlingDto.årsak) } just runs
+
+            // Act
+            henleggBehandlingController.henleggBehandling(
+                behandlingId = behandlingId,
+                henleggBehandlingDto = henleggBehandlingDto,
+            )
+
+            // Assert
+            verify(exactly = 0) { brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(any(), any()) }
+            verify(exactly = 1) { henleggBehandlingService.henleggBehandling(behandlingId, henleggBehandlingDto.årsak) }
+        }
+
+        @Test
+        fun `skal henlegge behandling og lage brev hvis skalSendeHenleggelsesBrev er true`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(mottakerRolle = MottakerRolle.BRUKER),
+                        ),
+                )
+
+            every { brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(eq(behandlingId), any()) } just runs
+            every { henleggBehandlingService.henleggBehandling(behandlingId, henleggBehandlingDto.årsak) } just runs
+
+            // Act
+            henleggBehandlingController.henleggBehandling(
+                behandlingId = behandlingId,
+                henleggBehandlingDto = henleggBehandlingDto,
+            )
+
+            // Assert
+            verify(exactly = 1) { brevService.lagHenleggelsesbrevOgOpprettJournalføringstask(any(), any()) }
+            verify(exactly = 1) { henleggBehandlingService.henleggBehandling(behandlingId, henleggBehandlingDto.årsak) }
+        }
+
+        @Test
+        fun `skal kaste feil hvis dto validering feiler`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.FEILREGISTRERT,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere = emptyList(),
+                )
+
+            every { henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto) } throws ApiFeil.badRequest("Ops! En feil oppstod.")
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingController.henleggBehandling(
+                        behandlingId = behandlingId,
+                        henleggBehandlingDto = henleggBehandlingDto,
+                    )
+                }
+            assertThat(exception.message).isEqualTo("Ops! En feil oppstod.")
+        }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingDtoTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingDtoTest.kt
@@ -1,0 +1,258 @@
+package no.nav.familie.klage.henlegg
+
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.testutil.DtoTestUtil
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class HenleggBehandlingDtoTest {
+    @Nested
+    inner class Valider {
+        @Test
+        fun `skal kaste feil hvis henlagt årsak er feilregistrert og man prøver å sende brev samtidig`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.FEILREGISTRERT,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere = listOf(DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(mottakerRolle = MottakerRolle.BRUKER)),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("Kan ikke sende henleggelsesbrev når årsak er FEILREGISTRERT.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis man skal sende henleggesesbrev og nye brevmottakere er tom`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere = emptyList(),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("Forventer minst en brevmottaker.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis flere enn 2 nye brevmottakere blir sendt inn`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(mottakerRolle = MottakerRolle.BRUKER),
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.FULLMAKT),
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.VERGE),
+                        ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("Forventer ikke mer enn 2 brevmottakere.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis duplikate mottaker roller blir sendt inn`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE),
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE),
+                        ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("Forventer ingen duplikate mottaker roller.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis mottaker roller BRUKER og BRUKER_MED_UTENLANDSK_ADRESSE blir kombinert`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.BRUKER),
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE),
+                        ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("${MottakerRolle.BRUKER} kan ikke kombineres med ${MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE}.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis mottaker roller DØDSBO kombineres med en annen mottaker rolle`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.DØDSBO),
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE),
+                        ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("${MottakerRolle.DØDSBO} kan ikke kombineres med flere mottaker roller.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis valideringen av en av de nye brevmottakerene feiler`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(navn = ""),
+                        ),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingDto.valider()
+                }
+            assertThat(exception.message).isEqualTo("Navn kan ikke være tomt.")
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis valideringen er ok for henlagt årsak TRUKKET_TILBAKE`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.DØDSBO),
+                        ),
+                )
+
+            // Act & assert
+            assertDoesNotThrow { henleggBehandlingDto.valider() }
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis valideringen er ok for henlagt årsak FEILREGISTRERT`() {
+            // Arrange
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.FEILREGISTRERT,
+                    skalSendeHenleggelsesbrev = false,
+                    nyeBrevmottakere = emptyList(),
+                )
+
+            // Act & assert
+            assertDoesNotThrow { henleggBehandlingDto.valider() }
+        }
+    }
+
+    @Nested
+    inner class FinnNyBrevmottakerBruker {
+        @Test
+        fun `skal finne brevmottaker bruker`() {
+            // Arrange
+            val bruker = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(mottakerRolle = MottakerRolle.BRUKER)
+            val verge = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.VERGE)
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere = listOf(bruker, verge),
+                )
+
+            // Act
+            val brevmottakerBruker = henleggBehandlingDto.finnNyBrevmottakerBruker()
+
+            // Assert
+            assertThat(brevmottakerBruker).isEqualTo(bruker)
+        }
+
+        @Test
+        fun `skal ikke finne brevmottaker bruker da det ikke er lagt til`() {
+            // Arrange
+            val bruker = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE)
+            val verge = DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(mottakerRolle = MottakerRolle.VERGE)
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere = listOf(bruker, verge),
+                )
+
+            // Act
+            val brevmottakerBruker = henleggBehandlingDto.finnNyBrevmottakerBruker()
+
+            // Assert
+            assertThat(brevmottakerBruker).isNull()
+        }
+
+        @Test
+        fun `skal kaste exception om man finner flere brukere`() {
+            // Arrange
+            val bruker1 = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(mottakerRolle = MottakerRolle.BRUKER)
+            val bruker2 = DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(mottakerRolle = MottakerRolle.BRUKER)
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere = listOf(bruker1, bruker2),
+                )
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    henleggBehandlingDto.finnNyBrevmottakerBruker()
+                }
+            assertThat(exception.message).isEqualTo("Forventer ikke mer enn 1 brevmottaker med mottaker rolle ${MottakerRolle.BRUKER}.")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingServiceTest.kt
@@ -99,7 +99,7 @@ internal class HenleggBehandlingServiceTest {
                 behandlingRepository.findByIdOrThrow(any())
             } returns behandling
 
-            henleggBehandlingService.henleggBehandling(behandling.id, HenlagtDto(henlagtÅrsak))
+            henleggBehandlingService.henleggBehandling(behandling.id, henlagtÅrsak)
             assertThat(behandlingSlot.captured.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
             assertThat(behandlingSlot.captured.resultat).isEqualTo(BehandlingResultat.HENLAGT)
             assertThat(behandlingSlot.captured.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
@@ -116,7 +116,7 @@ internal class HenleggBehandlingServiceTest {
 
             val feil: ApiFeil =
                 org.junit.jupiter.api.assertThrows {
-                    henleggBehandlingService.henleggBehandling(behandling.id, HenlagtDto(henlagtÅrsak))
+                    henleggBehandlingService.henleggBehandling(behandling.id, henlagtÅrsak)
                 }
 
             assertThat(feil.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)

--- a/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidatorTest.kt
@@ -198,7 +198,7 @@ class HenleggBehandlingValidatorTest {
                 assertThrows<ApiFeil> {
                     henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
                 }
-            assertThat(exception.message).isEqualTo("Bruker fra dto er ulik bruker utledet fra behandlingen.")
+            assertThat(exception.message).isEqualTo("Innsendt bruker samsvarer ikke med bruker utledet fra behandlingen.")
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingValidatorTest.kt
@@ -1,0 +1,204 @@
+package no.nav.familie.klage.henlegg
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.brevmottaker.BrevmottakerService
+import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
+import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.klage.testutil.DomainUtil
+import no.nav.familie.klage.testutil.DtoTestUtil
+import no.nav.familie.kontrakter.felles.klage.HenlagtÅrsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class HenleggBehandlingValidatorTest {
+    private val brevmottakerService = mockk<BrevmottakerService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val henleggBehandlingValidator =
+        HenleggBehandlingValidator(
+            brevmottakerService = brevmottakerService,
+            featureToggleService = featureToggleService,
+        )
+
+    @BeforeEach
+    internal fun setUp() {
+        every { featureToggleService.isEnabled(any()) } returns true
+    }
+
+    @Nested
+    inner class ValiderHenleggBehandlingDto {
+        @Test
+        fun `skal kaste feil om årsak er feilregistrert men skalSendeHenleggelsesbrev er true og toggle er skrudd av`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.FEILREGISTRERT,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                                personIdent = "1",
+                                mottakerRolle = MottakerRolle.BRUKER,
+                                navn = "navn",
+                            ),
+                        ),
+                )
+
+            every { featureToggleService.isEnabled(Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL) } returns false
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
+                }
+            assertThat(exception.message).isEqualTo("Skal ikke sende brev hvis type er ulik trukket tilbake")
+        }
+
+        @Test
+        fun `skal ikke kaste feil om dto er OK og toggle er skrudd av`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.FEILREGISTRERT,
+                    skalSendeHenleggelsesbrev = false,
+                    nyeBrevmottakere = emptyList(),
+                )
+
+            every { featureToggleService.isEnabled(Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL) } returns false
+
+            // Act & assert
+            assertDoesNotThrow {
+                henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste exception om dto er validert OK og inneholder bruker`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brukerFraDto =
+                DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val brukerFraBehandling =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            brukerFraDto,
+                        ),
+                )
+
+            every { brevmottakerService.utledBrevmottakerBrukerFraBehandling(behandlingId) } returns brukerFraBehandling
+
+            // Act & assert
+            assertDoesNotThrow {
+                henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste exception om dto er validert OK og inneholder ikke bruker`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brukerMedUtenlandskAdresseFraDto =
+                DtoTestUtil.lagNyBrevmottakerPersonUtenIdentDto(
+                    mottakerRolle = MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE,
+                    navn = "navn",
+                    adresselinje1 = "Adresse 1, 0001, Nordpolen",
+                    adresselinje2 = null,
+                    poststed = null,
+                    postnummer = null,
+                    landkode = "DK",
+                )
+
+            val brukerFraBehandling =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            brukerMedUtenlandskAdresseFraDto,
+                        ),
+                )
+
+            every { brevmottakerService.utledBrevmottakerBrukerFraBehandling(behandlingId) } returns brukerFraBehandling
+
+            // Act & assert
+            assertDoesNotThrow {
+                henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
+            }
+        }
+
+        @Test
+        fun `skal kaste exception bruker fra dto og bruker fra behandling er ulike`() {
+            // Arrange
+            val behandlingId = UUID.randomUUID()
+
+            val brukerFraDto =
+                DtoTestUtil.lagNyBrevmottakerPersonMedIdentDto(
+                    personIdent = "1",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val brukerFraBehandling =
+                DomainUtil.lagBrevmottakerPersonMedIdent(
+                    personIdent = "2",
+                    mottakerRolle = MottakerRolle.BRUKER,
+                    navn = "navn",
+                )
+
+            val henleggBehandlingDto =
+                HenleggBehandlingDto(
+                    årsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+                    skalSendeHenleggelsesbrev = true,
+                    nyeBrevmottakere =
+                        listOf(
+                            brukerFraDto,
+                        ),
+                )
+
+            every { brevmottakerService.utledBrevmottakerBrukerFraBehandling(behandlingId) } returns brukerFraBehandling
+
+            // Act & assert
+            val exception =
+                assertThrows<ApiFeil> {
+                    henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
+                }
+            assertThat(exception.message).isEqualTo("Bruker fra dto er ulik bruker utledet fra behandlingen.")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DtoTestUtil.kt
@@ -1,11 +1,27 @@
 package no.nav.familie.klage.testutil
 
+import no.nav.familie.klage.behandling.domain.Behandling
+import no.nav.familie.klage.behandling.domain.PåklagetVedtakstype
+import no.nav.familie.klage.behandling.dto.BehandlingDto
+import no.nav.familie.klage.behandling.dto.PåklagetVedtakDto
+import no.nav.familie.klage.brev.dto.AvsnittDto
+import no.nav.familie.klage.brev.dto.FritekstBrevRequestDto
+import no.nav.familie.klage.brev.dto.SignaturDto
 import no.nav.familie.klage.brevmottaker.domain.MottakerRolle
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerOrganisasjonDto
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonMedIdentDto
 import no.nav.familie.klage.brevmottaker.dto.NyBrevmottakerPersonUtenIdentDto
 import no.nav.familie.klage.brevmottaker.dto.SlettbarBrevmottakerPersonUtenIdentDto
+import no.nav.familie.klage.fagsak.domain.Fagsak
+import no.nav.familie.klage.personopplysninger.dto.Adressebeskyttelse
+import no.nav.familie.klage.personopplysninger.dto.Folkeregisterpersonstatus
+import no.nav.familie.klage.personopplysninger.dto.FullmaktDto
+import no.nav.familie.klage.personopplysninger.dto.Kjønn
+import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
+import no.nav.familie.klage.personopplysninger.dto.VergemålDto
+import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
 import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
 import no.nav.familie.kontrakter.felles.klage.OpprettKlagebehandlingRequest
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
@@ -34,7 +50,7 @@ object DtoTestUtil {
 
     fun lagNyBrevmottakerPersonMedIdentDto(
         personIdent: String = "23097825289",
-        mottakerRolle: MottakerRolle = MottakerRolle.FULLMAKT,
+        mottakerRolle: MottakerRolle = MottakerRolle.BRUKER,
         navn: String = "Navn Navnesen",
     ): NyBrevmottakerPersonMedIdentDto =
         NyBrevmottakerPersonMedIdentDto(
@@ -78,5 +94,120 @@ object DtoTestUtil {
             behandlendeEnhet,
             klageGjelderTilbakekreving,
             behandlingsårsak,
+        )
+
+    fun lagPersonopplysningerDto(
+        personIdent: String = "12345678903",
+        navn: String = "Navn Navnesen",
+        kjønn: Kjønn = Kjønn.MANN,
+        adressebeskyttelse: Adressebeskyttelse? = null,
+        folkeregisterpersonstatus: Folkeregisterpersonstatus? = null,
+        dødsdato: LocalDate? = null,
+        fullmakt: List<FullmaktDto> = emptyList(),
+        egenAnsatt: Boolean = false,
+        vergemål: List<VergemålDto> = emptyList(),
+    ) = PersonopplysningerDto(
+        personIdent = personIdent,
+        navn = navn,
+        kjønn = kjønn,
+        adressebeskyttelse = adressebeskyttelse,
+        folkeregisterpersonstatus = folkeregisterpersonstatus,
+        dødsdato = dødsdato,
+        fullmakt = fullmakt,
+        egenAnsatt = egenAnsatt,
+        vergemål = vergemål,
+    )
+
+    fun lagVergemålDto(
+        embete: String? = null,
+        type: String? = null,
+        motpartsPersonident: String? = null,
+        navn: String? = null,
+        omfang: String? = null,
+    ): VergemålDto =
+        VergemålDto(
+            embete = embete,
+            type = type,
+            motpartsPersonident = motpartsPersonident,
+            navn = navn,
+            omfang = omfang,
+        )
+
+    fun lagFullmaktDto(
+        gyldigFraOgMed: LocalDate = LocalDate.now().minusDays(1),
+        gyldigTilOgMed: LocalDate? = LocalDate.now(),
+        navn: String? = "Navn Navnesen",
+        motpartsPersonident: String = "30987654321",
+        områder: List<String> = emptyList(),
+    ): FullmaktDto =
+        FullmaktDto(
+            gyldigFraOgMed = gyldigFraOgMed,
+            gyldigTilOgMed = gyldigTilOgMed,
+            navn = navn,
+            motpartsPersonident = motpartsPersonident,
+            områder = områder,
+        )
+
+    fun lagSignaturDto(
+        navn: String = "Enhetsnavn",
+        enhet: String = "0001",
+    ): SignaturDto =
+        SignaturDto(
+            navn = navn,
+            enhet = enhet,
+        )
+
+    fun lagPåklagetVedtakDto(
+        eksternFagsystemBehandlingId: String? = UUID.randomUUID().toString(),
+        internKlagebehandlingId: String? = UUID.randomUUID().toString(),
+        påklagetVedtakstype: PåklagetVedtakstype = PåklagetVedtakstype.VEDTAK,
+        fagsystemVedtak: FagsystemVedtak? = null,
+        manuellVedtaksdato: LocalDate? = null,
+        regelverk: Regelverk? = null,
+    ): PåklagetVedtakDto =
+        PåklagetVedtakDto(
+            eksternFagsystemBehandlingId = eksternFagsystemBehandlingId,
+            internKlagebehandlingId = internKlagebehandlingId,
+            påklagetVedtakstype = påklagetVedtakstype,
+            fagsystemVedtak = fagsystemVedtak,
+            manuellVedtaksdato = manuellVedtaksdato,
+            regelverk = regelverk,
+        )
+
+    fun lagBehandlingDto(
+        fagsak: Fagsak = DomainUtil.fagsak(),
+        behandling: Behandling = DomainUtil.behandling(fagsak),
+    ): BehandlingDto =
+        BehandlingDto(
+            id = behandling.id,
+            fagsakId = behandling.fagsakId,
+            steg = behandling.steg,
+            status = behandling.status,
+            sistEndret = behandling.sporbar.endret.endretTid,
+            resultat = behandling.resultat,
+            opprettet = behandling.sporbar.opprettetTid,
+            vedtaksdato = behandling.vedtakDato,
+            stønadstype = fagsak.stønadstype,
+            klageinstansResultat = emptyList(),
+            påklagetVedtak = lagPåklagetVedtakDto(internKlagebehandlingId = behandling.id.toString()),
+            eksternFagsystemFagsakId = fagsak.eksternId,
+            fagsystem = fagsak.fagsystem,
+            klageMottatt = behandling.klageMottatt,
+            fagsystemRevurdering = behandling.fagsystemRevurdering,
+            årsak = behandling.årsak,
+            behandlendeEnhet = behandling.behandlendeEnhet,
+        )
+
+    fun lagFritekstBrevRequestDto(
+        overskrift: String = "Overskrift",
+        avsnitt: List<AvsnittDto> = emptyList(),
+        personIdent: String = "12345678903",
+        navn: String = "Navn Navnesen",
+    ): FritekstBrevRequestDto =
+        FritekstBrevRequestDto(
+            overskrift = overskrift,
+            avsnitt = avsnitt,
+            personIdent = personIdent,
+            navn = navn,
         )
 }


### PR DESCRIPTION
Favro: [NAV-25011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25011)

Relatert front-end PR: https://github.com/navikt/familie-klage-frontend/pull/953

Legger til muligheten for å sette brevmottakere ved henlegging av behandlinger. 