### PR TITLE
NAV-25831: Fikser feil i nytt endepunkt for henting av klagebehandlinger for BAKS

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/fagsak/FagsakService.kt
@@ -51,7 +51,7 @@ class FagsakService(
         eksternId: String,
         fagsystem: Fagsystem,
         stønadstype: Stønadstype? = null,
-    ): Fagsak {
+    ): Fagsak? {
         val stønadstype =
             stønadstype ?: when (fagsystem) {
                 Fagsystem.KS -> Stønadstype.KONTANTSTØTTE
@@ -60,7 +60,6 @@ class FagsakService(
             }
         val fagsak = fagsakRepository.findByEksternIdAndFagsystemAndStønadstype(eksternId, fagsystem, stønadstype)
         return fagsak?.tilFagsakMedPerson(fagsakPersonService.hentIdenter(fagsak.fagsakPersonId))
-            ?: throw Feil("Finner ikke fagsak for eksternId=$eksternId, fagsystem=$fagsystem og stønadstype=$stønadstype")
     }
 
     private fun opprettFagsak(

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/sikkerhet/TilgangService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.klage.felles.domain.Sporingsdata
 import no.nav.familie.klage.felles.dto.Tilgang
 import no.nav.familie.klage.infrastruktur.config.FagsystemRolleConfig
 import no.nav.familie.klage.infrastruktur.config.RolleConfig
+import no.nav.familie.klage.infrastruktur.config.getNullable
 import no.nav.familie.klage.infrastruktur.config.getValue
 import no.nav.familie.klage.infrastruktur.exception.ManglerTilgang
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
@@ -88,6 +89,9 @@ class TilgangService(
         event: AuditLoggerEvent,
     ) {
         val fagsak = hentFagsakForEksternIdOgFagsystem(eksternFagsakId = eksternFagsakId, fagsystem = fagsystem)
+        if (fagsak == null) {
+            return
+        }
         val personIdent = fagsak.hentAktivIdent()
 
         val tilgang =
@@ -224,8 +228,8 @@ class TilgangService(
     private fun hentFagsakForEksternIdOgFagsystem(
         eksternFagsakId: String,
         fagsystem: Fagsystem,
-    ): Fagsak =
-        cacheManager.getValue("fagsakForEksternIdOgFagsystem", eksternFagsakId) {
+    ): Fagsak? =
+        cacheManager.getNullable("fagsakForEksternIdOgFagsystem", eksternFagsakId) {
             fagsakService.hentFagsakForEksternIdOgFagsystem(eksternFagsakId, fagsystem)
         }
 

--- a/src/test/kotlin/no/nav/familie/klage/fagsak/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/fagsak/FagsakServiceTest.kt
@@ -45,7 +45,7 @@ class FagsakServiceTest {
 
         @ParameterizedTest
         @EnumSource(Stønadstype::class, names = ["BARNETRYGD", "KONTANTSTØTTE"])
-        fun `skal kaste feil dersom fagsystem er BA eller KS og ekstern fagsak ikke finnes`(stønadstype: Stønadstype) {
+        fun `skal returnere null dersom fagsystem er BA eller KS og ekstern fagsak ikke finnes`(stønadstype: Stønadstype) {
             // Arrange
             val fagsak = fagsak(stønadstype = stønadstype)
             val fagsystem = if (stønadstype == Stønadstype.BARNETRYGD) Fagsystem.BA else Fagsystem.KS
@@ -53,15 +53,14 @@ class FagsakServiceTest {
             every { fagsakRepository.findByEksternIdAndFagsystemAndStønadstype(fagsak.eksternId, fagsystem, stønadstype) } returns null
 
             // Act & Assert
-            val feil =
-                assertThrows<Feil> {
-                    fagsakService.hentFagsakForEksternIdOgFagsystem(
-                        eksternId = fagsak.eksternId,
-                        fagsystem = fagsystem,
-                        stønadstype = null,
-                    )
-                }
-            assertThat(feil.message).isEqualTo("Finner ikke fagsak for eksternId=${fagsak.eksternId}, fagsystem=$fagsystem og stønadstype=$stønadstype")
+            val fagsakForEksternIdOgFagsystem =
+                fagsakService.hentFagsakForEksternIdOgFagsystem(
+                    eksternId = fagsak.eksternId,
+                    fagsystem = fagsystem,
+                    stønadstype = null,
+                )
+
+            assertThat(fagsakForEksternIdOgFagsystem).isNull()
         }
 
         @ParameterizedTest
@@ -88,7 +87,8 @@ class FagsakServiceTest {
                 )
 
             // Assert
-            assertThat(fagsakMedEksternId.id).isEqualTo(fagsak.id)
+            assertThat(fagsakMedEksternId).isNotNull
+            assertThat(fagsakMedEksternId!!.id).isEqualTo(fagsak.id)
             assertThat(fagsakMedEksternId.eksternId).isEqualTo(fagsak.eksternId)
             assertThat(fagsakMedEksternId.fagsystem).isEqualTo(fagsak.fagsystem)
             assertThat(fagsakMedEksternId.stønadstype).isEqualTo(fagsak.stønadstype)


### PR DESCRIPTION
Kall mot endepunkt feilet for alle eksterne fagsaker uten tilknyttet fagsak i familie-klage. Feilen skyldtes bruk av cache-metode som krevde at verdien ikke var null.

Tar i bruk cache-metode som tillatter null-verdier og håndterer at fagsak kan være null i koden forøvrig.