### PR TITLE
Disabler jackson-dataformat-yaml fra spring-mvc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-common</artifactId>
             <version>${springdoc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,6 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-common</artifactId>
             <version>${springdoc.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>

--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/config/ApplicationConfig.kt
@@ -18,10 +18,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
+import org.springframework.http.converter.HttpMessageConverters
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
+import org.springframework.http.converter.yaml.MappingJackson2YamlHttpMessageConverter
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.client.RestOperations
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
@@ -73,6 +76,16 @@ class ApplicationConfig {
             .readTimeout(Duration.of(30, ChronoUnit.SECONDS))
             .additionalMessageConverters(listOf(jacksonJsonHttpMessageConverter) + RestTemplate().messageConverters)
     }
+
+    @Bean
+    fun removeYamlConverter(): WebMvcConfigurer =
+        object : WebMvcConfigurer {
+            override fun configureMessageConverters(builder: HttpMessageConverters.ServerBuilder) {
+                builder.configureMessageConvertersList { converters ->
+                    converters.removeIf { it is MappingJackson2YamlHttpMessageConverter }
+                }
+            }
+        }
 
     @Bean("utenAuth")
     fun restTemplate(


### PR DESCRIPTION
Fjern YAML HttpMessageConverter fra Spring MVC
jackson-dataformat-yaml ligger på classpath (krevd av springdoc) og får Spring til å auto-registrere en MappingJackson2YamlHttpMessageConverter. 

Denne bruker en ObjectMapper uten KotlinModule og logger warnings ved oppstart når den evaluerer Kotlin data classes:
Failed to evaluate Jackson deserialization for type PdlResponse<PdlPersonData>:
InvalidDefinitionException: Argument #0 of Creator has no property name
Vi bruker ikke YAML som HTTP-format, så converteren fjernes fra Spring MVC via WebMvcConfigurer. Springdoc sin YAML-eksport av API-spec påvirkes ikke — den håndterer serialisering internt.

Dette fører til gjentatte warnings i prod-loggen:

Failed to evaluate Jackson deserialization for type PdlResponse<PdlPersonData>: InvalidDefinitionException: Argument #0 of Creator has no property name: can not use as property-based Creator 

<img width="1132" height="550" alt="image" src="https://github.com/user-attachments/assets/33bea81b-108c-45d6-9a49-25526491f507" />



