### PR TITLE
NAV-26083: Fjerner toggle for å sende endret enhet som behandlingstatistikk

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetService.kt
@@ -7,7 +7,6 @@ import no.nav.familie.klage.behandlingsstatistikk.BehandlingsstatistikkTask
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
 import no.nav.familie.prosessering.internal.TaskService
@@ -76,16 +75,14 @@ class BehandlendeEnhetService(
                     "\n\n$begrunnelse",
         )
 
-        if (featureToggleService.isEnabled(Toggle.SEND_ENDRET_ENHET_TIL_SAK)) {
-            taskService.save(
-                // Sender "påbegynt" hver gang man endrer enhet da "hendelse" blir sendt i sakstatistikkfeltet
-                // "BehandlingStatus" og sak/dvh er ikke interessert i å innføre en "ENDRET_ENHET" hendelse
-                BehandlingsstatistikkTask.opprettPåbegyntTask(
-                    behandlingId = behandlingId,
-                    eksternFagsakId = fagsak.eksternId,
-                    fagsystem = fagsystem,
-                ),
-            )
-        }
+        taskService.save(
+            // Sender "påbegynt" hver gang man endrer enhet da "hendelse" blir sendt i sakstatistikkfeltet
+            // "BehandlingStatus" og sak/dvh er ikke interessert i å innføre en "ENDRET_ENHET" hendelse
+            BehandlingsstatistikkTask.opprettPåbegyntTask(
+                behandlingId = behandlingId,
+                eksternFagsakId = fagsak.eksternId,
+                fagsystem = fagsystem,
+            ),
+        )
     }
 }

--- a/src/main/kotlin/no/nav/familie/klage/formkrav/FormService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/formkrav/FormService.kt
@@ -15,7 +15,6 @@ import no.nav.familie.klage.formkrav.domain.FormVilkår
 import no.nav.familie.klage.formkrav.dto.FormkravDto
 import no.nav.familie.klage.formkrav.dto.tilDto
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.repository.findByIdOrThrow
 import no.nav.familie.klage.vurdering.VurderingService
 import no.nav.familie.kontrakter.felles.klage.Fagsystem
@@ -82,30 +81,17 @@ class FormService(
         eksternFagsakId: String,
         fagsystem: Fagsystem,
     ) {
-        if (featureToggleService.isEnabled(Toggle.SEND_ENDRET_ENHET_TIL_SAK)) {
-            val behandlingshistorikk = behandlingshistorikkService.hentBehandlingshistorikk(behandlingId)
-            val harFormkravHistorikk = behandlingshistorikk.any { it.steg == StegType.FORMKRAV }
-            val harEndretEnhetHistorikk = behandlingshistorikk.any { it.historikkHendelse === HistorikkHendelse.BEHANDLENDE_ENHET_ENDRET }
-            if (!harFormkravHistorikk && !harEndretEnhetHistorikk) {
-                taskService.save(
-                    BehandlingsstatistikkTask.opprettPåbegyntTask(
-                        behandlingId = behandlingId,
-                        eksternFagsakId = eksternFagsakId,
-                        fagsystem = fagsystem,
-                    ),
-                )
-            }
-        } else {
-            behandlingshistorikkService.hentBehandlingshistorikk(behandlingId).find { it.steg == StegType.FORMKRAV }
-                ?: run {
-                    taskService.save(
-                        BehandlingsstatistikkTask.opprettPåbegyntTask(
-                            behandlingId = behandlingId,
-                            eksternFagsakId = eksternFagsakId,
-                            fagsystem = fagsystem,
-                        ),
-                    )
-                }
+        val behandlingshistorikk = behandlingshistorikkService.hentBehandlingshistorikk(behandlingId)
+        val harFormkravHistorikk = behandlingshistorikk.any { it.steg == StegType.FORMKRAV }
+        val harEndretEnhetHistorikk = behandlingshistorikk.any { it.historikkHendelse === HistorikkHendelse.BEHANDLENDE_ENHET_ENDRET }
+        if (!harFormkravHistorikk && !harEndretEnhetHistorikk) {
+            taskService.save(
+                BehandlingsstatistikkTask.opprettPåbegyntTask(
+                    behandlingId = behandlingId,
+                    eksternFagsakId = eksternFagsakId,
+                    fagsystem = fagsystem,
+                ),
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -26,7 +26,6 @@ enum class Toggle(
     SKAL_BRUKE_KABAL_API_V4("familie-klage.skal-bruke-kabal-api-v4", "Release"),
     SKAL_BRUKE_NY_LØYPE_FOR_JOURNALFØRING("familie-klage.skal-bruke-ny-loype-for-journalforing", "Release"),
     BRUK_NY_HENLEGG_BEHANDLING_MODAL("familie-klage.bruk-ny-henlegg-behandling-modal", "Release"),
-    SEND_ENDRET_ENHET_TIL_SAK("familie-klage.send-endret-enhet-til-sak"),
     ;
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/enhet/BehandlendeEnhetServiceTest.kt
@@ -14,7 +14,6 @@ import no.nav.familie.klage.behandlingshistorikk.domain.HistorikkHendelse
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.klage.oppgave.OppgaveService
 import no.nav.familie.klage.testutil.DomainUtil.behandling
@@ -55,7 +54,6 @@ class BehandlendeEnhetServiceTest {
         mockkObject(SikkerhetContext)
         every { taskService.save(any()) } returnsArgument 0
         every { SikkerhetContext.hentSaksbehandler(true) } returns "saksbehandler1"
-        every { featureToggleService.isEnabled(Toggle.SEND_ENDRET_ENHET_TIL_SAK) } returns true
     }
 
     @AfterEach

--- a/src/test/kotlin/no/nav/familie/klage/formkrav/FormServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/formkrav/FormServiceTest.kt
@@ -18,7 +18,6 @@ import no.nav.familie.klage.formkrav.domain.Form
 import no.nav.familie.klage.formkrav.domain.FormVilkår
 import no.nav.familie.klage.formkrav.dto.tilDto
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.klage.testutil.DomainUtil.behandling
@@ -74,7 +73,6 @@ class FormServiceTest {
         every { fagsakMock.eksternId } returns "123"
         every { fagsakMock.fagsystem } returns Fagsystem.BA
         every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsakMock
-        every { featureToggleService.isEnabled(Toggle.SEND_ENDRET_ENHET_TIL_SAK) } returns true
     }
 
     @AfterEach


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26083

Fjerner toggle da den har vært skrudd på i prod en stund. 