### PR TITLE
NAV-29578: Filtrer bort historiske navn

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -21,6 +21,7 @@ enum class Toggle(
     // Release
     MANUELL_BREVMOTTAKER_ORGANISASJON("familie-klage.manuell-brevmottaker-organisasjon"),
     BRUK_SØKER_PERSONOPPLYSNINGER("familie-klage.bruk-soker-personopplysninger"),
+    FILTRER_HISTORISKE_NAVN("familie-klage.filtere-historiske-navn"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerService.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.klage.personopplysninger
 
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.personopplysninger.dto.Adressebeskyttelse
 import no.nav.familie.klage.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.klage.personopplysninger.dto.FullmaktDto
@@ -12,6 +14,7 @@ import no.nav.familie.klage.personopplysninger.pdl.Fullmakt
 import no.nav.familie.klage.personopplysninger.pdl.PdlClient
 import no.nav.familie.klage.personopplysninger.pdl.PdlPerson
 import no.nav.familie.klage.personopplysninger.pdl.gjeldende
+import no.nav.familie.klage.personopplysninger.pdl.gjeldendeGammel
 import no.nav.familie.klage.personopplysninger.pdl.visningsnavn
 import no.nav.familie.kontrakter.felles.klage.Stønadstype
 import org.springframework.cache.annotation.Cacheable
@@ -25,6 +28,7 @@ class PersonopplysningerService(
     private val pdlClient: PdlClient,
     private val integrasjonerClient: PersonopplysningerIntegrasjonerClient,
     private val fullmaktService: FullmaktService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     @Cacheable("hentPersonopplysninger", cacheManager = "shortCache", key = "'fagsakEier:' + #behandlingId")
     fun hentPersonopplysningerFagsakEier(behandlingId: UUID): PersonopplysningerDto {
@@ -48,7 +52,12 @@ class PersonopplysningerService(
         val fullmakt = fullmaktService.hentFullmakt(ident)
         return PersonopplysningerDto(
             personIdent = ident,
-            navn = pdlPerson.navn.gjeldende().visningsnavn(),
+            navn =
+                if (featureToggleService.isEnabled(Toggle.FILTRER_HISTORISKE_NAVN)) {
+                    pdlPerson.navn.gjeldende().visningsnavn()
+                } else {
+                    pdlPerson.navn.gjeldendeGammel().visningsnavn()
+                },
             fødselsdato = pdlPerson.fødselsdato.gjeldende()?.let { it.fødselsdato ?: LocalDate.of(it.fødselsår, 1, 1) },
             kjønn =
                 Kjønn.valueOf(

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtil.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.klage.personopplysninger.pdl
 
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import org.springframework.http.HttpStatus
+
 fun Navn.visningsnavn(): String =
     if (mellomnavn == null) {
         "$fornavn $etternavn"
@@ -14,7 +17,27 @@ fun Personnavn.visningsnavn(): String =
         "$fornavn $mellomnavn $etternavn"
     }
 
-fun List<Navn>.gjeldende(): Navn = this.single()
+@Deprecated("Bruk gjeldende() istedenfor")
+fun List<Navn>.gjeldendeGammel(): Navn = this.single()
+
+fun List<Navn>.gjeldende(): Navn {
+    val ikkeHistoriskeNavn = this.filter { !it.metadata.historisk }
+    if (ikkeHistoriskeNavn.isEmpty()) {
+        throw Feil(
+            message = "Fant ingen gjeldende navn for personen. Forventet minst ett.",
+            frontendFeilmelding = "Fant ikke det gjeldende navnet til personen.",
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+        )
+    }
+    if (ikkeHistoriskeNavn.size > 1) {
+        throw Feil(
+            message = "Fant flere (${this.size}) gjeldende navn for personen. Forventet kun ett.",
+            frontendFeilmelding = "Fant ikke det gjeldende navnet til personen.",
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+        )
+    }
+    return ikkeHistoriskeNavn.single()
+}
 
 fun List<Dødsfall>.gjeldende(): Dødsfall? = this.firstOrNull()
 

--- a/src/main/kotlin/no/nav/familie/klage/søk/SøkController.kt
+++ b/src/main/kotlin/no/nav/familie/klage/søk/SøkController.kt
@@ -3,9 +3,12 @@ package no.nav.familie.klage.søk
 import no.nav.familie.klage.fagsak.FagsakService
 import no.nav.familie.klage.felles.domain.AuditLoggerEvent
 import no.nav.familie.klage.infrastruktur.exception.ApiFeil
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.klage.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.klage.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.klage.personopplysninger.pdl.PdlClient
 import no.nav.familie.klage.personopplysninger.pdl.gjeldende
+import no.nav.familie.klage.personopplysninger.pdl.gjeldendeGammel
 import no.nav.familie.klage.personopplysninger.pdl.visningsnavn
 import no.nav.familie.klage.søk.dto.PersonIdentDto
 import no.nav.familie.klage.søk.dto.PersonTreffDto
@@ -29,6 +32,7 @@ class SøkController(
     private val pdlClient: PdlClient,
     private val eregService: EregService,
     private val fagsakService: FagsakService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     @PostMapping("person")
     fun søkPerson(
@@ -39,7 +43,13 @@ class SøkController(
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
         tilgangService.validerTilgangTilPersonMedRelasjoner(personIdent, AuditLoggerEvent.UPDATE)
         val person = pdlClient.hentPerson(personIdent, fagsak.stønadstype)
-        val result = PersonTreffDto(personIdent, person.navn.gjeldende().visningsnavn())
+        val navn =
+            if (featureToggleService.isEnabled(Toggle.FILTRER_HISTORISKE_NAVN)) {
+                person.navn.gjeldende().visningsnavn()
+            } else {
+                person.navn.gjeldendeGammel().visningsnavn()
+            }
+        val result = PersonTreffDto(personIdent, navn)
         return Ressurs.success(result)
     }
 

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/PersonopplysningerServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.klage.fagsak.FagsakService
+import no.nav.familie.klage.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.klage.personopplysninger.dto.Adressebeskyttelse
 import no.nav.familie.klage.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.klage.personopplysninger.dto.Kjønn
@@ -38,9 +39,10 @@ internal class PersonopplysningerServiceTest {
     private val pdlClient = mockk<PdlClient>()
     private val integrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val fullmaktService = mockk<FullmaktService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val personopplysningerService =
-        PersonopplysningerService(fagsakService, pdlClient, integrasjonerClient, fullmaktService)
+        PersonopplysningerService(fagsakService, pdlClient, integrasjonerClient, fullmaktService, featureToggleService)
 
     private val fagsak = fagsak()
 
@@ -52,6 +54,7 @@ internal class PersonopplysningerServiceTest {
         every { pdlClient.hentNavnBolk(any(), any()) } returns navnBolkResponse()
         every { integrasjonerClient.egenAnsatt(any()) } returns true
         every { fullmaktService.hentFullmakt(any()) } returns listOf(fullmakt())
+        every { featureToggleService.isEnabled(any()) } returns true
     }
 
     private fun fullmakt() = Fullmakt(LocalDate.now(), null, "01010199999", "fullmakt etternavn", MotpartsRolle.FULLMEKTIG, listOf("område"))

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtilTest.kt
@@ -1,0 +1,81 @@
+package no.nav.familie.klage.personopplysninger.pdl
+
+import no.nav.familie.klage.infrastruktur.exception.Feil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class PdlPersonUtilTest {
+    @Nested
+    inner class Gjeldende {
+        @Test
+        fun `skal finne gjeldende navn og filtrere bort historiske navn`() {
+            // Arrange
+            val navn1 =
+                Navn(
+                    fornavn = "Fornavn1",
+                    mellomnavn = "Mellomnavn1",
+                    etternavn = "Etternavn1",
+                    metadata = Metadata(historisk = false),
+                )
+
+            val navn2 =
+                Navn(
+                    fornavn = "Fornavn2",
+                    mellomnavn = "Mellomnavn2",
+                    etternavn = "Etternavn2",
+                    metadata = Metadata(historisk = true),
+                )
+
+            val alleNavn = listOf(navn1, navn2)
+
+            // Act
+            val gjeldendeNavn = alleNavn.gjeldende()
+
+            assertThat(gjeldendeNavn).isEqualTo(navn1)
+        }
+
+        @Test
+        fun `skal kaste feil hvis ingen navn finnnes`() {
+            // Arrange
+            val alleNavn = emptyList<Navn>()
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    alleNavn.gjeldende()
+                }
+            assertThat(exception.message).isEqualTo("Fant ingen gjeldende navn for personen. Forventet minst ett.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis flere gjeldende navn finnes`() {
+            // Arrange
+            val navn1 =
+                Navn(
+                    fornavn = "Fornavn1",
+                    mellomnavn = "Mellomnavn1",
+                    etternavn = "Etternavn1",
+                    metadata = Metadata(historisk = false),
+                )
+
+            val navn2 =
+                Navn(
+                    fornavn = "Fornavn2",
+                    mellomnavn = "Mellomnavn2",
+                    etternavn = "Etternavn2",
+                    metadata = Metadata(historisk = false),
+                )
+
+            val alleNavn = listOf(navn1, navn2)
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    alleNavn.gjeldende()
+                }
+            assertThat(exception.message).isEqualTo("Fant flere (2) gjeldende navn for personen. Forventet kun ett.")
+        }
+    }
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29578

Filterer bort historiske navn slik at `.single()` ikke kaster feil når man får flere navn og der alle bortsatt fra ett er historiske.

Kaster også `Feil` med mer beskrivende meldinger. 