### PR TITLE
Bump familie-felles og ta i bruk sikkerhet-token-support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <kotlin.version>2.3.10</kotlin.version>
         <springdoc.version>3.0.1</springdoc.version>
         <mockk-jvm.version>1.14.6</mockk-jvm.version>
-        <felles.version>4.20260205114838_3a4c3dc</felles.version>
+        <felles.version>4.20260428092133_557f62f</felles.version>
         <prosessering.version>2.20260420122910_8bfca04</prosessering.version>
         <start-class>no.nav.familie.klage.ApplicationKt</start-class>
         <kontrakter.version>4.0_20260310154326_244725f</kontrakter.version>
@@ -171,6 +171,11 @@
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>kafka</artifactId>
+            <version>${felles.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet-token-support</artifactId>
             <version>${felles.version}</version>
         </dependency>
         <!-- Logging og metrikker -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
             <version>${felles.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet-token-support</artifactId>
+            <version>${felles.version}</version>
+        </dependency>
+        <dependency>
             <groupId>no.nav.familie</groupId>
             <artifactId>prosessering-core</artifactId>
             <version>${prosessering.version}</version>
@@ -171,11 +176,6 @@
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>kafka</artifactId>
-            <version>${felles.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.familie.felles</groupId>
-            <artifactId>sikkerhet-token-support</artifactId>
             <version>${felles.version}</version>
         </dependency>
         <!-- Logging og metrikker -->

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/ApplicationConfig.kt
@@ -9,6 +9,7 @@ import no.nav.familie.prosessering.config.ProsesseringInfoProvider
 import no.nav.familie.restklient.config.RestTemplateAzure
 import no.nav.familie.restklient.interceptor.ConsumerIdClientInterceptor
 import no.nav.familie.restklient.interceptor.MdcValuesPropagatingClientInterceptor
+import no.nav.familie.sikkerhet.context.FamilieFellesNavTokenSupportKonfigurasjon
 import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
@@ -38,7 +39,7 @@ import java.time.temporal.ChronoUnit
     "no.nav.familie.unleash",
 )
 @EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
-@Import(RestTemplateAzure::class)
+@Import(RestTemplateAzure::class, FamilieFellesNavTokenSupportKonfigurasjon::class)
 @EnableOAuth2Client(cacheEnabled = true)
 @EnableScheduling
 class ApplicationConfig {


### PR DESCRIPTION
Bumper `familie-felles` til nyeste versjon (`4.20260428092133_557f62f`) og introduserer `sikkerhet-token-support`-modulen.

## Endringer
- `felles.version` bumped fra `4.20260205114838_3a4c3dc` → `4.20260428092133_557f62f`
- Legger til `no.nav.familie.felles:sikkerhet-token-support` som dependency
- Importerer `FamilieFellesNavTokenSupportKonfigurasjon` i `ApplicationConfig` via `@Import`

`FamilieFellesNavTokenSupportKonfigurasjon` registrerer `NavTokenSupportTokenContext` som `TokenContext`-implementasjon, slik at applikasjonen kan bruke den nye `TokenContext`-abstraksjonen fra familie-felles.