### PR TITLE
Valider at brevmottaker-organisasjoner eksisterer ved ferdigstillelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingService.kt
@@ -59,6 +59,7 @@ class FerdigstillBehandlingService(
         if (behandlingsresultat == IKKE_MEDHOLD || behandlingsresultat == IKKE_MEDHOLD_FORMKRAV_AVVIST) {
             when (behandling.årsak) {
                 ORDINÆR -> {
+                    brevService.validerAtBrevmottakerOrganisasjonerEksisterer(behandlingId)
                     brevService.lagBrevPdf(behandlingId)
                     brevService.validerRiktigSaksbehandlerSignatur(behandlingId)
                     opprettJournalførBrevTask(behandlingId, fagsak.eksternId, fagsak.fagsystem)

--- a/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/brev/BrevService.kt
@@ -34,6 +34,7 @@ import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.infrastruktur.repository.findByIdOrThrow
 import no.nav.familie.klage.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.personopplysninger.PersonopplysningerService
 import no.nav.familie.klage.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.klage.vurdering.VurderingService
@@ -64,6 +65,7 @@ class BrevService(
     private val taskService: TaskService,
     private val brevmottakerUtleder: BrevmottakerUtleder,
     private val featureToggleService: FeatureToggleService,
+    private val familieIntegrasjonerClient: FamilieIntegrasjonerClient,
 ) {
     fun hentBrev(behandlingId: UUID): Brev = brevRepository.findByIdOrThrow(behandlingId)
 
@@ -445,4 +447,17 @@ class BrevService(
             }
         }
     }
+
+    fun validerAtBrevmottakerOrganisasjonerEksisterer(behandlingId: UUID) {
+        val brevmottakere = hentBrevmottakere(behandlingId)
+        val organisasjonSomIkkeEksisterer =
+            brevmottakere.organisasjoner.find { !organisasjonEksisterer(it.organisasjonsnummer) }
+        feilHvis(organisasjonSomIkkeEksisterer != null) {
+            "Organisasjon med organisasjonsnummer ${organisasjonSomIkkeEksisterer!!.organisasjonsnummer} " +
+                "er registrert som brevmottaker, men eksisterer ikke lenger i Enhetsregisteret. " +
+                "Fjern organisasjonen som brevmottaker for å ferdigstille behandlingen."
+        }
+    }
+
+    private fun organisasjonEksisterer(organisasjonsnummer: String): Boolean = runCatching { familieIntegrasjonerClient.hentOrganisasjon(organisasjonsnummer) }.isSuccess
 }

--- a/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/behandling/FerdigstillBehandlingServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.klage.behandling.domain.StegType
 import no.nav.familie.klage.behandlingsstatistikk.BehandlingsstatistikkTask
 import no.nav.familie.klage.blankett.LagSaksbehandlingsblankettTask
 import no.nav.familie.klage.brev.BrevService
+import no.nav.familie.klage.brevmottaker.domain.Brevmottakere
 import no.nav.familie.klage.distribusjon.DistribusjonService
 import no.nav.familie.klage.distribusjon.JournalførBrevTask
 import no.nav.familie.klage.distribusjon.SendTilKabalTask
@@ -106,6 +107,8 @@ class FerdigstillBehandlingServiceTest {
         every { taskService.save(capture(saveTaskSlot)) } answers { firstArg() }
         every { oppgaveTaskService.lagFerdigstillOppgaveForBehandlingTask(behandling.id, any(), any()) } just Runs
         justRun { brevService.lagBrevPdf(any()) }
+        every { brevService.hentBrevmottakere(any()) } returns Brevmottakere()
+        justRun { brevService.validerAtBrevmottakerOrganisasjonerEksisterer(any()) }
         every { fagsystemVedtakService.opprettRevurdering(any()) } returns OpprettRevurderingResponse(Opprettet("opprettetId"))
         every { brevService.validerRiktigSaksbehandlerSignatur(any()) } just Runs
     }
@@ -244,5 +247,39 @@ class FerdigstillBehandlingServiceTest {
         // Assert
         assertThat(fagsystemRevurderingSlot.single()).isNotNull
         verify(exactly = 1) { fagsystemVedtakService.opprettRevurdering(behandling) }
+    }
+
+    @Test
+    fun `skal feile ved ferdigstillelse dersom brevmottaker-organisasjon ikke eksisterer`() {
+        // Arrange
+        every { brevService.validerAtBrevmottakerOrganisasjonerEksisterer(any()) } throws
+            Feil("Organisasjon med organisasjonsnummer 987654321 er registrert som brevmottaker, men eksisterer ikke lenger i Enhetsregisteret.")
+
+        // Act & Assert
+        assertThrows<Feil> {
+            ferdigstillBehandlingService.ferdigstillKlagebehandling(behandlingId = behandling.id)
+        }
+    }
+
+    @Test
+    fun `skal ferdigstille behandling når brevmottaker-organisasjon eksisterer`() {
+        // Act
+        ferdigstillBehandlingService.ferdigstillKlagebehandling(behandlingId = behandling.id)
+
+        // Assert
+        assertThat(behandlingsresultatSlot.captured).isEqualTo(BehandlingResultat.IKKE_MEDHOLD)
+        verify { brevService.validerAtBrevmottakerOrganisasjonerEksisterer(behandling.id) }
+    }
+
+    @Test
+    fun `skal ikke validere brevmottaker-organisasjoner ved årsak HENVENDELSE_FRA_KABAL`() {
+        // Arrange
+        every { behandlingService.hentBehandling(any()) } returns behandling.copy(årsak = Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL)
+
+        // Act
+        ferdigstillBehandlingService.ferdigstillKlagebehandling(behandlingId = behandling.id)
+
+        // Assert
+        verify(exactly = 0) { brevService.validerAtBrevmottakerOrganisasjonerEksisterer(any()) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/brev/BrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/brev/BrevServiceTest.kt
@@ -17,12 +17,14 @@ import no.nav.familie.klage.formkrav.FormService
 import no.nav.familie.klage.infrastruktur.exception.Feil
 import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.klage.integrasjoner.FamilieIntegrasjonerClient
 import no.nav.familie.klage.personopplysninger.PersonopplysningerService
 import no.nav.familie.klage.testutil.BrukerContextUtil
 import no.nav.familie.klage.testutil.DomainUtil
 import no.nav.familie.klage.testutil.DtoTestUtil
 import no.nav.familie.klage.vurdering.VurderingService
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
+import no.nav.familie.kontrakter.felles.organisasjon.Organisasjon
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
@@ -48,6 +51,7 @@ class BrevServiceTest {
     private val taskService = mockk<TaskService>()
     private val brevmottakerUtleder = mockk<BrevmottakerUtleder>()
     private val featureToggleService = mockk<FeatureToggleService>()
+    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
 
     private val brevService =
         BrevService(
@@ -64,6 +68,7 @@ class BrevServiceTest {
             taskService = taskService,
             brevmottakerUtleder = brevmottakerUtleder,
             featureToggleService = featureToggleService,
+            familieIntegrasjonerClient = familieIntegrasjonerClient,
         )
 
     @BeforeEach
@@ -75,6 +80,64 @@ class BrevServiceTest {
     @AfterEach
     fun tearDown() {
         BrukerContextUtil.clearBrukerContext()
+    }
+
+    @Nested
+    inner class ValiderBrevmottakerOrganisasjonerEksisterer {
+        private val behandling = DomainUtil.behandling()
+        private val organisasjonsnummer = "987654321"
+        private val brevmottakerOrganisasjon =
+            DomainUtil.lagBrevmottakerOrganisasjon(organisasjonsnummer = organisasjonsnummer)
+
+        @Test
+        fun `skal ikke kaste feil når det ikke er organisasjoner som brevmottakere`() {
+            // Arrange
+            val brev = DomainUtil.lagBrev(behandlingId = behandling.id, mottakere = DomainUtil.lagBrevmottakere())
+            every { brevRepository.findByIdOrNull(behandling.id) } returns brev
+
+            // Act & Assert
+            assertDoesNotThrow {
+                brevService.validerAtBrevmottakerOrganisasjonerEksisterer(behandling.id)
+            }
+        }
+
+        @Test
+        fun `skal ikke kaste feil når organisasjon eksisterer i Enhetsregisteret`() {
+            // Arrange
+            val brev =
+                DomainUtil.lagBrev(
+                    behandlingId = behandling.id,
+                    mottakere = DomainUtil.lagBrevmottakere(organisasjoner = listOf(brevmottakerOrganisasjon)),
+                )
+            every { brevRepository.findByIdOrNull(behandling.id) } returns brev
+            every { familieIntegrasjonerClient.hentOrganisasjon(organisasjonsnummer) } returns
+                Organisasjon(organisasjonsnummer, "Orgnavn")
+
+            // Act & Assert
+            assertDoesNotThrow {
+                brevService.validerAtBrevmottakerOrganisasjonerEksisterer(behandling.id)
+            }
+        }
+
+        @Test
+        fun `skal kaste feil når organisasjon ikke eksisterer i Enhetsregisteret`() {
+            // Arrange
+            val brev =
+                DomainUtil.lagBrev(
+                    behandlingId = behandling.id,
+                    mottakere = DomainUtil.lagBrevmottakere(organisasjoner = listOf(brevmottakerOrganisasjon)),
+                )
+            every { brevRepository.findByIdOrNull(behandling.id) } returns brev
+            every { familieIntegrasjonerClient.hentOrganisasjon(organisasjonsnummer) } throws
+                RuntimeException("Organisasjon ikke funnet")
+
+            // Act & Assert
+            val feil =
+                assertThrows<Feil> {
+                    brevService.validerAtBrevmottakerOrganisasjonerEksisterer(behandling.id)
+                }
+            assertThat(feil.message).contains(organisasjonsnummer)
+        }
     }
 
     @Nested


### PR DESCRIPTION
### Favro: NAV-29568

## Hva er gjort?

Saksbehandler kan legge til en organisasjon som manuell brevmottaker, men organisasjonen kan bli slettet i Enhetsregisteret før behandlingen er ferdigstilt.

For å hindre at brev sendes til en ikke-eksisterende organisasjon, er det lagt til validering i ferdigstillelsesfløyen:

- `BrevService.validerAtBrevmottakerOrganisasjonerEksisterer` sjekker mot `FamilieIntegrasjonerClient.hentOrganisasjon` at alle organisasjoner registrert som brevmottakere faktisk eksisterer i Enhetsregisteret.
- Valideringen kalles fra `FerdigstillBehandlingService` for behandlinger med årsak `ORDINÆR`, rett før brev-PDF genereres og journalføres.
- Kaster `Feil` med orgnummer og veiledende melding dersom organisasjonen ikke finnes.

## Tester

- `BrevServiceTest.ValiderBrevmottakerOrganisasjonerEksisterer`: 3 enhetstester for selve valideringslogikken
- `FerdigstillBehandlingServiceTest`: 3 tester for at valideringen kalles/ikke kalles riktig