### PR TITLE
Egen tilgangskontroll dersom fagsystem er BA eller KS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>3.20250616113100_41d23f2</felles.version>
         <prosessering.version>2.20250728105838_1f618e2</prosessering.version>
         <start-class>no.nav.familie.klage.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20250730094742_b263f30</kontrakter.version>
+        <kontrakter.version>3.0_20250804150632_f7e9709</kontrakter.version>
         <saksstatistikk-klage.version>2.0_20250730094950_2d4dd59</saksstatistikk-klage.version>
         <nav.security.version>5.0.34</nav.security.version> <!-- Denne burde være samme versjon som i felles -->
         <okhttp3.version>4.9.1</okhttp3.version> <!-- overskriver spring sin versjon, blir brukt av mock-oauth2-server -->

--- a/src/main/kotlin/no/nav/familie/klage/amelding/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/amelding/InntektController.kt
@@ -24,7 +24,7 @@ class InntektController(
     fun genererAInntektUrl(
         @PathVariable("fagsakId") fagsakId: UUID,
     ): Ressurs<String> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForFagsak(fagsakId)
         return success(inntektService.genererAInntektUrlPåFagsak(fagsakId))
     }

--- a/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/BehandlingController.kt
@@ -48,7 +48,7 @@ class BehandlingController(
     fun hentBehandling(
         @PathVariable behandlingId: UUID,
     ): Ressurs<BehandlingDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(behandlingService.hentBehandlingDto(behandlingId))
     }
@@ -57,7 +57,7 @@ class BehandlingController(
     fun ferdigstillBehandling(
         @PathVariable behandlingId: UUID,
     ): Ressurs<Unit> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.CREATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(ferdigstillBehandlingService.ferdigstillKlagebehandling(behandlingId))
     }
@@ -66,7 +66,7 @@ class BehandlingController(
     fun hentFagsystemVedtak(
         @PathVariable behandlingId: UUID,
     ): Ressurs<List<FagsystemVedtak>> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(fagsystemVedtakService.hentFagsystemVedtak(behandlingId))
     }
@@ -75,7 +75,7 @@ class BehandlingController(
     fun kanOppretteRevurdering(
         @PathVariable behandlingId: UUID,
     ): Ressurs<KanOppretteRevurderingResponse> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(opprettRevurderingService.kanOppretteRevurdering(behandlingId))
     }
