### PR TITLE
Fang ressursException som egentlig er Forbidden fra integrasjoner og logg warn i stedet for error

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/exception/ApiExceptionHandler.kt
@@ -21,8 +21,8 @@ class ApiExceptionHandler {
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(throwable: Throwable): ResponseEntity<Ressurs<Nothing>> {
         val metodeSomFeiler = finnMetodeSomFeiler(throwable)
-        secureLogger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)}", throwable)
-        logger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)} ")
+        secureLogger.error("Uventet feil: Metode: $metodeSomFeiler Øverste Feil: ${throwable::class} Rotfeil: ${rootCause(throwable)}", throwable)
+        logger.error("Uventet feil: Metode: $metodeSomFeiler Øverste Feil: ${throwable::class} Rotfeil: ${rootCause(throwable)}", throwable)
 
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -101,8 +101,8 @@ class ApiExceptionHandler {
         val firstElement =
             e.stackTrace.firstOrNull {
                 it.className.startsWith("no.nav.familie.klage") &&
-                    !it.className.contains("$") &&
-                    !it.className.contains("InsertUpdateRepositoryImpl")
+                        !it.className.contains("$") &&
+                        !it.className.contains("InsertUpdateRepositoryImpl")
             }
         if (firstElement != null) {
             val className = firstElement.className.split(".").lastOrNull()

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/exception/Feil.kt
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-class Feil(
+open class Feil(
     message: String,
     val frontendFeilmelding: String? = null,
     val httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-26684

Har opplevd mye bråkete loggs i klage. Det kommer av at vi kaster en RessursException som blir fanget av default exceptionhandleren i ApiExceptionHandler.

Flyten er slik:
* Klage prøver å hente ansvarlig saksbehandler og kaller oppgaveClient.finnOppgaveMedId()
* Integrasjoner får en RestClientResponseException 403 fra oppgave
* Integrasjoner pakker feilen inn i en Ressurs-feil med melding = "Feil mot ekstern tjeneste. ${e.statusCode.value()}" <- i dette tilfellet 403 (Responsen som blir sendt tilbake til klage har httpstatus 500)
* Klage fanger opp dette som en RestClientResponseException med status 500 (se securelogs) og kaster en ressursException

* Tidligere fanget ApiExceptionhandleren i Klage opp dette med default handleren og logger derfor Error: Uventet feil 
* Fanger nå feilen i hentAnsvarligSaksbehandlerForBehandlingsId og kaster Mangler Tilgang - exception i stedet

Tar gjerne input på:
* Burde vi heller fange feilen i oppgaveClient.finnOppgaveMedId() i klage?
* Er det uheldig at vi endrer statuskode fra 403 til 500 i integrasjoner? Feilen skjer jo "internt" i integrasjoner, men autentiseringen kommer fra klage så synes på én måte det gir mening å returnere 403. 