### PR TITLE
Oppdater db versjon i test

### DIFF
--- a/src/test/kotlin/no/nav/familie/klage/infrastruktur/db/DbContainerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/klage/infrastruktur/db/DbContainerInitializer.kt
@@ -19,7 +19,7 @@ class DbContainerInitializer : ApplicationContextInitializer<ConfigurableApplica
     companion object {
         // Lazy because we only want it to be initialized when accessed
         private val postgres: KPostgreSQLContainer by lazy {
-            KPostgreSQLContainer("postgres:14.6")
+            KPostgreSQLContainer("postgres:17.9")
                 .withDatabaseName("klage")
                 .withUsername("postgres")
                 .withPassword("test")


### PR DESCRIPTION
Oppdaterer DB versjon i testcontainer til 17.9 - lik som versjonen i prod gcp.