### PR TITLE
Brev i skjermet barn-fagsaker

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevClient.kt
@@ -34,7 +34,7 @@ class BrevClient(
 
     fun genererHtmlFritekstbrev(
         fritekstBrev: FritekstBrevRequestDto,
-        saksbehandlerNavn: String,
+        saksbehandlerNavn: String?,
         enhet: String,
         fagsystem: Fagsystem,
         brevmottakere: Brevmottakere?,
@@ -62,7 +62,7 @@ class BrevClient(
     fun genererHtml(
         brevmal: String,
         saksbehandlerBrevrequest: JsonNode,
-        saksbehandlersignatur: String,
+        saksbehandlersignatur: String?,
         saksbehandlerEnhet: String?,
         skjulBeslutterSignatur: Boolean,
         stønadstype: Stønadstype,
@@ -105,14 +105,14 @@ class BrevClient(
 
 data class FritekstBrevRequestMedSignatur(
     val brevFraSaksbehandler: FritekstBrevRequestDto,
-    val saksbehandlersignatur: String,
+    val saksbehandlersignatur: String? = null,
     val enhet: String,
     val brevmottakere: Brevmottakere? = null,
 )
 
 data class BrevRequest(
     val brevFraSaksbehandler: JsonNode,
-    val saksbehandlersignatur: String,
+    val saksbehandlersignatur: String? = null,
     val saksbehandlerEnhet: String? = null,
     val besluttersignatur: String? = null,
     val beslutterEnhet: String? = null,

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevInnholdUtleder.kt
@@ -11,6 +11,7 @@ import no.nav.familie.klage.felles.util.TekstUtil.norskFormat
 import no.nav.familie.klage.felles.util.TekstUtil.norskFormatLang
 import no.nav.familie.klage.felles.util.TekstUtil.storForbokstav
 import no.nav.familie.klage.formkrav.domain.Form
+import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.klage.vurdering.VurderingValidator.validerVurdering
 import no.nav.familie.klage.vurdering.domain.Vurdering
 import no.nav.familie.klage.vurdering.dto.tilDto
@@ -26,14 +27,14 @@ class BrevInnholdUtleder(
     fun lagOpprettholdelseBrev(
         fagsak: Fagsak,
         innstillingKlageinstans: String,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
         påklagetVedtakDetaljer: PåklagetVedtakDetaljer,
         klageMottatt: LocalDate,
     ): FritekstBrevRequestDto =
         FritekstBrevRequestDto(
             overskrift = "Vi har sendt klagen din til Nav Klageinstans Nord",
-            navn = navn,
-            personIdent = fagsak.hentFagsakEierIdent(),
+            navn = personopplysninger.navn,
+            personIdent = personopplysninger.personIdent,
             avsnitt =
                 listOf(
                     AvsnittDto(
@@ -61,7 +62,7 @@ class BrevInnholdUtleder(
         fagsak: Fagsak,
         klagefristUnntakBegrunnelse: String?,
         vurdering: Vurdering,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
         påklagetVedtakDetaljer: PåklagetVedtakDetaljer,
         klageMottatt: LocalDate,
     ): FritekstBrevRequestDto {
@@ -70,8 +71,8 @@ class BrevInnholdUtleder(
 
         return FritekstBrevRequestDto(
             overskrift = "Vi har sendt klagen $possesiv til Nav Klageinstans Nord",
-            navn = navn,
-            personIdent = fagsak.hentFagsakEierIdent(),
+            navn = personopplysninger.navn,
+            personIdent = personopplysninger.personIdent,
             avsnitt =
                 listOfNotNull(
                     AvsnittDto(
@@ -131,7 +132,7 @@ class BrevInnholdUtleder(
 
     fun lagFormkravAvvistBrev(
         fagsak: Fagsak,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
         form: Form,
         påklagetVedtakDetaljer: PåklagetVedtakDetaljer?,
     ): FritekstBrevRequestDto {
@@ -141,8 +142,8 @@ class BrevInnholdUtleder(
 
         return FritekstBrevRequestDto(
             overskrift = "Vi har avvist klagen $possesiv på vedtaket om ${visningsnavn(fagsak.stønadstype, påklagetVedtakDetaljer)}",
-            personIdent = fagsak.hentFagsakEierIdent(),
-            navn = navn,
+            personIdent = personopplysninger.personIdent,
+            navn = personopplysninger.navn,
             avsnitt =
                 listOf(
                     AvsnittDto(
@@ -166,7 +167,7 @@ class BrevInnholdUtleder(
 
     fun lagFormkravAvvistBrevIkkePåklagetVedtak(
         fagsak: Fagsak,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
         formkrav: Form,
     ): FritekstBrevRequestDto {
         val brevtekstFraSaksbehandler =
@@ -175,8 +176,8 @@ class BrevInnholdUtleder(
 
         return FritekstBrevRequestDto(
             overskrift = "Vi har avvist klagen $possesiv",
-            personIdent = fagsak.hentFagsakEierIdent(),
-            navn = navn,
+            personIdent = personopplysninger.navn,
+            navn = personopplysninger.navn,
             avsnitt =
                 listOf(
                     AvsnittDto(
@@ -200,14 +201,14 @@ class BrevInnholdUtleder(
 
     fun lagHenleggelsesbrevBaksInnhold(
         fagsak: Fagsak,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
     ): FritekstBrevRequestDto {
         val (possesiv, subjekt) = hentPronomen(fagsak)
 
         return FritekstBrevRequestDto(
             overskrift = "Saken $possesiv er avsluttet",
-            personIdent = fagsak.hentFagsakEierIdent(),
-            navn = navn,
+            personIdent = personopplysninger.personIdent,
+            navn = personopplysninger.navn,
             avsnitt =
                 listOfNotNull(
                     AvsnittDto(

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -93,7 +93,7 @@ class BrevService(
             } else {
                 personopplysningerService.hentPersonopplysningerFagsakEier(behandlingId)
             }
-        val navn = personopplysninger.navn
+        val personopplysningerForSignatur = personopplysningerService.hentPersonopplysningerFagsakEier(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsak(behandling.fagsakId)
         val påklagetVedtakDetaljer = behandling.påklagetVedtak.påklagetVedtakDetaljer
@@ -103,7 +103,7 @@ class BrevService(
 
         val brevRequest = lagBrevRequest(behandling, fagsak, personopplysninger, påklagetVedtakDetaljer, behandling.klageMottatt)
 
-        val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysninger, fagsak.fagsystem)
+        val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysningerForSignatur, fagsak.fagsystem)
 
         val html =
             brevClient.genererHtmlFritekstbrev(
@@ -314,7 +314,8 @@ class BrevService(
             } else {
                 personopplysningerService.hentPersonopplysningerFagsakEier(behandlingId)
             }
-        val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysninger, fagsak.fagsystem)
+        val personopplysningerForSignatur = personopplysningerService.hentPersonopplysningerFagsakEier(behandlingId)
+        val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysningerForSignatur, fagsak.fagsystem)
         val stønadstype = fagsak.stønadstype
 
         val html =

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -35,6 +35,7 @@ import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.infrastruktur.repository.findByIdOrThrow
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.klage.personopplysninger.PersonopplysningerService
+import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.klage.vurdering.VurderingService
 import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.familie.kontrakter.felles.klage.BehandlingResultat
@@ -100,7 +101,7 @@ class BrevService(
 
         behandling.validerRedigerbarBehandlingOgBehandlingsstegBrev()
 
-        val brevRequest = lagBrevRequest(behandling, fagsak, navn, påklagetVedtakDetaljer, behandling.klageMottatt)
+        val brevRequest = lagBrevRequest(behandling, fagsak, personopplysninger, påklagetVedtakDetaljer, behandling.klageMottatt)
 
         val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysninger, fagsak.fagsystem)
 
@@ -124,7 +125,7 @@ class BrevService(
     private fun lagBrevRequest(
         behandling: Behandling,
         fagsak: Fagsak,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
         påklagetVedtakDetaljer: PåklagetVedtakDetaljer?,
         klageMottatt: LocalDate,
     ): FritekstBrevRequestDto {
@@ -146,7 +147,7 @@ class BrevService(
                     brevInnholdUtleder.lagOpprettholdelseBrev(
                         fagsak = fagsak,
                         innstillingKlageinstans = innstillingKlageinstans,
-                        navn = navn,
+                        personopplysninger = personopplysninger,
                         påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                         klageMottatt = klageMottatt,
                     )
@@ -167,7 +168,7 @@ class BrevService(
                         fagsak = fagsak,
                         klagefristUnntakBegrunnelse = if (klagefristUnntakOppfylt) formkrav.brevtekst else null,
                         vurdering = vurdering,
-                        navn = navn,
+                        personopplysninger = personopplysninger,
                         påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                         klageMottatt = klageMottatt,
                     )
@@ -180,7 +181,7 @@ class BrevService(
                     PåklagetVedtakstype.UTEN_VEDTAK -> {
                         brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
                             fagsak = fagsak,
-                            navn = navn,
+                            personopplysninger = personopplysninger,
                             formkrav = formkrav,
                         )
                     }
@@ -188,7 +189,7 @@ class BrevService(
                     else -> {
                         brevInnholdUtleder.lagFormkravAvvistBrev(
                             fagsak = fagsak,
-                            navn = navn,
+                            personopplysninger = personopplysninger,
                             form = formkrav,
                             påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                         )
@@ -320,7 +321,7 @@ class BrevService(
             when (stønadstype) {
                 Stønadstype.BARNETRYGD,
                 Stønadstype.KONTANTSTØTTE,
-                -> lagHenleggelsesbrevHtmlBaks(signaturMedEnhet, personopplysninger.navn, fagsak, brevmottakere)
+                -> lagHenleggelsesbrevHtmlBaks(signaturMedEnhet, personopplysninger, fagsak, brevmottakere)
 
                 Stønadstype.OVERGANGSSTØNAD,
                 Stønadstype.BARNETILSYN,
@@ -353,14 +354,14 @@ class BrevService(
 
     private fun lagHenleggelsesbrevHtmlBaks(
         signaturMedEnhet: SignaturDto,
-        navn: String,
+        personopplysninger: PersonopplysningerDto,
         fagsak: Fagsak,
         brevmottakere: Brevmottakere,
     ): String {
         val henleggelsesbrevInnhold =
             brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
                 fagsak = fagsak,
-                navn = navn,
+                personopplysninger = personopplysninger,
             )
 
         return brevClient.genererHtmlFritekstbrev(

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevsignaturService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevsignaturService.kt
@@ -21,7 +21,7 @@ class BrevsignaturService(
         val harStrengtFortroligAdresse: Boolean = personopplysningerDto.adressebeskyttelse?.erStrengtFortrolig() ?: false
 
         if (harStrengtFortroligAdresse) {
-            return SignaturDto(NAV_ANONYM_NAVN, ENHET_VIKAFOSSEN)
+            return SignaturDto(enhet = ENHET_VIKAFOSSEN)
         }
 
         return when (fagsystem) {
@@ -54,7 +54,6 @@ class BrevsignaturService(
     private fun hentSaksbehandlerInfo(navIdent: String) = oppgaveClient.hentSaksbehandlerInfo(navIdent)
 
     companion object {
-        const val NAV_ANONYM_NAVN = "Nav anonym"
         const val ENHET_VIKAFOSSEN = "Nav Vikafossen"
         const val ENHET_NAY = "Nav arbeid og ytelser"
         const val ENHET_NFP = "Nav familie- og pensjonsytelser"

--- a/src/main/kotlin/no/nav/familie/klage/brev/dto/SignaturDto.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/dto/SignaturDto.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.klage.brev.dto
 
 data class SignaturDto(
-    val navn: String,
+    val navn: String? = null,
     val enhet: String,
 )

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevInnholdUtlederTest.kt
@@ -11,6 +11,10 @@ import no.nav.familie.klage.brev.dto.Heading
 import no.nav.familie.klage.fagsak.domain.PersonIdent
 import no.nav.familie.klage.felles.util.StønadstypeVisningsnavn.visningsnavn
 import no.nav.familie.klage.felles.util.TekstUtil.storForbokstav
+import no.nav.familie.klage.personopplysninger.dto.Adressebeskyttelse
+import no.nav.familie.klage.personopplysninger.dto.Folkeregisterpersonstatus
+import no.nav.familie.klage.personopplysninger.dto.Kjønn
+import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.klage.testutil.DomainUtil.fagsak
 import no.nav.familie.klage.testutil.DomainUtil.ikkeOppfyltForm
 import no.nav.familie.klage.testutil.DomainUtil.lagInstitusjon
@@ -28,12 +32,26 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
 internal class BrevInnholdUtlederTest {
     private val ident = "12345678903"
     private val navn = "Navn Navnesen"
+    private val personopplysninger =
+        PersonopplysningerDto(
+            personIdent = ident,
+            navn = navn,
+            fødselsdato = LocalDate.of(1990, 1, 1),
+            kjønn = Kjønn.KVINNE,
+            adressebeskyttelse = Adressebeskyttelse.UGRADERT,
+            folkeregisterpersonstatus = Folkeregisterpersonstatus.BOSATT,
+            dødsdato = null,
+            fullmakt = listOf(),
+            egenAnsatt = false,
+            vergemål = listOf(),
+        )
     private val vedtakstidspunkt = LocalDateTime.of(2021, 11, 5, 14, 56, 22)
     private val avvistBrevInnholdUtlederLookup = mockk<AvvistBrevInnholdUtleder.Lookup>()
     private val brevInnholdUtleder = BrevInnholdUtleder(avvistBrevInnholdUtlederLookup)
@@ -106,7 +124,7 @@ internal class BrevInnholdUtlederTest {
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     innstillingKlageinstans = innstillingKlageinstans,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -148,7 +166,7 @@ internal class BrevInnholdUtlederTest {
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     innstillingKlageinstans = innstillingKlageinstans,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -191,7 +209,7 @@ internal class BrevInnholdUtlederTest {
                 brevInnholdUtleder.lagOpprettholdelseBrev(
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     innstillingKlageinstans = innstillingKlageinstans,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -234,7 +252,7 @@ internal class BrevInnholdUtlederTest {
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     klagefristUnntakBegrunnelse = null,
                     vurdering = vurdering,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -287,7 +305,7 @@ internal class BrevInnholdUtlederTest {
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     klagefristUnntakBegrunnelse = null,
                     vurdering = vurdering,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -342,7 +360,7 @@ internal class BrevInnholdUtlederTest {
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     klagefristUnntakBegrunnelse = null,
                     vurdering = vurdering,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -389,7 +407,7 @@ internal class BrevInnholdUtlederTest {
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     klagefristUnntakBegrunnelse = null,
                     vurdering = vurdering,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -436,7 +454,7 @@ internal class BrevInnholdUtlederTest {
                     fagsak = fagsak.copy(stønadstype = stønadstype),
                     klagefristUnntakBegrunnelse = klagefristUnntakBegrunnelse,
                     vurdering = vurdering,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -479,7 +497,7 @@ internal class BrevInnholdUtlederTest {
                     fagsak = fagsak.copy(stønadstype = Stønadstype.BARNETRYGD, institusjon = lagInstitusjon()),
                     klagefristUnntakBegrunnelse = null,
                     vurdering = vurdering,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                     klageMottatt = klageMottatt,
                 )
@@ -539,7 +557,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -583,7 +601,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -627,7 +645,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -671,7 +689,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -713,7 +731,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -755,7 +773,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -797,7 +815,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -839,7 +857,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -881,7 +899,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -918,7 +936,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -955,7 +973,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = null,
                 )
@@ -992,7 +1010,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -1029,7 +1047,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = null,
                 )
@@ -1071,7 +1089,7 @@ internal class BrevInnholdUtlederTest {
             val formkravAvvistBrev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak,
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -1101,7 +1119,7 @@ internal class BrevInnholdUtlederTest {
             val brev =
                 brevInnholdUtleder.lagFormkravAvvistBrev(
                     fagsak = fagsak.copy(stønadstype = Stønadstype.BARNETRYGD, institusjon = lagInstitusjon()),
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     form = ikkeOppfyltForm(),
                     påklagetVedtakDetaljer = påklagetVedtakDetaljer,
                 )
@@ -1128,7 +1146,7 @@ internal class BrevInnholdUtlederTest {
                 assertThrows<IllegalStateException> {
                     brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
                         fagsak = fagsak(),
-                        navn = navn,
+                        personopplysninger = personopplysninger,
                         formkrav = ikkeOppfyltForm().copy(brevtekst = null),
                     )
                 }
@@ -1147,7 +1165,7 @@ internal class BrevInnholdUtlederTest {
             val brev =
                 brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
                     fagsak = fagsak.copy(stønadstype = stønadstype),
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     formkrav = ikkeOppfyltForm(),
                 )
 
@@ -1174,7 +1192,7 @@ internal class BrevInnholdUtlederTest {
             val brev =
                 brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
                     fagsak = fagsak.copy(stønadstype = stønadstype),
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     formkrav = ikkeOppfyltForm(),
                 )
 
@@ -1195,7 +1213,7 @@ internal class BrevInnholdUtlederTest {
             val brev =
                 brevInnholdUtleder.lagFormkravAvvistBrevIkkePåklagetVedtak(
                     fagsak = fagsak.copy(stønadstype = Stønadstype.BARNETRYGD, institusjon = lagInstitusjon()),
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                     formkrav = ikkeOppfyltForm(),
                 )
 
@@ -1224,7 +1242,7 @@ internal class BrevInnholdUtlederTest {
             val henleggelsesbrevBaksInnhold =
                 brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
                     fagsak = fagsak.copy(stønadstype = stønadstype),
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                 )
 
             // Assert
@@ -1247,7 +1265,7 @@ internal class BrevInnholdUtlederTest {
             val henleggelsesbrevBaksInnhold =
                 brevInnholdUtleder.lagHenleggelsesbrevBaksInnhold(
                     fagsak = fagsak.copy(stønadstype = Stønadstype.BARNETRYGD, institusjon = lagInstitusjon()),
-                    navn = navn,
+                    personopplysninger = personopplysninger,
                 )
 
             // Assert

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevsignaturServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevsignaturServiceTest.kt
@@ -27,7 +27,7 @@ internal class BrevsignaturServiceTest {
         val signaturMedEnhet = brevsignaturService.lagSignatur(personopplysningerDto, Fagsystem.EF)
 
         assertThat(signaturMedEnhet.enhet).isEqualTo(BrevsignaturService.ENHET_VIKAFOSSEN)
-        assertThat(signaturMedEnhet.navn).isEqualTo(BrevsignaturService.NAV_ANONYM_NAVN)
+        assertThat(signaturMedEnhet.navn).isNull()
     }
 
     @Test


### PR DESCRIPTION
Favro: NAV-27967

Korrigerer brevet i skjermet barn-fagsaker
- Bruker samme personopplysninger for å sette navn og ident i brevet, i stedet for `fagsak.hentFagsakEierIdent()`
- Bruk fagsakeiers personopplysninger for å utlede brevsignatur
- Ikke sett saksbehandlersignatur, kun enhet, i vikafossen-saker