### PR TITLE
 refactor: fjern ubrukte OAuth2 client-registreringer

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,15 +34,6 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      pdl:
-        resource-url: ${PDL_URL}
-        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
-        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${PDL_SCOPE}
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
       pdl-clientcredentials:
         resource-url: ${PDL_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
@@ -92,15 +83,6 @@ no.nav.security.jwt:
         resource-url: ${FAMILIE_EF_SAK_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${FAMILIE_EF_SAK_SCOPE}
-        authentication:
-          client-id: ${AZURE_APP_CLIENT_ID}
-          client-secret: ${AZURE_APP_CLIENT_SECRET}
-          client-auth-method: client_secret_basic
-      familie-ef-sak-clientcredentials:
-        resource-url: ${FAMILIE_EF_SAK_URL}
-        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
-        grant-type: client_credentials
         scope: ${FAMILIE_EF_SAK_SCOPE}
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}


### PR DESCRIPTION
I forbindelse med omskriving til texas så har jeg gått igjennom konfigursjon for klientene:

 Fjerner to overflødige registreringer fra application.yml:

 - `pdl` (jwt-bearer): PdlClient bruker eksplisitt @Qualifier("azureClientCredential"),
   så jwt-bearer-registreringen matches aldri av noen interceptor.

 - `familie-ef-sak-clientcredentials`: FamilieEFSakClient kalles kun fra
   controller-kontekst (TilgangService, FagsystemVedtakService) der det alltid
   finnes en brukerkontext. client_credentials-varianten brukes aldri.

Har lyst til å merge denne før man gjør Texas
