### PR TITLE
NAV-29578: Velger navn basert på master fra PDL

### DIFF
--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/Master.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/Master.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.klage.personopplysninger.pdl
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+enum class Master(
+    val prioritet: Int,
+) {
+    PDL(1),
+    FREG(2),
+    UKJENT(3),
+    ;
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(Master::class.java)
+
+        fun fraVerdi(verdi: String): Master =
+            when (verdi.uppercase()) {
+                "PDL" -> {
+                    PDL
+                }
+
+                "FREG" -> {
+                    FREG
+                }
+
+                else -> {
+                    logger.warn("Ukjent verdi for master: $verdi, burde legges til i Master enum")
+                    UKJENT
+                }
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPerson.kt
@@ -94,6 +94,7 @@ data class PdlPerson(
 )
 
 data class Metadata(
+    val master: String,
     val historisk: Boolean,
 )
 

--- a/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtil.kt
+++ b/src/main/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtil.kt
@@ -21,22 +21,32 @@ fun Personnavn.visningsnavn(): String =
 fun List<Navn>.gjeldendeGammel(): Navn = this.single()
 
 fun List<Navn>.gjeldende(): Navn {
-    val ikkeHistoriskeNavn = this.filter { !it.metadata.historisk }
-    if (ikkeHistoriskeNavn.isEmpty()) {
+    val masterOgNavn =
+        this
+            .filter { !it.metadata.historisk }
+            .groupBy { Master.fraVerdi(it.metadata.master) }
+            .minByOrNull { it.key.prioritet }
+
+    if (masterOgNavn == null) {
         throw Feil(
             message = "Fant ingen gjeldende navn for personen. Forventet minst ett.",
             frontendFeilmelding = "Fant ikke det gjeldende navnet til personen.",
             httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
         )
     }
-    if (ikkeHistoriskeNavn.size > 1) {
+
+    val master = masterOgNavn.key
+    val navn = masterOgNavn.value
+
+    if (navn.size > 1) {
         throw Feil(
-            message = "Fant flere (${this.size}) gjeldende navn for personen. Forventet kun ett.",
-            frontendFeilmelding = "Fant ikke det gjeldende navnet til personen.",
+            message = "Fant flere (${navn.size}) gjeldende navn for personen med master $master. Forventet nøyaktig ett.",
+            frontendFeilmelding = "Fant flere gjeldende navn til personen.",
             httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
         )
     }
-    return ikkeHistoriskeNavn.single()
+
+    return navn.single()
 }
 
 fun List<Dødsfall>.gjeldende(): Dødsfall? = this.firstOrNull()

--- a/src/main/resources/pdl/hent-person.graphql
+++ b/src/main/resources/pdl/hent-person.graphql
@@ -7,6 +7,7 @@ query($ident: ID!){
         adressebeskyttelse {
             gradering
             metadata {
+                master
                 historisk
             }
         }
@@ -17,6 +18,7 @@ query($ident: ID!){
             status
             forenkletStatus
             metadata {
+                master
                 historisk
             }
         }
@@ -28,6 +30,7 @@ query($ident: ID!){
             mellomnavn
             etternavn
             metadata {
+                master
                 historisk
             }
         }

--- a/src/main/resources/pdl/navn_bolk.graphql
+++ b/src/main/resources/pdl/navn_bolk.graphql
@@ -8,6 +8,7 @@ query($identer: [ID!]!){
                 mellomnavn
                 etternavn
                 metadata {
+                    master
                     historisk
                 }
             }

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/MasterTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/MasterTest.kt
@@ -1,0 +1,91 @@
+package no.nav.familie.klage.personopplysninger.pdl
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class MasterTest {
+    @Nested
+    inner class FraVerdi {
+        @Test
+        fun `skal mappe til PDL enum for store bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("PDL")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.PDL)
+        }
+
+        @Test
+        fun `skal mappe til PDL enum for små bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("pdl")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.PDL)
+        }
+
+        @Test
+        fun `skal mappe til PDL enum for store og små bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("pDl")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.PDL)
+        }
+
+        @Test
+        fun `skal mappe til FREG enum for store bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("FREG")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.FREG)
+        }
+
+        @Test
+        fun `skal mappe til FREG enum for små bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("freg")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.FREG)
+        }
+
+        @Test
+        fun `skal mappe til FREG enum for store og små bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("fReG")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.FREG)
+        }
+
+        @Test
+        fun `skal mappe til UKJENT enum for store bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("UKJENT")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.UKJENT)
+        }
+
+        @Test
+        fun `skal mappe til UKJENT enum for små bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("ukjent")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.UKJENT)
+        }
+
+        @Test
+        fun `skal mappe til UKJENT enum for store og små bokstaver`() {
+            // Act
+            val master = Master.fraVerdi("uKjEnT")
+
+            // Assert
+            assertThat(master).isEqualTo(Master.UKJENT)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlPersonUtilTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.klage.personopplysninger.pdl
 
 import no.nav.familie.klage.infrastruktur.exception.Feil
+import no.nav.familie.klage.testutil.PdlTestdataHelper.lagNavn
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -12,32 +13,88 @@ class PdlPersonUtilTest {
         @Test
         fun `skal finne gjeldende navn og filtrere bort historiske navn`() {
             // Arrange
-            val navn1 =
-                Navn(
-                    fornavn = "Fornavn1",
-                    mellomnavn = "Mellomnavn1",
-                    etternavn = "Etternavn1",
-                    metadata = Metadata(historisk = false),
-                )
-
-            val navn2 =
-                Navn(
-                    fornavn = "Fornavn2",
-                    mellomnavn = "Mellomnavn2",
-                    etternavn = "Etternavn2",
-                    metadata = Metadata(historisk = true),
-                )
-
-            val alleNavn = listOf(navn1, navn2)
+            val gjeldendeNavn = lagNavn(fornavn = "Aktiv", historisk = false)
+            val historiskNavn = lagNavn(fornavn = "Gammelt", historisk = true)
+            val alleNavn = listOf(gjeldendeNavn, historiskNavn)
 
             // Act
-            val gjeldendeNavn = alleNavn.gjeldende()
+            val resultat = alleNavn.gjeldende()
 
-            assertThat(gjeldendeNavn).isEqualTo(navn1)
+            // Assert
+            assertThat(resultat).isEqualTo(gjeldendeNavn)
         }
 
         @Test
-        fun `skal kaste feil hvis ingen navn finnnes`() {
+        fun `skal foretrekke PDL fremfor FREG når begge er gjeldende`() {
+            // Arrange
+            val pdlNavn = lagNavn(fornavn = "FraPdl", master = "PDL", historisk = false)
+            val fregNavn = lagNavn(fornavn = "FraFreg", master = "FREG", historisk = false)
+            val alleNavn = listOf(fregNavn, pdlNavn)
+
+            // Act
+            val resultat = alleNavn.gjeldende()
+
+            // Assert
+            assertThat(resultat).isEqualTo(pdlNavn)
+        }
+
+        @Test
+        fun `skal foretrekke FREG fremfor andre kilder når PDL mangler`() {
+            // Arrange
+            val fregNavn = lagNavn(fornavn = "FraFreg", master = "FREG", historisk = false)
+            val annenNavn = lagNavn(fornavn = "FraAnnen", master = "ANNEN_KILDE", historisk = false)
+            val alleNavn = listOf(annenNavn, fregNavn)
+
+            // Act
+            val resultat = alleNavn.gjeldende()
+
+            // Assert
+            assertThat(resultat).isEqualTo(fregNavn)
+        }
+
+        @Test
+        fun `skal bruke navn fra ukjent kilde når det er eneste gjeldende`() {
+            // Arrange
+            val annenNavn = lagNavn(fornavn = "FraAnnen", master = "ANNEN_KILDE", historisk = false)
+            val alleNavn = listOf(annenNavn)
+
+            // Act
+            val resultat = alleNavn.gjeldende()
+
+            // Assert
+            assertThat(resultat).isEqualTo(annenNavn)
+        }
+
+        @Test
+        fun `skal behandle master uavhengig av store og små bokstaver`() {
+            // Arrange
+            val pdlNavn = lagNavn(fornavn = "FraPdl", master = "pdl", historisk = false)
+            val fregNavn = lagNavn(fornavn = "FraFreg", master = "freg", historisk = false)
+            val alleNavn = listOf(fregNavn, pdlNavn)
+
+            // Act
+            val resultat = alleNavn.gjeldende()
+
+            // Assert
+            assertThat(resultat).isEqualTo(pdlNavn)
+        }
+
+        @Test
+        fun `skal ignorere historisk PDL-navn og velge gjeldende FREG-navn`() {
+            // Arrange
+            val historiskPdlNavn = lagNavn(fornavn = "GammeltPdl", master = "PDL", historisk = true)
+            val fregNavn = lagNavn(fornavn = "FraFreg", master = "FREG", historisk = false)
+            val alleNavn = listOf(historiskPdlNavn, fregNavn)
+
+            // Act
+            val resultat = alleNavn.gjeldende()
+
+            // Assert
+            assertThat(resultat).isEqualTo(fregNavn)
+        }
+
+        @Test
+        fun `skal kaste feil hvis ingen navn finnes`() {
             // Arrange
             val alleNavn = emptyList<Navn>()
 
@@ -46,36 +103,42 @@ class PdlPersonUtilTest {
                 assertThrows<Feil> {
                     alleNavn.gjeldende()
                 }
-            assertThat(exception.message).isEqualTo("Fant ingen gjeldende navn for personen. Forventet minst ett.")
+            assertThat(exception.message)
+                .isEqualTo("Fant ingen gjeldende navn for personen. Forventet minst ett.")
         }
 
         @Test
-        fun `skal kaste feil hvis flere gjeldende navn finnes`() {
+        fun `skal kaste feil hvis kun historiske navn finnes`() {
             // Arrange
-            val navn1 =
-                Navn(
-                    fornavn = "Fornavn1",
-                    mellomnavn = "Mellomnavn1",
-                    etternavn = "Etternavn1",
-                    metadata = Metadata(historisk = false),
+            val alleNavn =
+                listOf(
+                    lagNavn(fornavn = "Gammelt1", historisk = true),
+                    lagNavn(fornavn = "Gammelt2", historisk = true),
                 )
-
-            val navn2 =
-                Navn(
-                    fornavn = "Fornavn2",
-                    mellomnavn = "Mellomnavn2",
-                    etternavn = "Etternavn2",
-                    metadata = Metadata(historisk = false),
-                )
-
-            val alleNavn = listOf(navn1, navn2)
 
             // Act & assert
             val exception =
                 assertThrows<Feil> {
                     alleNavn.gjeldende()
                 }
-            assertThat(exception.message).isEqualTo("Fant flere (2) gjeldende navn for personen. Forventet kun ett.")
+            assertThat(exception.message)
+                .isEqualTo("Fant ingen gjeldende navn for personen. Forventet minst ett.")
+        }
+
+        @Test
+        fun `skal kaste feil hvis flere gjeldende navn med samme master finnes`() {
+            // Arrange
+            val pdlNavn1 = lagNavn(fornavn = "Pdl1", master = "PDL", historisk = false)
+            val pdlNavn2 = lagNavn(fornavn = "Pdl2", master = "PDL", historisk = false)
+            val alleNavn = listOf(pdlNavn1, pdlNavn2)
+
+            // Act & assert
+            val exception =
+                assertThrows<Feil> {
+                    alleNavn.gjeldende()
+                }
+            assertThat(exception.message)
+                .isEqualTo("Fant flere (2) gjeldende navn for personen med master PDL. Forventet nøyaktig ett.")
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/klage/personopplysninger/pdl/PdlTestdata.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 object PdlTestdata {
-    private val metadataGjeldende = Metadata(false)
+    private val metadataGjeldende = Metadata("PDL", false)
 
     private const val IDENT = "2"
 

--- a/src/test/kotlin/no/nav/familie/klage/testutil/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/familie/klage/testutil/PdlTestdataHelper.kt
@@ -14,7 +14,7 @@ import no.nav.familie.klage.personopplysninger.pdl.VergemaalEllerFremtidsfullmak
 import java.time.LocalDate
 
 object PdlTestdataHelper {
-    val metadataGjeldende = Metadata(historisk = false)
+    val metadataGjeldende = Metadata(master = "PDL", historisk = false)
 
     fun lagKjønn(kjønnType: KjønnType = KjønnType.KVINNE) = Kjønn(kjønnType)
 
@@ -23,12 +23,13 @@ object PdlTestdataHelper {
         mellomnavn: String? = "mellomnavn",
         etternavn: String = "Etternavn",
         historisk: Boolean = false,
+        master: String = "PDL",
     ): Navn =
         Navn(
             fornavn,
             mellomnavn,
             etternavn,
-            Metadata(historisk = historisk),
+            Metadata(master = master, historisk = historisk),
         )
 
     fun pdlNavn(navn: List<Navn> = emptyList()) =


### PR DESCRIPTION
Favro: NAV-29578

Skal velge navn basert på master. Prioritere PDL, så FREG, så UKJENT. Prioriteringen skal være lik som i ba-sak. 