@@ -84,7 +84,7 @@ class BehandlingController(
     fun hentAnsvarligSaksbehandlerForBehandling(
         @PathVariable behandlingId: UUID,
     ): Ressurs<SaksbehandlerDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+        tilgangService.validerTilgangTilBehandling(
             behandlingId = behandlingId,
             event = AuditLoggerEvent.ACCESS,
         )
@@ -97,7 +97,7 @@ class BehandlingController(
     fun hentOppgave(
         @PathVariable behandlingId: UUID,
     ): Ressurs<OppgaveDto?> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+        tilgangService.validerTilgangTilBehandling(
             behandlingId = behandlingId,
             event = AuditLoggerEvent.ACCESS,
         )
@@ -121,7 +121,7 @@ class BehandlingController(
         @PathVariable behandlingId: UUID,
         @RequestBody settPåVentRequest: SettPåVentRequest,
     ): Ressurs<UUID> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+        tilgangService.validerTilgangTilBehandling(
             behandlingId = behandlingId,
             event = AuditLoggerEvent.UPDATE,
         )
@@ -135,7 +135,7 @@ class BehandlingController(
     fun taAvVent(
         @PathVariable behandlingId: UUID,
     ): Ressurs<UUID> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+        tilgangService.validerTilgangTilBehandling(
             behandlingId = behandlingId,
             event = AuditLoggerEvent.UPDATE,
         )
@@ -150,7 +150,7 @@ class BehandlingController(
         @PathVariable behandlingId: UUID,
         @RequestBody oppdaterBehandlendeEnhetDto: OppdaterBehandlendeEnhetDto,
     ): Ressurs<UUID> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+        tilgangService.validerTilgangTilBehandling(
             behandlingId = behandlingId,
             event = AuditLoggerEvent.UPDATE,
         )

--- a/src/main/kotlin/no/nav/familie/klage/behandlingshistorikk/BehandlingshistorikkController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandlingshistorikk/BehandlingshistorikkController.kt
@@ -24,7 +24,7 @@ class BehandlingshistorikkController(
     fun hentBehandlingshistorikk(
         @PathVariable behandlingId: UUID,
     ): Ressurs<List<Behandlingshistorikk>> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(behandlingshistorikkService.hentBehandlingshistorikk(behandlingId))
     }

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevController.kt
@@ -27,7 +27,7 @@ class BrevController(
     fun hentBrevPdf(
         @PathVariable behandlingId: UUID,
     ): Ressurs<ByteArray> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(brevService.hentBrevPdf(behandlingId))
     }
@@ -36,7 +36,7 @@ class BrevController(
     fun lagEllerOppdaterBrev(
         @PathVariable behandlingId: UUID,
     ): Ressurs<ByteArray> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(brevService.lagBrev(behandlingId))
     }
@@ -45,7 +45,7 @@ class BrevController(
     fun hentBrevmottakere(
         @PathVariable behandlingId: UUID,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(brevService.hentBrevmottakere(behandlingId).tilBrevmottakereDto())
     }
@@ -55,7 +55,7 @@ class BrevController(
         @PathVariable behandlingId: UUID,
         @RequestBody mottakere: BrevmottakereDto,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         brevService.settBrevmottakere(behandlingId, mottakere)
         return Ressurs.success(mottakere)

--- a/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerController.kt
@@ -34,7 +34,7 @@ class BrevmottakerController(
     fun hentBrevmottakere(
         @PathVariable behandlingId: UUID,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
         return Ressurs.success(brevmottakere.tilBrevmottakereDto())
@@ -45,7 +45,7 @@ class BrevmottakerController(
         @PathVariable behandlingId: UUID,
         @RequestBody brevmottakereDto: BrevmottakereDto,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         brevmottakereDto.valider()
         val nyeBrevmottakere = brevmottakerService.erstattBrevmottakere(behandlingId, brevmottakereDto.tilBrevmottakere())
@@ -57,7 +57,7 @@ class BrevmottakerController(
         @PathVariable behandlingId: UUID,
         @RequestBody nyBrevmottakerDto: NyBrevmottakerDto,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.CREATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         nyBrevmottakerDto.valider()
         brevmottakerService.opprettBrevmottaker(behandlingId, nyBrevmottakerDto.tilNyBrevmottaker())
@@ -70,7 +70,7 @@ class BrevmottakerController(
         @PathVariable behandlingId: UUID,
         @RequestBody slettbarBrevmottakerDto: SlettbarBrevmottakerDto,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.DELETE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.DELETE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         brevmottakerService.slettBrevmottaker(behandlingId, slettbarBrevmottakerDto.tilSlettbarBrevmottaker())
         val brevmottakere = brevmottakerService.hentBrevmottakere(behandlingId)
@@ -81,7 +81,7 @@ class BrevmottakerController(
     fun utledInitielleBrevmottakere(
         @PathVariable behandlingId: UUID,
     ): Ressurs<BrevmottakereDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         val brevmottakere = brevmottakerService.utledInitielleBrevmottakere(behandlingId)
         return Ressurs.success(brevmottakere.tilBrevmottakereDto())

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -69,24 +69,18 @@ class EksternBehandlingController(
             "Ugyldig fagsystem: $fagsystem. Endepunkt støtter kun BA og KS."
         }
 
-        val behandlinger = hentBehandlingerBAKS(eksternFagsakId, fagsystem)
-
-        return Ressurs.success(behandlinger)
-    }
-
-    private fun hentBehandlingerBAKS(
-        eksternFagsakId: String,
-        fagsystem: Fagsystem,
-    ): List<KlagebehandlingDto> {
         tilgangService.validerTilgangTilEksternFagsak(eksternFagsakId = eksternFagsakId, fagsystem = fagsystem, event = AuditLoggerEvent.ACCESS)
 
         logger.info("Henter klagebehandlinger for eksternFagsakId=$eksternFagsakId")
 
-        return behandlingService
-            .finnKlagebehandlingsresultat(
-                eksternFagsakId = eksternFagsakId,
-                fagsystem = fagsystem,
-            ).map { it.tilEksternKlagebehandlingDto(behandlingService.hentKlageresultatDto(it.id)) }
+        val behandlinger =
+            behandlingService
+                .finnKlagebehandlingsresultat(
+                    eksternFagsakId = eksternFagsakId,
+                    fagsystem = fagsystem,
+                ).map { it.tilEksternKlagebehandlingDto(behandlingService.hentKlageresultatDto(it.id)) }
+
+        return Ressurs.success(behandlinger)
     }
 
     private fun validerTilgang(behandlinger: Map<String, List<KlagebehandlingDto>>) {

--- a/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/ekstern/EksternBehandlingController.kt
@@ -53,14 +53,46 @@ class EksternBehandlingController(
         val antallTreff = behandlinger.entries.associate { it.key to it.value.size }
         logger.info("Henter klagebehandlingsresultat for eksternFagsakIder=$eksternFagsakIder antallTreff=$antallTreff")
         validerTilgang(behandlinger)
+        return Ressurs.success(behandlinger)
+    }
+
+    @GetMapping("/baks/{fagsystem}")
+    fun hentBehandlingerBAKS(
+        @PathVariable fagsystem: Fagsystem,
+        @RequestParam("eksternFagsakId") eksternFagsakId: String,
+    ): Ressurs<List<KlagebehandlingDto>> {
+        feilHvis(eksternFagsakId.isBlank()) {
+            "Mangler eksternFagsakId i query param"
+        }
+
+        feilHvis(fagsystem !in listOf(Fagsystem.BA, Fagsystem.KS)) {
+            "Ugyldig fagsystem: $fagsystem. Endepunkt støtter kun BA og KS."
+        }
+
+        val behandlinger = hentBehandlingerBAKS(eksternFagsakId, fagsystem)
 
         return Ressurs.success(behandlinger)
     }
 
+    private fun hentBehandlingerBAKS(
+        eksternFagsakId: String,
+        fagsystem: Fagsystem,
+    ): List<KlagebehandlingDto> {
+        tilgangService.validerTilgangTilEksternFagsak(eksternFagsakId = eksternFagsakId, fagsystem = fagsystem, event = AuditLoggerEvent.ACCESS)
+
+        logger.info("Henter klagebehandlinger for eksternFagsakId=$eksternFagsakId")
+
+        return behandlingService
+            .finnKlagebehandlingsresultat(
+                eksternFagsakId = eksternFagsakId,
+                fagsystem = fagsystem,
+            ).map { it.tilEksternKlagebehandlingDto(behandlingService.hentKlageresultatDto(it.id)) }
+    }
+
     private fun validerTilgang(behandlinger: Map<String, List<KlagebehandlingDto>>) {
-        behandlinger.entries.flatMap { it.value }.map { it.fagsakId }.distinct().forEach {
-            tilgangService.validerTilgangTilPersonMedRelasjonerForFagsak(it, AuditLoggerEvent.ACCESS)
-            tilgangService.validerHarVeilederrolleTilStønadForFagsak(it)
+        behandlinger.entries.flatMap { it.value }.map { it.fagsakId }.distinct().forEach { fagsakId ->
+            tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+            tilgangService.validerHarVeilederrolleTilStønadForFagsak(fagsakId)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/fagsak/FagsakService.kt
@@ -47,6 +47,22 @@ class FagsakService(
             ?: throw Feil("Finner ikke fagsak til behandlingId=$behandlingId")
     }
 
+    fun hentFagsakForEksternIdOgFagsystem(
+        eksternId: String,
+        fagsystem: Fagsystem,
+        stønadstype: Stønadstype? = null,
+    ): Fagsak {
+        val stønadstype =
+            stønadstype ?: when (fagsystem) {
+                Fagsystem.KS -> Stønadstype.KONTANTSTØTTE
+                Fagsystem.BA -> Stønadstype.BARNETRYGD
+                else -> throw Feil("Stønadstype må spesifiseres for fagsystem $fagsystem")
+            }
+        val fagsak = fagsakRepository.findByEksternIdAndFagsystemAndStønadstype(eksternId, fagsystem, stønadstype)
+        return fagsak?.tilFagsakMedPerson(fagsakPersonService.hentIdenter(fagsak.fagsakPersonId))
+            ?: throw Feil("Finner ikke fagsak for eksternId=$eksternId, fagsystem=$fagsystem og stønadstype=$stønadstype")
+    }
+
     private fun opprettFagsak(
         stønadstype: Stønadstype,
         eksternId: String,

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormController.kt
@@ -26,7 +26,7 @@ class FormController(
     fun hentVilkår(
         @PathVariable behandlingId: UUID,
     ): Ressurs<FormkravDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(formService.hentFormDto(behandlingId))
     }
@@ -35,7 +35,7 @@ class FormController(
     fun oppdaterFormkravVilkår(
         @RequestBody form: FormkravDto,
     ): Ressurs<FormkravDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(form.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(form.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(form.behandlingId)
         return Ressurs.success(formService.oppdaterFormkrav(form))
     }

--- a/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingController.kt
@@ -35,7 +35,7 @@ class HenleggBehandlingController(
         @RequestBody henleggBehandlingDto: HenleggBehandlingDto,
     ): Ressurs<Unit> {
         logger.info("Henlegger behandling=$behandlingId")
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         henleggBehandlingValidator.validerHenleggBehandlingDto(behandlingId, henleggBehandlingDto)
         if (henleggBehandlingDto.skalSendeHenleggelsesbrev) {
@@ -49,7 +49,7 @@ class HenleggBehandlingController(
     fun genererHenleggBrev(
         @PathVariable behandlingId: UUID,
     ): Ressurs<ByteArray> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(brevService.genererHenleggelsesbrev(behandlingId))
     }

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -27,6 +27,7 @@ enum class Toggle(
     SKAL_BRUKE_KABAL_API_V4("familie-klage.skal-bruke-kabal-api-v4", "Release"),
     SKAL_BRUKE_NY_LØYPE_FOR_JOURNALFØRING("familie-klage.skal-bruke-ny-loype-for-journalforing", "Release"),
     BRUK_NY_HENLEGG_BEHANDLING_MODAL("familie-klage.bruk-ny-henlegg-behandling-modal", "Release"),
+    BRUK_NY_TILGANG_KONTROLL_BAKS("familie-klage.bruk-ny-tilgang-kontroll-baks", "Release"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
@@ -87,7 +87,7 @@ class TilgangService(
         fagsystem: Fagsystem,
         event: AuditLoggerEvent,
     ) {
-        val fagsak = fagsakService.hentFagsakForEksternIdOgFagsystem(eksternId = eksternFagsakId, fagsystem = fagsystem)
+        val fagsak = hentFagsakForEksternIdOgFagsystem(eksternFagsakId = eksternFagsakId, fagsystem = fagsystem)
         val personIdent = fagsak.hentAktivIdent()
 
         val tilgang =
@@ -219,6 +219,14 @@ class TilgangService(
     private fun hentFagsakForBehandling(behandlingId: UUID): Fagsak =
         cacheManager.getValue("fagsakForBehandling", behandlingId) {
             fagsakService.hentFagsakForBehandling(behandlingId)
+        }
+
+    private fun hentFagsakForEksternIdOgFagsystem(
+        eksternFagsakId: String,
+        fagsystem: Fagsystem,
+    ): Fagsak =
+        cacheManager.getValue("fagsakForEksternIdOgFagsystem", eksternFagsakId) {
+            fagsakService.hentFagsakForEksternIdOgFagsystem(eksternFagsakId, fagsystem)
         }
 
     private fun validerHarRolleForBehandling(

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
@@ -62,7 +62,7 @@ class TilgangService(
         val tilgang =
             when (fagsak.fagsystem) {
                 Fagsystem.BA, Fagsystem.KS ->
-                    harTilgangTilEksternFagsak(
+                    hentTilgangTilEksternFagsak(
                         eksternFagsakId = fagsak.eksternId,
                         personIdent = personIdent,
                         fagsystem = fagsak.fagsystem,
@@ -93,7 +93,7 @@ class TilgangService(
         val tilgang =
             when (fagsak.fagsystem) {
                 Fagsystem.BA, Fagsystem.KS ->
-                    harTilgangTilEksternFagsak(
+                    hentTilgangTilEksternFagsak(
                         eksternFagsakId = fagsak.eksternId,
                         personIdent = personIdent,
                         fagsystem = fagsak.fagsystem,
@@ -123,7 +123,7 @@ class TilgangService(
         val tilgang =
             when (fagsak.fagsystem) {
                 Fagsystem.BA, Fagsystem.KS ->
-                    harTilgangTilEksternFagsak(
+                    hentTilgangTilEksternFagsak(
                         eksternFagsakId = fagsak.eksternId,
                         personIdent = personIdent,
                         fagsystem = fagsak.fagsystem,
@@ -174,15 +174,15 @@ class TilgangService(
         minimumsrolle: BehandlerRolle,
     ): Boolean = harTilgangTilFagsakGittRolle(behandlingService.hentBehandling(behandlingId).fagsakId, minimumsrolle)
 
-    private fun harTilgangTilEksternFagsak(
+    private fun hentTilgangTilEksternFagsak(
         eksternFagsakId: String,
         personIdent: String,
         fagsystem: Fagsystem,
     ): Tilgang =
         if (featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS)) {
             when (fagsystem) {
-                Fagsystem.BA -> familieBASakClient.harTilgangTilFagsak(eksternFagsakId)
-                Fagsystem.KS -> familieKSSakClient.harTilgangTilFagsak(eksternFagsakId)
+                Fagsystem.BA -> familieBASakClient.hentTilgangTilFagsak(eksternFagsakId)
+                Fagsystem.KS -> familieKSSakClient.hentTilgangTilFagsak(eksternFagsakId)
                 else -> throw IllegalArgumentException("Ugyldig fagsystem: $eksternFagsakId. Validering av tilgang til ekstern fagsag støttes kun for BA og KS.")
             }
         } else {

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
@@ -13,7 +13,12 @@ import no.nav.familie.klage.infrastruktur.config.FagsystemRolleConfig
 import no.nav.familie.klage.infrastruktur.config.RolleConfig
 import no.nav.familie.klage.infrastruktur.config.getValue
 import no.nav.familie.klage.infrastruktur.exception.ManglerTilgang
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.klage.integrasjoner.FamilieBASakClient
+import no.nav.familie.klage.integrasjoner.FamilieKSSakClient
 import no.nav.familie.klage.personopplysninger.PersonopplysningerIntegrasjonerClient
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
@@ -27,6 +32,9 @@ class TilgangService(
     private val auditLogger: AuditLogger,
     private val behandlingService: BehandlingService,
     private val fagsakService: FagsakService,
+    private val familieBASakClient: FamilieBASakClient,
+    private val familieKSSakClient: FamilieKSSakClient,
+    private val featureToggleService: FeatureToggleService,
 ) {
     fun validerTilgangTilPersonMedRelasjoner(
         personIdent: String,
@@ -44,16 +52,85 @@ class TilgangService(
         }
     }
 
-    fun validerTilgangTilPersonMedRelasjonerForBehandling(
+    fun validerTilgangTilFagsak(
+        fagsakId: UUID,
+        event: AuditLoggerEvent,
+    ) {
+        val fagsak = hentFagsak(fagsakId)
+        val personIdent = fagsak.hentAktivIdent()
+
+        val tilgang =
+            when (fagsak.fagsystem) {
+                Fagsystem.BA, Fagsystem.KS ->
+                    harTilgangTilEksternFagsak(
+                        eksternFagsakId = fagsak.eksternId,
+                        personIdent = personIdent,
+                        fagsystem = fagsak.fagsystem,
+                    )
+                Fagsystem.EF -> harTilgangTilPersonMedRelasjoner(personIdent)
+            }
+
+        auditLogger.log(Sporingsdata(event, personIdent, tilgang, custom1 = CustomKeyValue("fagsak", fagsakId.toString())))
+
+        if (!tilgang.harTilgang) {
+            throw ManglerTilgang(
+                melding =
+                    "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                        "har ikke tilgang til fagsak=$fagsakId",
+                frontendFeilmelding = "Mangler tilgang til opplysningene. ${tilgang.utledÅrsakstekst()}",
+            )
+        }
+    }
+
+    fun validerTilgangTilEksternFagsak(
+        eksternFagsakId: String,
+        fagsystem: Fagsystem,
+        event: AuditLoggerEvent,
+    ) {
+        val fagsak = fagsakService.hentFagsakForEksternIdOgFagsystem(eksternId = eksternFagsakId, fagsystem = fagsystem)
+        val personIdent = fagsak.hentAktivIdent()
+
+        val tilgang =
+            when (fagsak.fagsystem) {
+                Fagsystem.BA, Fagsystem.KS ->
+                    harTilgangTilEksternFagsak(
+                        eksternFagsakId = fagsak.eksternId,
+                        personIdent = personIdent,
+                        fagsystem = fagsak.fagsystem,
+                    )
+                Fagsystem.EF -> harTilgangTilPersonMedRelasjoner(personIdent)
+            }
+
+        auditLogger.log(Sporingsdata(event, personIdent, tilgang, custom1 = CustomKeyValue("fagsak", fagsak.id.toString())))
+
+        if (!tilgang.harTilgang) {
+            throw ManglerTilgang(
+                melding =
+                    "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                        "har ikke tilgang til fagsak=${fagsak.id}",
+                frontendFeilmelding = "Mangler tilgang til opplysningene. ${tilgang.utledÅrsakstekst()}",
+            )
+        }
+    }
+
+    fun validerTilgangTilBehandling(
         behandlingId: UUID,
         event: AuditLoggerEvent,
     ) {
-        val personIdent =
-            cacheManager.getValue("behandlingPersonIdent", behandlingId) {
-                behandlingService.hentAktivIdent(behandlingId).first
+        val fagsak = hentFagsakForBehandling(behandlingId)
+        val personIdent = fagsak.hentAktivIdent()
+
+        val tilgang =
+            when (fagsak.fagsystem) {
+                Fagsystem.BA, Fagsystem.KS ->
+                    harTilgangTilEksternFagsak(
+                        eksternFagsakId = fagsak.eksternId,
+                        personIdent = personIdent,
+                        fagsystem = fagsak.fagsystem,
+                    )
+                Fagsystem.EF -> harTilgangTilPersonMedRelasjoner(personIdent)
             }
 
-        val tilgang = harTilgangTilPersonMedRelasjoner(personIdent)
         auditLogger.log(
             Sporingsdata(
                 event,
@@ -72,6 +149,45 @@ class TilgangService(
             )
         }
     }
+
+    fun validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId: UUID) {
+        validerHarRolleForBehandling(behandlingId, BehandlerRolle.SAKSBEHANDLER)
+    }
+
+    fun validerHarVeilederrolleTilStønadForBehandling(behandlingId: UUID) {
+        validerHarRolleForBehandling(behandlingId, BehandlerRolle.VEILEDER)
+    }
+
+    fun validerHarVeilederrolleTilStønadForFagsak(fagsakId: UUID) {
+        harTilgangTilFagsakGittRolle(fagsakId, BehandlerRolle.VEILEDER)
+    }
+
+    fun harEgenAnsattRolle(): Boolean = SikkerhetContext.harRolle(rolleConfig.egenAnsatt)
+
+    fun harMinimumRolleTversFagsystem(minimumsrolle: BehandlerRolle): Boolean =
+        harTilgangTilGittRolleForFagsystem(rolleConfig.ba, minimumsrolle) ||
+            harTilgangTilGittRolleForFagsystem(rolleConfig.ef, minimumsrolle) ||
+            harTilgangTilGittRolleForFagsystem(rolleConfig.ks, minimumsrolle)
+
+    fun harTilgangTilBehandlingGittRolle(
+        behandlingId: UUID,
+        minimumsrolle: BehandlerRolle,
+    ): Boolean = harTilgangTilFagsakGittRolle(behandlingService.hentBehandling(behandlingId).fagsakId, minimumsrolle)
+
+    private fun harTilgangTilEksternFagsak(
+        eksternFagsakId: String,
+        personIdent: String,
+        fagsystem: Fagsystem,
+    ): Tilgang =
+        if (featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS)) {
+            when (fagsystem) {
+                Fagsystem.BA -> familieBASakClient.harTilgangTilFagsak(eksternFagsakId)
+                Fagsystem.KS -> familieKSSakClient.harTilgangTilFagsak(eksternFagsakId)
+                else -> throw IllegalArgumentException("Ugyldig fagsystem: $eksternFagsakId. Validering av tilgang til ekstern fagsag støttes kun for BA og KS.")
+            }
+        } else {
+            harTilgangTilPersonMedRelasjoner(personIdent)
+        }
 
     private fun harTilgangTilPersonMedRelasjoner(personIdent: String): Tilgang =
         harSaksbehandlerTilgang("validerTilgangTilPersonMedBarn", personIdent) {
@@ -95,40 +211,15 @@ class TilgangService(
         } ?: error("Finner ikke verdi fra cache=$cacheName")
     }
 
-    fun validerTilgangTilPersonMedRelasjonerForFagsak(
-        fagsakId: UUID,
-        event: AuditLoggerEvent,
-    ) {
-        val personIdent = hentFagsak(fagsakId).hentAktivIdent()
-
-        val tilgang = harTilgangTilPersonMedRelasjoner(personIdent)
-        auditLogger.log(Sporingsdata(event, personIdent, tilgang, custom1 = CustomKeyValue("fagsak", fagsakId.toString())))
-        if (!tilgang.harTilgang) {
-            throw ManglerTilgang(
-                melding =
-                    "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
-                        "har ikke tilgang til fagsak=$fagsakId",
-                frontendFeilmelding = "Mangler tilgang til opplysningene. ${tilgang.utledÅrsakstekst()}",
-            )
-        }
-    }
-
     private fun hentFagsak(fagsakId: UUID): Fagsak =
         cacheManager.getValue("fagsak", fagsakId) {
             fagsakService.hentFagsak(fagsakId)
         }
 
-    fun validerHarSaksbehandlerrolleTilStønadForBehandling(behandlingId: UUID) {
-        validerHarRolleForBehandling(behandlingId, BehandlerRolle.SAKSBEHANDLER)
-    }
-
-    fun validerHarVeilederrolleTilStønadForBehandling(behandlingId: UUID) {
-        validerHarRolleForBehandling(behandlingId, BehandlerRolle.VEILEDER)
-    }
-
-    fun validerHarVeilederrolleTilStønadForFagsak(fagsakId: UUID) {
-        harTilgangTilFagsakGittRolle(fagsakId, BehandlerRolle.VEILEDER)
-    }
+    private fun hentFagsakForBehandling(behandlingId: UUID): Fagsak =
+        cacheManager.getValue("fagsakForBehandling", behandlingId) {
+            fagsakService.hentFagsakForBehandling(behandlingId)
+        }
 
     private fun validerHarRolleForBehandling(
         behandlingId: UUID,
@@ -144,25 +235,13 @@ class TilgangService(
         }
     }
 
-    fun harMinimumRolleTversFagsystem(minimumsrolle: BehandlerRolle): Boolean =
-        harTilgangTilGittRolleForFagsystem(rolleConfig.ba, minimumsrolle) ||
-            harTilgangTilGittRolleForFagsystem(rolleConfig.ef, minimumsrolle) ||
-            harTilgangTilGittRolleForFagsystem(rolleConfig.ks, minimumsrolle)
-
-    fun harTilgangTilBehandlingGittRolle(
-        behandlingId: UUID,
-        minimumsrolle: BehandlerRolle,
-    ): Boolean = harTilgangTilFagsakGittRolle(behandlingService.hentBehandling(behandlingId).fagsakId, minimumsrolle)
-
-    fun harTilgangTilFagsakGittRolle(
+    private fun harTilgangTilFagsakGittRolle(
         fagsakId: UUID,
         minimumsrolle: BehandlerRolle,
     ): Boolean {
         val stønadstype = hentFagsak(fagsakId).stønadstype
         return harTilgangTilGittRolle(stønadstype, minimumsrolle)
     }
-
-    fun harEgenAnsattRolle(): Boolean = SikkerhetContext.harRolle(rolleConfig.egenAnsatt)
 
     private fun harTilgangTilGittRolle(
         stønadstype: Stønadstype,

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.klage.integrasjoner
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.klage.felles.dto.Tilgang
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
@@ -50,5 +51,15 @@ class FamilieBASakClient(
                 .build()
                 .toUri()
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
+    }
+
+    fun harTilgangTilFagsak(eksternFagsakId: String): Tilgang {
+        val tilgangUri =
+            UriComponentsBuilder
+                .fromUri(familieBaSakUri)
+                .pathSegment("api/klage/fagsak/$eksternFagsakId/har-tilgang")
+                .build()
+                .toUri()
+        return getForEntity<Ressurs<Tilgang>>(tilgangUri).getDataOrThrow()
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -53,11 +53,11 @@ class FamilieBASakClient(
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
     }
 
-    fun harTilgangTilFagsak(eksternFagsakId: String): Tilgang {
+    fun hentTilgangTilFagsak(eksternFagsakId: String): Tilgang {
         val tilgangUri =
             UriComponentsBuilder
                 .fromUri(familieBaSakUri)
-                .pathSegment("api/klage/fagsak/$eksternFagsakId/har-tilgang")
+                .pathSegment("api/klage/fagsak/$eksternFagsakId/tilgang")
                 .build()
                 .toUri()
         return getForEntity<Ressurs<Tilgang>>(tilgangUri).getDataOrThrow()

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieBASakClient.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
 import no.nav.familie.kontrakter.felles.klage.KanOppretteRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
+import no.nav.familie.kontrakter.felles.tilgangskontroll.FagsakTilgang
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -60,6 +61,7 @@ class FamilieBASakClient(
                 .pathSegment("api/klage/fagsak/$eksternFagsakId/tilgang")
                 .build()
                 .toUri()
-        return getForEntity<Ressurs<Tilgang>>(tilgangUri).getDataOrThrow()
+        val fagsakTilgang = getForEntity<Ressurs<FagsakTilgang>>(tilgangUri).getDataOrThrow()
+        return Tilgang(harTilgang = fagsakTilgang.harTilgang, begrunnelse = fagsakTilgang.begrunnelse)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.klage.integrasjoner
 
 import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.klage.felles.dto.Tilgang
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
@@ -50,5 +51,15 @@ class FamilieKSSakClient(
                 .build()
                 .toUri()
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
+    }
+
+    fun harTilgangTilFagsak(eksternFagsakId: String): Tilgang {
+        val tilgangUri =
+            UriComponentsBuilder
+                .fromUri(familieKsSakUri)
+                .pathSegment("api/klage/fagsak/$eksternFagsakId/har-tilgang")
+                .build()
+                .toUri()
+        return getForEntity<Ressurs<Tilgang>>(tilgangUri).getDataOrThrow()
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.getDataOrThrow
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
 import no.nav.familie.kontrakter.felles.klage.KanOppretteRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
+import no.nav.familie.kontrakter.felles.tilgangskontroll.FagsakTilgang
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -60,6 +61,7 @@ class FamilieKSSakClient(
                 .pathSegment("api/klage/fagsak/$eksternFagsakId/tilgang")
                 .build()
                 .toUri()
-        return getForEntity<Ressurs<Tilgang>>(tilgangUri).getDataOrThrow()
+        val fagsakTilgang = getForEntity<Ressurs<FagsakTilgang>>(tilgangUri).getDataOrThrow()
+        return Tilgang(harTilgang = fagsakTilgang.harTilgang, begrunnelse = fagsakTilgang.begrunnelse)
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/integrasjoner/FamilieKSSakClient.kt
@@ -53,11 +53,11 @@ class FamilieKSSakClient(
         return postForEntity<Ressurs<OpprettRevurderingResponse>>(hentVedtakUri, emptyMap<String, String>()).getDataOrThrow()
     }
 
-    fun harTilgangTilFagsak(eksternFagsakId: String): Tilgang {
+    fun hentTilgangTilFagsak(eksternFagsakId: String): Tilgang {
         val tilgangUri =
             UriComponentsBuilder
                 .fromUri(familieKsSakUri)
-                .pathSegment("api/klage/fagsak/$eksternFagsakId/har-tilgang")
+                .pathSegment("api/klage/fagsak/$eksternFagsakId/tilgang")
                 .build()
                 .toUri()
         return getForEntity<Ressurs<Tilgang>>(tilgangUri).getDataOrThrow()

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerController.kt
@@ -24,7 +24,7 @@ class PersonopplysningerController(
     fun hentPersonopplysninger(
         @PathVariable behandlingId: UUID,
     ): Ressurs<PersonopplysningerDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(personopplysningerService.hentPersonopplysninger(behandlingId))
     }

--- a/src/main/kotlin/no/nav/familie/klage/vedlegg/VedleggController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vedlegg/VedleggController.kt
@@ -31,7 +31,7 @@ class VedleggController(
     fun finnVedleggForBehandling(
         @PathVariable behandlingId: UUID,
     ): Ressurs<List<DokumentinfoDto>> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(vedleggService.finnVedleggPåBehandling(behandlingId))
     }

--- a/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/vurdering/VurderingController.kt
@@ -26,7 +26,7 @@ class VurderingController(
     fun hentVurdering(
         @PathVariable behandlingId: UUID,
     ): Ressurs<VurderingDto?> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarVeilederrolleTilStønadForBehandling(behandlingId)
         return Ressurs.success(vurderingService.hentVurderingDto(behandlingId))
     }
@@ -36,7 +36,7 @@ class VurderingController(
     fun lagreVurderingOgOppdaterStegDeprekert(
         @RequestBody vurdering: VurderingDto,
     ): Ressurs<VurderingDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(vurdering.behandlingId)
         return Ressurs.success(vurderingService.lagreVurderingOgOppdaterSteg(vurdering))
     }
@@ -45,7 +45,7 @@ class VurderingController(
     fun lagreVurderingOgOppdaterSteg(
         @RequestBody vurdering: VurderingDto,
     ): Ressurs<VurderingDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(
+        tilgangService.validerTilgangTilBehandling(
             vurdering.behandlingId,
             AuditLoggerEvent.UPDATE,
         )
@@ -57,7 +57,7 @@ class VurderingController(
     fun lagreVurdering(
         @RequestBody vurdering: VurderingDto,
     ): Ressurs<VurderingDto> {
-        tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(vurdering.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(vurdering.behandlingId)
         return Ressurs.success(vurderingService.lagreVurdering(vurdering))
     }

--- a/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brevmottaker/BrevmottakerControllerTest.kt
@@ -52,6 +52,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                                         PersonIdent(".*ikkeTilgang.*"),
                                     ),
                             ),
+                        eksternId = ".*ikkeTilgang.*",
                     ),
                 )
             val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
@@ -72,7 +73,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                 "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
             )
             assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
-                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+                "Mangler tilgang til opplysningene. Årsak: Fagsaken inneholder personer som krever ytterligere tilganger.",
             )
             assertThat(exchange.body?.data).isNull()
         }
@@ -179,6 +180,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                                         PersonIdent(".*ikkeTilgang.*"),
                                     ),
                             ),
+                        eksternId = ".*ikkeTilgang.*",
                     ),
                 )
             val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
@@ -205,7 +207,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                 "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
             )
             assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
-                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+                "Mangler tilgang til opplysningene. Årsak: Fagsaken inneholder personer som krever ytterligere tilganger.",
             )
             assertThat(exchange.body?.data).isNull()
         }
@@ -347,6 +349,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                                         PersonIdent(".*ikkeTilgang.*"),
                                     ),
                             ),
+                        eksternId = ".*ikkeTilgang.*",
                     ),
                 )
             val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
@@ -367,7 +370,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
             assertThat(exchange.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
             assertThat(exchange.body?.melding).isEqualTo("Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}")
             assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
-                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+                "Mangler tilgang til opplysningene. Årsak: Fagsaken inneholder personer som krever ytterligere tilganger.",
             )
             assertThat(exchange.body?.data).isNull()
         }
@@ -513,6 +516,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                                         PersonIdent(".*ikkeTilgang.*"),
                                     ),
                             ),
+                        eksternId = ".*ikkeTilgang.*",
                     ),
                 )
             val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
@@ -536,7 +540,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                 "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
             )
             assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
-                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+                "Mangler tilgang til opplysningene. Årsak: Fagsaken inneholder personer som krever ytterligere tilganger.",
             )
             assertThat(exchange.body?.data).isNull()
         }
@@ -634,6 +638,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                                         PersonIdent(".*ikkeTilgang.*"),
                                     ),
                             ),
+                        eksternId = ".*ikkeTilgang.*",
                     ),
                 )
             val behandling = testoppsettService.lagreBehandling(behandling(fagsak))
@@ -654,7 +659,7 @@ class BrevmottakerControllerTest : OppslagSpringRunnerTest() {
                 "Saksbehandler julenissen har ikke tilgang til behandling=${behandling.id}",
             )
             assertThat(exchange.body?.frontendFeilmelding).isEqualTo(
-                "Mangler tilgang til opplysningene. Årsak: Mock sier: Du har ikke tilgang til person ikkeTilgang",
+                "Mangler tilgang til opplysningene. Årsak: Fagsaken inneholder personer som krever ytterligere tilganger.",
             )
             assertThat(exchange.body?.data).isNull()
         }

--- a/src/test/kotlin/no/nav/familie/klage/fagsak/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/fagsak/FagsakServiceTest.kt
@@ -1,0 +1,100 @@
+package no.nav.familie.klage.fagsak
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.personopplysninger.pdl.PdlClient
+import no.nav.familie.klage.testutil.DomainUtil.fagsak
+import no.nav.familie.klage.testutil.DomainUtil.fagsakDomain
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
+import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class FagsakServiceTest {
+    private val fagsakRepository = mockk<FagsakRepository>()
+    private val fagsakPersonService = mockk<FagsakPersonService>()
+    private val pdlClient = mockk<PdlClient>()
+
+    private val fagsakService: FagsakService =
+        FagsakService(
+            fagsakRepository = fagsakRepository,
+            fagsakPersonService = fagsakPersonService,
+            pdlClient = pdlClient,
+        )
+
+    @Nested
+    inner class HentFagsakForEksternIdOgFagsystem {
+        @ParameterizedTest
+        @EnumSource(Fagsystem::class, names = ["BA", "KS"], mode = EnumSource.Mode.EXCLUDE)
+        fun `skal kaste feil dersom fagsystem ikke er BA eller KS og støndstype er null`(fagsystem: Fagsystem) {
+            // Arrange
+
+            // Act & Assert
+            val feil =
+                assertThrows<Feil> {
+                    fagsakService.hentFagsakForEksternIdOgFagsystem(
+                        eksternId = "123",
+                        fagsystem = fagsystem,
+                        stønadstype = null,
+                    )
+                }
+            assertThat(feil.message).isEqualTo("Stønadstype må spesifiseres for fagsystem $fagsystem")
+        }
+
+        @ParameterizedTest
+        @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+        fun `skal kaste feil dersom fagsystem er BA eller KS og ekstern fagsak ikke finnes`(stønadstype: Stønadstype) {
+            // Arrange
+            val fagsak = fagsak(stønadstype = stønadstype)
+            val fagsystem = if (stønadstype == Stønadstype.BARNETRYGD) Fagsystem.BA else Fagsystem.KS
+
+            every { fagsakRepository.findByEksternIdAndFagsystemAndStønadstype(fagsak.eksternId, fagsystem, stønadstype) } returns null
+
+            // Act & Assert
+            val feil =
+                assertThrows<Feil> {
+                    fagsakService.hentFagsakForEksternIdOgFagsystem(
+                        eksternId = fagsak.eksternId,
+                        fagsystem = fagsystem,
+                        stønadstype = null,
+                    )
+                }
+            assertThat(feil.message).isEqualTo("Finner ikke fagsak for eksternId=${fagsak.eksternId}, fagsystem=$fagsystem og stønadstype=$stønadstype")
+        }
+
+        @ParameterizedTest
+        @EnumSource(Stønadstype::class)
+        fun `skal returnere fagsak dersom fagsak med eksternId finnes`(stønadstype: Stønadstype) {
+            // Arrange
+            val fagsystem =
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> Fagsystem.BA
+                    Stønadstype.KONTANTSTØTTE -> Fagsystem.KS
+                    Stønadstype.BARNETILSYN, Stønadstype.SKOLEPENGER, Stønadstype.OVERGANGSSTØNAD -> Fagsystem.EF
+                }
+            val fagsak = fagsakDomain(fagsystem = fagsystem, stønadstype = stønadstype)
+
+            every { fagsakRepository.findByEksternIdAndFagsystemAndStønadstype(fagsak.eksternId, fagsystem, stønadstype) } returns fagsak
+            every { fagsakPersonService.hentIdenter(fagsak.fagsakPersonId) } returns emptySet()
+
+            // Act
+            val fagsakMedEksternId =
+                fagsakService.hentFagsakForEksternIdOgFagsystem(
+                    eksternId = fagsak.eksternId,
+                    fagsystem = fagsystem,
+                    stønadstype = stønadstype,
+                )
+
+            // Assert
+            assertThat(fagsakMedEksternId.id).isEqualTo(fagsak.id)
+            assertThat(fagsakMedEksternId.eksternId).isEqualTo(fagsak.eksternId)
+            assertThat(fagsakMedEksternId.fagsystem).isEqualTo(fagsak.fagsystem)
+            assertThat(fagsakMedEksternId.stønadstype).isEqualTo(fagsak.stønadstype)
+            assertThat(fagsakMedEksternId.fagsakPersonId).isEqualTo(fagsak.fagsakPersonId)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/fagsak/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/fagsak/FagsakServiceTest.kt
@@ -31,8 +31,6 @@ class FagsakServiceTest {
         @ParameterizedTest
         @EnumSource(Fagsystem::class, names = ["BA", "KS"], mode = EnumSource.Mode.EXCLUDE)
         fun `skal kaste feil dersom fagsystem ikke er BA eller KS og støndstype er null`(fagsystem: Fagsystem) {
-            // Arrange
-
             // Act & Assert
             val feil =
                 assertThrows<Feil> {

--- a/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/henlegg/HenleggBehandlingControllerTest.kt
@@ -34,7 +34,7 @@ class HenleggBehandlingControllerTest {
 
     @BeforeEach
     fun setup() {
-        every { tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(any(), any()) } just runs
+        every { tilgangService.validerTilgangTilBehandling(any(), any()) } just runs
         every { tilgangService.validerHarSaksbehandlerrolleTilStønadForBehandling(any()) } just runs
         every { henleggBehandlingValidator.validerHenleggBehandlingDto(any(), any()) } just runs
     }
@@ -52,7 +52,7 @@ class HenleggBehandlingControllerTest {
                     skalSendeHenleggelsesbrev = false,
                 )
 
-            every { tilgangService.validerTilgangTilPersonMedRelasjonerForBehandling(any(), any()) } throws RuntimeException("Ops!")
+            every { tilgangService.validerTilgangTilBehandling(any(), any()) } throws RuntimeException("Ops!")
 
             // Act & assert
             val exception =

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
@@ -3,6 +3,7 @@ package no.nav.familie.klage.infrastruktur.config
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.klage.felles.dto.Tilgang
 import no.nav.familie.klage.integrasjoner.FamilieBASakClient
 import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
@@ -88,6 +89,10 @@ class FamilieBASakClientMock {
                     KanOppretteRevurderingResponse(false, KanIkkeOppretteRevurderingÅrsak.ÅPEN_BEHANDLING)
                 }
             }
+
+            every { mock.harTilgangTilFagsak(any()) } returns Tilgang(harTilgang = true)
+
+            every { mock.harTilgangTilFagsak(".*ikkeTilgang.*") } returns Tilgang(false, "Fagsaken inneholder personer som krever ytterligere tilganger.")
 
             return mock
         }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieBASakClientMock.kt
@@ -90,9 +90,9 @@ class FamilieBASakClientMock {
                 }
             }
 
-            every { mock.harTilgangTilFagsak(any()) } returns Tilgang(harTilgang = true)
+            every { mock.hentTilgangTilFagsak(any()) } returns Tilgang(harTilgang = true)
 
-            every { mock.harTilgangTilFagsak(".*ikkeTilgang.*") } returns Tilgang(false, "Fagsaken inneholder personer som krever ytterligere tilganger.")
+            every { mock.hentTilgangTilFagsak(".*ikkeTilgang.*") } returns Tilgang(false, "Fagsaken inneholder personer som krever ytterligere tilganger.")
 
             return mock
         }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
@@ -90,9 +90,9 @@ class FamilieKSSakClientMock {
                 }
             }
 
-            every { mock.harTilgangTilFagsak(any()) } returns Tilgang(harTilgang = true)
+            every { mock.hentTilgangTilFagsak(any()) } returns Tilgang(harTilgang = true)
 
-            every { mock.harTilgangTilFagsak(".*ikkeTilgang.*") } returns Tilgang(false, "Fagsaken inneholder personer som krever ytterligere tilganger.")
+            every { mock.hentTilgangTilFagsak(".*ikkeTilgang.*") } returns Tilgang(false, "Fagsaken inneholder personer som krever ytterligere tilganger.")
 
             return mock
         }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/FamilieKSSakClientMock.kt
@@ -3,6 +3,7 @@ package no.nav.familie.klage.infrastruktur.config
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.klage.felles.dto.Tilgang
 import no.nav.familie.klage.integrasjoner.FamilieKSSakClient
 import no.nav.familie.kontrakter.felles.Regelverk
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
@@ -88,6 +89,10 @@ class FamilieKSSakClientMock {
                     KanOppretteRevurderingResponse(false, KanIkkeOppretteRevurderingÅrsak.ÅPEN_BEHANDLING)
                 }
             }
+
+            every { mock.harTilgangTilFagsak(any()) } returns Tilgang(harTilgang = true)
+
+            every { mock.harTilgangTilFagsak(".*ikkeTilgang.*") } returns Tilgang(false, "Fagsaken inneholder personer som krever ytterligere tilganger.")
 
             return mock
         }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/config/OppslagSpringRunnerTest.kt
@@ -54,6 +54,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
     "mock-ereg",
     "mock-inntekt",
     "mock-fullmakt",
+    "mock-featuretoggle",
 )
 @EnableMockOAuth2Server
 abstract class OppslagSpringRunnerTest {

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangServiceTest.kt
@@ -128,20 +128,20 @@ internal class TilgangServiceTest {
                 val fagsak = fagsak(stønadstype = stønadstype)
                 every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
                 every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
-                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
-                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
 
                 // Act & Assert
                 val manglerTilgangException = assertThrows<ManglerTilgang> { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
 
                 when (stønadstype) {
                     Stønadstype.BARNETRYGD -> {
-                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     Stønadstype.KONTANTSTØTTE -> {
-                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     else -> return
                 }
@@ -161,20 +161,20 @@ internal class TilgangServiceTest {
                 val fagsak = fagsak(stønadstype = stønadstype)
                 every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
                 every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
-                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
-                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
 
                 // Act & Assert
                 assertDoesNotThrow { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
 
                 when (stønadstype) {
                     Stønadstype.BARNETRYGD -> {
-                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     Stønadstype.KONTANTSTØTTE -> {
-                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     else -> return
                 }
@@ -229,8 +229,8 @@ internal class TilgangServiceTest {
 
                 every { fagsakService.hentFagsakForEksternIdOgFagsystem(eksternId = fagsak.eksternId, fagsystem = fagsystem) } returns fagsak
                 every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
-                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
-                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
 
                 // Act & Assert
                 val manglerTilgangException =
@@ -244,12 +244,12 @@ internal class TilgangServiceTest {
 
                 when (stønadstype) {
                     Stønadstype.BARNETRYGD -> {
-                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     Stønadstype.KONTANTSTØTTE -> {
-                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     else -> return
                 }
@@ -271,8 +271,8 @@ internal class TilgangServiceTest {
 
                 every { fagsakService.hentFagsakForEksternIdOgFagsystem(fagsak.eksternId, fagsystem) } returns fagsak
                 every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
-                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
-                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
 
                 // Act & Assert
                 assertDoesNotThrow {
@@ -285,12 +285,12 @@ internal class TilgangServiceTest {
 
                 when (stønadstype) {
                     Stønadstype.BARNETRYGD -> {
-                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     Stønadstype.KONTANTSTØTTE -> {
-                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     else -> return
                 }
@@ -308,20 +308,20 @@ internal class TilgangServiceTest {
 
                 every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
                 every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
-                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
-                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
 
                 // Act & Assert
                 val manglerTilgangException = assertThrows<ManglerTilgang> { tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS) }
 
                 when (stønadstype) {
                     Stønadstype.BARNETRYGD -> {
-                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     Stønadstype.KONTANTSTØTTE -> {
-                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     else -> return
                 }
@@ -343,20 +343,20 @@ internal class TilgangServiceTest {
 
                 every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
                 every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
-                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
-                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
 
                 // Act & Assert
                 assertDoesNotThrow { tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS) }
 
                 when (stønadstype) {
                     Stønadstype.BARNETRYGD -> {
-                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     Stønadstype.KONTANTSTØTTE -> {
-                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
-                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 1) { familieKSSakClient.hentTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.hentTilgangTilFagsak(fagsak.eksternId) }
                     }
                     else -> return
                 }

--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangServiceTest.kt
@@ -2,22 +2,35 @@ package no.nav.familie.klage.infrastruktur.sikkerhet
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.familie.klage.behandling.BehandlingService
 import no.nav.familie.klage.behandling.domain.Behandling
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.fagsak.domain.Fagsak
 import no.nav.familie.klage.felles.domain.AuditLogger
+import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.felles.domain.BehandlerRolle
+import no.nav.familie.klage.felles.dto.Tilgang
 import no.nav.familie.klage.infrastruktur.config.RolleConfigTestUtil
+import no.nav.familie.klage.infrastruktur.exception.ManglerTilgang
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.klage.integrasjoner.FamilieBASakClient
+import no.nav.familie.klage.integrasjoner.FamilieKSSakClient
 import no.nav.familie.klage.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.klage.testutil.BrukerContextUtil.testWithBrukerContext
 import no.nav.familie.klage.testutil.DomainUtil.behandling
 import no.nav.familie.klage.testutil.DomainUtil.fagsak
+import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 
 internal class TilgangServiceTest {
@@ -27,6 +40,9 @@ internal class TilgangServiceTest {
     private val auditLogger = mockk<AuditLogger>(relaxed = true)
     private val behandlingService = mockk<BehandlingService>()
     private val fagsakService = mockk<FagsakService>()
+    private val familieBASakClient = mockk<FamilieBASakClient>()
+    private val familieKSSakClient = mockk<FamilieKSSakClient>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val tilgangService =
         TilgangService(
@@ -36,6 +52,9 @@ internal class TilgangServiceTest {
             auditLogger,
             behandlingService,
             fagsakService,
+            familieBASakClient,
+            familieKSSakClient,
+            featureToggleService,
         )
 
     private val fagsakEf = fagsak()
@@ -97,6 +116,289 @@ internal class TilgangServiceTest {
                 assertThat(tilgangService.harTilgangTilBehandlingGittRolle(behandlingEf.id, BehandlerRolle.VEILEDER)).isTrue
                 assertThat(tilgangService.harTilgangTilBehandlingGittRolle(behandlingEf.id, BehandlerRolle.SAKSBEHANDLER)).isTrue
                 assertThat(tilgangService.harTilgangTilBehandlingGittRolle(behandlingEf.id, BehandlerRolle.BESLUTTER)).isTrue
+            }
+        }
+
+        @Nested
+        inner class ValiderTilgangTilPersonMedRelasjonerForFagsak {
+            @ParameterizedTest
+            @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+            fun `skal kaste feil dersom saksbehandler ikke har tilgang til fagsak når fagsystem er BA eller KS`(stønadstype: Stønadstype) {
+                // Arrange
+                val fagsak = fagsak(stønadstype = stønadstype)
+                every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+                every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
+                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+
+                // Act & Assert
+                val manglerTilgangException = assertThrows<ManglerTilgang> { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
+
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> {
+                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    Stønadstype.KONTANTSTØTTE -> {
+                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    else -> return
+                }
+
+                assertThat(manglerTilgangException.message)
+                    .isEqualTo(
+                        "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                            "har ikke tilgang til fagsak=${fagsak.id}",
+                    )
+                assertThat(manglerTilgangException.frontendFeilmelding).isEqualTo("Mangler tilgang til opplysningene. Årsak: Ingen tilgang")
+            }
+
+            @ParameterizedTest
+            @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+            fun `skal ikke kaste feil dersom saksbehandler har tilgang til fagsak når fagsystem er BA eller KS`(stønadstype: Stønadstype) {
+                // Arrange
+                val fagsak = fagsak(stønadstype = stønadstype)
+                every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+                every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
+                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+
+                // Act & Assert
+                assertDoesNotThrow { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
+
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> {
+                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    Stønadstype.KONTANTSTØTTE -> {
+                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    else -> return
+                }
+            }
+
+            @Test
+            fun `skal kaste feil dersom saksbehandler ikke har tilgang til fagsak når fagsystem er EF`() {
+                // Arrange
+                val fagsak = fagsak()
+                every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+
+                every { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+
+                // Act & Assert
+                testWithBrukerContext {
+                    val manglerTilgangException = assertThrows<ManglerTilgang> { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
+
+                    verify(exactly = 1) { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) }
+                    assertThat(manglerTilgangException.message)
+                        .isEqualTo(
+                            "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                                "har ikke tilgang til fagsak=${fagsak.id}",
+                        )
+                    assertThat(manglerTilgangException.frontendFeilmelding).isEqualTo("Mangler tilgang til opplysningene. Årsak: Ingen tilgang")
+                }
+            }
+
+            @Test
+            fun `skal ikke kaste feil dersom saksbehandler har tilgang til fagsak når fagsystem er EF`() {
+                // Arrange
+                val fagsak = fagsak()
+                every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+
+                every { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) } returns Tilgang(harTilgang = true)
+
+                // Act & Assert
+                testWithBrukerContext {
+                    assertDoesNotThrow { tilgangService.validerTilgangTilFagsak(fagsak.id, AuditLoggerEvent.ACCESS) }
+                    verify(exactly = 1) { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) }
+                }
+            }
+        }
+
+        @Nested
+        inner class ValiderTilgangTilEksternFagsak {
+            @ParameterizedTest
+            @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+            fun `skal kaste feil dersom saksbehandler ikke har tilgang til ekstern fagsak når fagsystem er BA eller KS`(stønadstype: Stønadstype) {
+                // Arrange
+                val fagsak = fagsak(stønadstype = stønadstype)
+                val fagsystem = if (stønadstype == Stønadstype.BARNETRYGD) Fagsystem.BA else Fagsystem.KS
+
+                every { fagsakService.hentFagsakForEksternIdOgFagsystem(eksternId = fagsak.eksternId, fagsystem = fagsystem) } returns fagsak
+                every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
+                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+
+                // Act & Assert
+                val manglerTilgangException =
+                    assertThrows<ManglerTilgang> {
+                        tilgangService.validerTilgangTilEksternFagsak(
+                            eksternFagsakId = fagsak.eksternId,
+                            fagsystem = fagsystem,
+                            event = AuditLoggerEvent.ACCESS,
+                        )
+                    }
+
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> {
+                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    Stønadstype.KONTANTSTØTTE -> {
+                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    else -> return
+                }
+
+                assertThat(manglerTilgangException.message)
+                    .isEqualTo(
+                        "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                            "har ikke tilgang til fagsak=${fagsak.id}",
+                    )
+                assertThat(manglerTilgangException.frontendFeilmelding).isEqualTo("Mangler tilgang til opplysningene. Årsak: Ingen tilgang")
+            }
+
+            @ParameterizedTest
+            @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+            fun `skal ikke kaste feil dersom saksbehandler har tilgang til ekstern fagsak når fagsystem er BA eller KS`(stønadstype: Stønadstype) {
+                // Arrange
+                val fagsak = fagsak(stønadstype = stønadstype)
+                val fagsystem = if (stønadstype == Stønadstype.BARNETRYGD) Fagsystem.BA else Fagsystem.KS
+
+                every { fagsakService.hentFagsakForEksternIdOgFagsystem(fagsak.eksternId, fagsystem) } returns fagsak
+                every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
+                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+
+                // Act & Assert
+                assertDoesNotThrow {
+                    tilgangService.validerTilgangTilEksternFagsak(
+                        eksternFagsakId = fagsak.eksternId,
+                        fagsystem = fagsystem,
+                        event = AuditLoggerEvent.ACCESS,
+                    )
+                }
+
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> {
+                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    Stønadstype.KONTANTSTØTTE -> {
+                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    else -> return
+                }
+            }
+        }
+
+        @Nested
+        inner class ValiderTilgangTilBehandling {
+            @ParameterizedTest
+            @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+            fun `skal kaste feil dersom saksbehandler ikke har tilgang til behandling når fagsystem er BA eller KS`(stønadstype: Stønadstype) {
+                // Arrange
+                val fagsak = fagsak(stønadstype = stønadstype)
+                val behandling = behandling(fagsak)
+
+                every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
+                every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
+                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+
+                // Act & Assert
+                val manglerTilgangException = assertThrows<ManglerTilgang> { tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS) }
+
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> {
+                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    Stønadstype.KONTANTSTØTTE -> {
+                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    else -> return
+                }
+
+                assertThat(manglerTilgangException.message)
+                    .isEqualTo(
+                        "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                            "har ikke tilgang til behandling=${behandling.id}",
+                    )
+                assertThat(manglerTilgangException.frontendFeilmelding).isEqualTo("Mangler tilgang til opplysningene. Årsak: Ingen tilgang")
+            }
+
+            @ParameterizedTest
+            @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
+            fun `skal ikke kaste feil dersom saksbehandler har tilgang til behandling når fagsystem er BA eller KS`(stønadstype: Stønadstype) {
+                // Arrange
+                val fagsak = fagsak(stønadstype = stønadstype)
+                val behandling = behandling(fagsak)
+
+                every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
+                every { featureToggleService.isEnabled(Toggle.BRUK_NY_TILGANG_KONTROLL_BAKS) } returns true
+                every { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+                every { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) } returns Tilgang(harTilgang = true)
+
+                // Act & Assert
+                assertDoesNotThrow { tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS) }
+
+                when (stønadstype) {
+                    Stønadstype.BARNETRYGD -> {
+                        verify(exactly = 1) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    Stønadstype.KONTANTSTØTTE -> {
+                        verify(exactly = 1) { familieKSSakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                        verify(exactly = 0) { familieBASakClient.harTilgangTilFagsak(fagsak.eksternId) }
+                    }
+                    else -> return
+                }
+            }
+
+            @Test
+            fun `skal kaste feil dersom saksbehandler ikke har tilgang til behandling når fagsystem er EF`() {
+                // Arrange
+                val fagsak = fagsak()
+                val behandling = behandling(fagsak)
+
+                every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
+                every { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) } returns Tilgang(harTilgang = false, begrunnelse = "Ingen tilgang")
+
+                // Act & Assert
+                testWithBrukerContext {
+                    val manglerTilgangException = assertThrows<ManglerTilgang> { tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS) }
+
+                    verify(exactly = 1) { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) }
+                    assertThat(manglerTilgangException.message)
+                        .isEqualTo(
+                            "Saksbehandler ${SikkerhetContext.hentSaksbehandler()} " +
+                                "har ikke tilgang til behandling=${behandling.id}",
+                        )
+                    assertThat(manglerTilgangException.frontendFeilmelding).isEqualTo("Mangler tilgang til opplysningene. Årsak: Ingen tilgang")
+                }
+            }
+
+            @Test
+            fun `skal ikke kaste feil dersom saksbehandler har tilgang til behandling når fagsystem er EF`() {
+                // Arrange
+                val fagsak = fagsak()
+                val behandling = behandling(fagsak)
+
+                every { fagsakService.hentFagsakForBehandling(behandling.id) } returns fagsak
+                every { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) } returns Tilgang(harTilgang = true)
+
+                // Act & Assert
+                testWithBrukerContext {
+                    assertDoesNotThrow { tilgangService.validerTilgangTilBehandling(behandling.id, AuditLoggerEvent.ACCESS) }
+                    verify(exactly = 1) { personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(fagsak.hentAktivIdent()) }
+                }
             }
         }
     }

--- a/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/DomainUtil.kt
@@ -200,6 +200,7 @@ object DomainUtil {
         id: UUID = UUID.randomUUID(),
         person: FagsakPerson,
         sporbar: Sporbar = Sporbar(),
+        eksternId: String = "1",
     ): Fagsak =
         Fagsak(
             id = id,
@@ -207,7 +208,7 @@ object DomainUtil {
             personIdenter = person.identer,
             stønadstype = stønadstype,
             sporbar = sporbar,
-            eksternId = "1",
+            eksternId = eksternId,
             fagsystem =
                 when (stønadstype) {
                     Stønadstype.OVERGANGSSTØNAD,


### PR DESCRIPTION
Favro: [NAV-25324](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25324)

Tilgangskontrollen i klage er ulik tilgangskontrollen vi har i ba/ks-sak. Dette fører i noen tilfeller til at saksbehandler ikke har tilgang til klagebehandlingen for en fagsak de har tilgang til i ba/ks-sak. 

I og med at tilgangskontrollen i ba/ks-sak går ut på å sjekke tilgang til alle fagsak-deltagere får vi ikke endret tilgangskontrollen direkte i klageløsningen, da vi ikke vet hvem deltakerne er der. Tilgangskontroll for ba/ks-sak er derfor endret til at vi kjører et kall mot henholdsvis ba-sak og ks-sak og sjekker om saksbehandler har tilgang til den "eksterne" fagsaken. Har saksbehandler tilgang til den "eksterne" fagsaken gir vi saksbehandler tilgang.

Endringen er lagt bak toggle, og må testes godt før vi skrur på i prod.

Skal ikke påvirke EF. Noe av eksisterende kode er refaktorert/justert, men logikken skal være den samme som tidligere.