### PR TITLE
NAV-25804: Fjerner toggle for å legge til brevmottakere

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -15,7 +15,6 @@ class FeatureToggleController(
 ) {
     private val featureTogglesIBruk: Set<Toggle> =
         setOf(
-            Toggle.LEGG_TIL_BREVMOTTAKER_BAKS,
             Toggle.KAN_MELLOMLAGRE_VURDERING,
             Toggle.BRUK_NY_HENLEGG_BEHANDLING_MODAL,
         )

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -21,7 +21,6 @@ enum class Toggle(
     VELG_SIGNATUR_BASERT_PÅ_FAGSAK("familie-klage.velg-signatur-basert-paa-fagsak", "Permission"),
 
     // Release
-    LEGG_TIL_BREVMOTTAKER_BAKS("familie-klage.legg-til-brevmottaker-baks", "Release"),
     BRUK_NYTT_BREV_BA_KS("familie-klage.bruk-nytt-brev-ba-ks", "Release"),
     KAN_MELLOMLAGRE_VURDERING("familie-klage.kan-mellomlagre-vurdering", "Release"),
     SKAL_BRUKE_KABAL_API_V4("familie-klage.skal-bruke-kabal-api-v4", "Release"),


### PR DESCRIPTION
Fjerner toggle for å legge til brevmottakere.

Må merges etter https://github.com/navikt/familie-klage-frontend/pull/980