### PR TITLE
Ungår duplikat validering av vurdering samt kaster ApiFeil fremfor Feil ved manglende utfylt felt for BA/KS

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -39,6 +39,8 @@ import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.personopplysninger.PersonopplysningerService
 import no.nav.familie.klage.repository.findByIdOrThrow
 import no.nav.familie.klage.vurdering.VurderingService
+import no.nav.familie.klage.vurdering.VurderingValidator.validerVurdering
+import no.nav.familie.klage.vurdering.dto.tilDto
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
@@ -159,14 +161,6 @@ class BrevService(
                         klageMottatt = klageMottatt,
                     )
                 } else {
-                    fun getOrThrow(
-                        verdi: String?,
-                        felt: String,
-                    ): String {
-                        brukerfeilHvis(verdi == null) { "Feltet '$felt' er påkrevd og må fylles ut." }
-                        return verdi
-                    }
-
                     val klagefristUnntakOppfylt =
                         formkrav.klagefristOverholdtUnntak in
                             listOf(FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN, FormkravFristUnntak.UNNTAK_KAN_IKKE_LASTES)
@@ -175,20 +169,20 @@ class BrevService(
                         "Hvis unntak for klagefrist er oppfylt, må begrunnelse fylles ut i fritekstfelt"
                     }
 
-                    val dokumentasjonOgUtredning = getOrThrow(vurdering?.dokumentasjonOgUtredning, "dokumentasjonOgUtredning")
-                    val spørsmåletISaken = getOrThrow(vurdering?.spørsmåletISaken, "spørsmåletISaken")
-                    val aktuelleRettskilder = getOrThrow(vurdering?.aktuelleRettskilder, "aktuelleRettskilder")
-                    val klagersAnførsler = getOrThrow(vurdering?.klagersAnførsler, "klagersAnførsler")
-                    val vurderingAvKlagen = getOrThrow(vurdering?.vurderingAvKlagen, "vurderingAvKlagen")
+                    feilHvis(vurdering == null) {
+                        "Behandling ${behandling.id} mangler vurdering for generering av brev"
+                    }
+
+                    validerVurdering(vurdering.tilDto(), fagsak.fagsystem)
 
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         ident = fagsak.hentAktivIdent(),
                         klagefristUnntakBegrunnelse = if (klagefristUnntakOppfylt) formkrav.brevtekst else null,
-                        dokumentasjonOgUtredning = dokumentasjonOgUtredning,
-                        spørsmåletISaken = spørsmåletISaken,
-                        aktuelleRettskilder = aktuelleRettskilder,
-                        klagersAnførsler = klagersAnførsler,
-                        vurderingAvKlagen = vurderingAvKlagen,
+                        dokumentasjonOgUtredning = vurdering.dokumentasjonOgUtredning!!,
+                        spørsmåletISaken = vurdering.spørsmåletISaken!!,
+                        aktuelleRettskilder = vurdering.aktuelleRettskilder!!,
+                        klagersAnførsler = vurdering.klagersAnførsler!!,
+                        vurderingAvKlagen = vurdering.vurderingAvKlagen!!,
                         navn = navn,
                         stønadstype = fagsak.stønadstype,
                         påklagetVedtakDetaljer = påklagetVedtakDetaljer,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -162,8 +162,10 @@ class BrevService(
                     fun getOrThrow(
                         verdi: String?,
                         felt: String,
-                    ) = verdi
-                        ?: throw Feil("Behandling med resultat $behandlingResultat mangler $felt for generering av brev")
+                    ): String {
+                        brukerfeilHvis(verdi == null) { "Feltet '$felt' er påkrevd og må fylles ut." }
+                        return verdi
+                    }
 
                     val klagefristUnntakOppfylt =
                         formkrav.klagefristOverholdtUnntak in

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingValidator.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingValidator.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.klage.vurdering
 
+import no.nav.familie.klage.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.klage.infrastruktur.exception.feilHvis
 import no.nav.familie.klage.vurdering.domain.Vedtak
 import no.nav.familie.klage.vurdering.dto.VurderingDto
@@ -65,7 +66,7 @@ object VurderingValidator {
                         felterSomMangler.add("'Vurdering av klagen'")
                     }
 
-                    feilHvis(felterSomMangler.isNotEmpty()) {
+                    brukerfeilHvis(felterSomMangler.isNotEmpty()) {
                         val felterSomManglerFormatert =
                             if (felterSomMangler.size > 1) {
                                 "Feltene ${


### PR DESCRIPTION
Justerer validering av vurdering før generering av brev for å unngå duplikat valideringskode, samt endrer `feilHvis` til `brukerFeilHvis` slik at vi ikke logger error når validering feiler. Valideringsfeilene skyldes saksbehandler og ikke systemet.

Det skal i utgangspunktet ikke være mulig å havne i en situasjon hvor man skal generere brev og vurdering-feltene ikke er satt, men det kan skje dersom saksbehandler har samme behandling oppe i 2 vinduer. Denne endringen fører til at saksbehandler får en bedre feilmelding dersom feilen først skulle skje.

Endringen treffer kun BA og KS. Gjelder altså ikke EF.

Relatert slack-tråd: https://nav-it.slack.com/archives/C01G9BA8JKZ/p1750750954944469