### PR TITLE
NAV-26151: Legger til "ekstern_id" i "fagsak_person_unique" slik at ulike fagsak IDer er tillat.

### DIFF
--- a/src/main/resources/db/migration/V26__ny_fagsak_constraint.sql
+++ b/src/main/resources/db/migration/V26__ny_fagsak_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE fagsak
+    DROP CONSTRAINT fagsak_person_unique,
+    ADD CONSTRAINT fagsak_person_unique UNIQUE (fagsak_person_id, ekstern_id, stonadstype, fagsystem)


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26151

Når en person har 2 fagsaker, f.eks. en "normal" og en "enslig mindreårig", vil det oppstå en feil hvis man prøver å opprette en ny klagebehandling hvis en av fagsakene allerede har en klagebehandling. I familie-klage har vi følgende kode i `V1__baseline` 

> CONSTRAINT fagsak_person_unique UNIQUE (fagsak_person_id, stonadstype, fagsystem)

Denne endringen legger til feltet `ekstern_id` slik at man kan opprette en fagsak i klage per fagsak i de eksterne systemene. `ekstern_id` er den ekstern IDen til fagsaken i de eksterne fagsystemene.